### PR TITLE
yubi: management key recovery mechanism

### DIFF
--- a/client/agent/yubi.go
+++ b/client/agent/yubi.go
@@ -53,6 +53,11 @@ func (a *AgentConn) yubiUnlock(m libclient.MetaContext) error {
 	if err != nil {
 		return err
 	}
+	err = u.SyncYubiManagementKey(m)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -607,6 +612,20 @@ func (c *AgentConn) ProtectKeyWithPIN(
 		sess.doPinProtect = true
 		return nil
 	})
+}
+
+func (c *AgentConn) RecoverManagementKey(
+	ctx context.Context,
+	arg lcl.RecoverManagementKeyArg,
+) error {
+	m := c.MetaContext(ctx)
+	return libclient.RecoverYubiManagementKey(
+		m,
+		arg.Serial,
+		arg.Pin,
+		arg.Puk,
+		arg.Mk,
+	)
 }
 
 var _ lcl.YubiInterface = (*AgentConn)(nil)

--- a/client/libclient/bg_job_user.go
+++ b/client/libclient/bg_job_user.go
@@ -75,6 +75,11 @@ func (b *BgUserRefresh) refresh(m MetaContext, uc *UserContext) error {
 		return err
 	}
 
+	err = BgRotateYubiManagementKey(m, uc, uw)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/client/libclient/rotate_mgr.go
+++ b/client/libclient/rotate_mgr.go
@@ -305,6 +305,8 @@ func (r *rotateMgr) post(m MetaContext) error {
 	return err
 }
 
+// updatePPE updates the passphrase encryption system for the new PUK. Only encrypts
+// if the target role is the owner.
 func (r *rotateMgr) updatePPE(m MetaContext) error {
 	if r.selfRevoke {
 		return nil

--- a/client/libclient/ymk_mgr.go
+++ b/client/libclient/ymk_mgr.go
@@ -1,0 +1,450 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package libclient
+
+import (
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lib"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+)
+
+// YMKMgr is a manager for YubiKey Management Keys (YMKs). It's used to store
+// encryptions of the Yubi Management keys to the server, encrypted with the user's PUK.
+// This allows the user to recover their management key if they ever botch their PIN
+// enough times to lock. BTW, "PUK" here refers to the FOKS notion of PUK and not
+// YubiKey's PUK. We largely ignore the yubi PUK since it too has the constraint that it
+// can be locked out after enough failure attempts.
+
+type ymkMgrKey struct {
+	raw rem.YubiEncryptedManagementKey
+
+	ymk  *proto.YubiManagementKey
+	card proto.YubiCardID
+	slot proto.YubiSlot
+}
+
+type YMKPull struct {
+	uc *UserContext // one per user-context
+
+	// usually a 1:1 map, but the same user might have multiple yubikeys.
+	// some of them might not be currently available
+	ymks []*ymkMgrKey
+}
+
+type YMKPushOutcome int
+
+const (
+	YMKPushOutcomeNone YMKPushOutcome = iota
+	YMKPushOutcomeFresh
+	YMKPushOutcomeNew
+	YMKPushOutcomeNotAdmin
+	YMKPushOutcomeNoManagementKey
+	YMKPushOutcomeRefreshed
+	YMKPushOutcomeErr
+)
+
+type YMKPush struct {
+	uc *UserContext
+
+	noPUKRefresh bool
+	latestPUKgen proto.Generation
+	pushYmk      *ymkMgrKey
+	role         proto.Role
+	stale        bool
+	puk          core.SharedPrivateSuiter
+	yi           *proto.YubiKeyInfoHybrid
+	outcome      YMKPushOutcome
+}
+
+func NewYMKPush(uc *UserContext) *YMKPush {
+	return &YMKPush{
+		uc: uc,
+	}
+}
+
+func (y *YMKPush) WithoutPUKRefresh() *YMKPush {
+	y.noPUKRefresh = true
+	return y
+}
+
+func (y *YMKPush) WithLatestPUKGen(g proto.Generation) *YMKPush {
+	y.latestPUKgen = g
+	return y
+}
+
+func NewYMKPull(uc *UserContext) *YMKPull {
+	return &YMKPull{
+		uc: uc,
+	}
+}
+
+func (y *YMKPull) loadFromServer(m MetaContext) error {
+	cli, err := y.uc.UserClient(m)
+	if err != nil {
+		return err
+	}
+	res, err := cli.GetAllYubiManagementKeys(m.Ctx())
+	if err != nil {
+		return err
+	}
+	y.ymks = make([]*ymkMgrKey, len(res))
+	for i, ymk := range res {
+		y.ymks[i] = &ymkMgrKey{
+			raw: ymk,
+		}
+	}
+	return nil
+}
+
+func (y *ymkMgrKey) unbox(m MetaContext, uc *UserContext) error {
+	gt, err := y.raw.Role.GreaterThan(uc.Role())
+	if err != nil {
+		return err
+	}
+	if gt {
+		return core.PermissionError("cannot unbox ymk with lower role")
+	}
+	pm := NewPUKMinder(uc)
+	puk, err := pm.GetPUKAtRoleAndGeneration(m, y.raw.Role, y.raw.Gen)
+	if err != nil {
+		return err
+	}
+
+	key := puk.SecretBoxKey()
+
+	var payload lib.YubiManagementKeyBoxPayload
+	err = core.OpenSecretBoxInto(&payload, y.raw.Box, &key)
+	if err != nil {
+		return err
+	}
+	if !y.raw.Yk.Eq(payload.Yk) {
+		return core.KeyMismatchError{}
+	}
+	y.ymk = &payload.Mk
+	y.card = payload.Card
+	y.slot = payload.Slot
+
+	return nil
+}
+
+func (y *YMKPull) unbox(m MetaContext) error {
+	for _, ymk := range y.ymks {
+		err := ymk.unbox(m, y.uc)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (y *YMKPull) run(m MetaContext) error {
+
+	err := y.loadFromServer(m)
+	if err != nil {
+		return err
+	}
+
+	err = y.unbox(m)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (y *YMKPull) Recover(
+	m MetaContext,
+	id proto.YubiCardID,
+) (
+	*proto.YubiManagementKey,
+	error,
+) {
+	err := y.run(m)
+	if err != nil {
+		return nil, err
+	}
+	for _, ymk := range y.ymks {
+		if ymk.card.Eq(id) {
+			return ymk.ymk, nil
+		}
+	}
+	return nil, core.KeyNotFoundError{Which: "YubiManagementKey"}
+}
+
+func (y *YMKPush) syncOne(m MetaContext) error {
+	cli, err := y.uc.UserClient(m)
+	if err != nil {
+		return err
+	}
+	id := y.yi.Key.Id
+	res, err := cli.GetYubiManagementKey(m.Ctx(), id)
+
+	if _, ok := err.(core.KeyNotFoundError); ok {
+		m.Infow("YMKMgr.syncOne", "id", id, "status", "not_found")
+		return nil
+	}
+
+	if err != nil {
+		return err
+	}
+	y.pushYmk = &ymkMgrKey{
+		raw: res,
+	}
+	err = y.pushYmk.unbox(m, y.uc)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (y *YMKPush) getPUK(
+	m MetaContext,
+	role proto.Role,
+) (
+	core.SharedPrivateSuiter,
+	error,
+) {
+
+	eq, err := role.Eq(y.role)
+	if err != nil {
+		return nil, err
+	}
+	latest := y.uc.PrivKeys.LatestPuk()
+	var ret core.SharedPrivateSuiter
+
+	if eq && y.noPUKRefresh && latest != nil {
+		ret = latest
+	} else if eq && y.latestPUKgen.IsValid() &&
+		latest != nil && latest.Metadata().Gen == y.latestPUKgen {
+		ret = latest
+	} else {
+		pm := NewPUKMinder(y.uc)
+		pks, err := pm.GetPUKSetForRole(m, role)
+		if err != nil {
+			return nil, err
+		}
+		ret = pks.Current()
+	}
+	if ret == nil {
+		return nil, core.KeyNotFoundError{Which: "latest PUK"}
+	}
+	return ret, nil
+}
+
+func (y *YMKPush) setupNew(m MetaContext) error {
+
+	latest, err := y.getPUK(m, y.role)
+	if err != nil {
+		return err
+	}
+	y.pushYmk = &ymkMgrKey{}
+	y.puk = latest
+	return nil
+}
+
+func (y *YMKPush) checkEncFresh(m MetaContext, mk *proto.YubiManagementKey) error {
+	if y.pushYmk == nil {
+		return core.InternalError("no push ymk")
+	}
+	latest, err := y.getPUK(m, y.pushYmk.raw.Role)
+	if err != nil {
+		return err
+	}
+	gen := latest.Metadata().Gen
+
+	// Reencrypt in 2 scenarios: (1) if the PUK has been rolled/upgraded;
+	// or (2) if the YubiManagementKey has changed.
+	if gen > y.pushYmk.raw.Gen || !mk.Eq(*y.pushYmk.ymk) {
+		y.stale = true
+		y.puk = latest
+	}
+
+	return nil
+}
+
+func (y *YMKPush) box(m MetaContext, mk *lib.YubiManagementKey) error {
+	pylod := lib.YubiManagementKeyBoxPayload{
+		Mk:   *mk,
+		Card: y.yi.Card,
+		Slot: y.yi.Key.Slot,
+		Yk:   y.yi.Key.Id,
+	}
+	key := y.puk.SecretBoxKey()
+	enc, err := core.SealIntoSecretBox(&pylod, &key)
+	if err != nil {
+		return err
+	}
+	y.pushYmk.raw = rem.YubiEncryptedManagementKey{
+		Box:  *enc,
+		Role: y.puk.GetRole(),
+		Gen:  y.puk.Metadata().Gen,
+		Yk:   y.yi.Key.Id,
+	}
+
+	// Set internal fields as if unbox has just happened
+	y.pushYmk.card = y.yi.Card
+	y.pushYmk.slot = y.yi.Key.Slot
+	y.pushYmk.ymk = mk
+
+	return nil
+}
+
+func (y *YMKPush) push(m MetaContext) error {
+	cli, err := y.uc.UserClient(m)
+	if err != nil {
+		return err
+	}
+	err = cli.PutYubiManagementKey(m.Ctx(), y.pushYmk.raw)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (y *YMKPush) Run(m MetaContext) (err error) {
+
+	m = m.WithLogTag("ymkpush")
+	defer func() {
+		if err != nil {
+			y.outcome = YMKPushOutcomeErr
+			m.Warnw("YMKPush", "err", err)
+		} else {
+			m.Infow("YMKPush", "status", "success")
+		}
+	}()
+	yi := y.uc.Info.YubiInfo
+	y.yi = yi
+
+	if yi == nil {
+		m.Infow("YMKPush", "exit", "no_yubi_info")
+		return nil
+	}
+
+	m.Infow("YMKPush", "ymk", yi.Key.Id, "slot", yi.Key.Slot)
+
+	var admin bool
+	role := y.uc.Role()
+	admin, err = role.IsAdminOrAbove()
+	if err != nil {
+		return err
+	}
+	y.role = role
+
+	if !admin {
+		m.Infow("YMKPush", "exit", "no admin")
+		y.outcome = YMKPushOutcomeNotAdmin
+		return nil
+	}
+
+	mk, err := m.G().YubiDispatch().GetManagementKey(m.Ctx(), yi.Card)
+	if err != nil {
+		return err
+	}
+
+	if mk == nil {
+		m.Infow("YMKPush", "exit", "no mk")
+		y.outcome = YMKPushOutcomeNoManagementKey
+		return nil
+	}
+
+	err = y.syncOne(m)
+	if err != nil {
+		return err
+	}
+
+	outcome := YMKPushOutcomeNew
+
+	if y.pushYmk != nil {
+
+		err = y.checkEncFresh(m, mk)
+		if err != nil {
+			return err
+		}
+
+		if !y.stale {
+			m.Infow("YMKPush", "exit", "not stale")
+			y.outcome = YMKPushOutcomeFresh
+			return nil
+		}
+		outcome = YMKPushOutcomeRefreshed
+
+	} else {
+		err = y.setupNew(m)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = y.box(m, mk)
+	if err != nil {
+		return err
+	}
+
+	err = y.push(m)
+	if err != nil {
+		return err
+	}
+	y.outcome = outcome
+
+	return nil
+}
+
+func (y *YMKPush) Outcome() YMKPushOutcome {
+	return y.outcome
+}
+
+func (u *UserContext) SyncYubiManagementKey(m MetaContext) error {
+	return NewYMKPush(u).WithoutPUKRefresh().Run(m)
+}
+
+func BgRotateYubiManagementKey(m MetaContext, uc *UserContext, uw *UserWrapper) error {
+	g, err := uw.LatestPUKGenForRole(uc.Role())
+	if err != nil {
+		return err
+	}
+	return NewYMKPush(uc).WithLatestPUKGen(g).Run(m)
+}
+
+// RecoverYubiManagementKey resets the YubiKey PIN and PUK to the new values. It needs
+// a management key to do this. If the user didn't specify a management key (passed in
+// via mk), then we try to recover it via the server-sync method. If that fails, we return an
+// error. Requires the YubiKey to be present, and the user to be logged in and active.
+func RecoverYubiManagementKey(
+	m MetaContext,
+	serial proto.YubiSerial,
+	newPin proto.YubiPIN,
+	newPuk proto.YubiPUK,
+	mk *proto.YubiManagementKey,
+) error {
+	disp := m.G().YubiDispatch()
+	cardID, err := disp.FindCardIDBySerial(m.Ctx(), serial)
+	if err != nil {
+		return err
+	}
+
+	// If the user didn't specify a management key, then we have to
+	// try to recover it via the server-sync method.
+	if mk == nil {
+		au := m.G().ActiveUser()
+		if au == nil {
+			return core.NoActiveUserError{}
+		}
+		tmp, err := NewYMKPull(au).Recover(m, *cardID)
+		if err != nil {
+			return err
+		}
+		mk = tmp
+	}
+
+	if mk == nil {
+		return core.InternalError("no management key")
+	}
+
+	err = disp.ResetPINandPUK(m.Ctx(), *cardID, *mk, newPin, newPuk)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/client/libyubi/base.go
+++ b/client/libyubi/base.go
@@ -18,19 +18,11 @@ import (
 type BusBase struct {
 	sync.Mutex
 	handleTab map[proto.YubiCardName]*Handle
-	pt        *PINTable
-}
-
-func newPINTable() *PINTable {
-	return &PINTable{
-		pins: make(map[proto.FixedEntityID]*core.Pin),
-	}
 }
 
 func newBusBase() *BusBase {
 	return &BusBase{
 		handleTab: make(map[proto.YubiCardName]*Handle),
-		pt:        newPINTable(),
 	}
 }
 
@@ -60,8 +52,6 @@ func (h *Handle) clearSecrets() {
 	h.pin = nil
 	h.mgmt = nil
 }
-
-func (b *RealBus) PINTable() *PINTable { return b.pt }
 
 func (h *Handle) decref() {
 	h.Lock()
@@ -240,16 +230,4 @@ func checkIsEC256(cert *x509.Certificate) *ecdsa.PublicKey {
 		return nil
 	}
 	return ecdsa
-}
-
-func (p *PINTable) Get(id proto.FixedEntityID) *core.Pin {
-	p.Lock()
-	defer p.Unlock()
-	return p.pins[id]
-}
-
-func (p *PINTable) Put(id proto.FixedEntityID, pin *core.Pin) {
-	p.Lock()
-	defer p.Unlock()
-	p.pins[id] = pin
 }

--- a/client/libyubi/real.go
+++ b/client/libyubi/real.go
@@ -359,4 +359,14 @@ func setOrGetManagementKeyLocked(
 	return &new, true, nil
 }
 
+func (c *RealCard) SetRetries(
+	mk proto.YubiManagementKey,
+	pinRetries,
+	pukRetries int,
+) error {
+	c.Lock()
+	defer c.Unlock()
+	return c.card.SetRetries(mk.Bytes(), piv.DefaultPIN, pinRetries, pukRetries)
+}
+
 var _ Card = (*RealCard)(nil)

--- a/client/libyubi/top.go
+++ b/client/libyubi/top.go
@@ -68,6 +68,16 @@ func (d *Dispatch) LoadHybrid(
 	return loadHybrid(ctx, d.bus, i, r, h)
 }
 
+func (d *Dispatch) GetManagementKey(
+	ctx context.Context,
+	i proto.YubiCardID,
+) (
+	*proto.YubiManagementKey,
+	error,
+) {
+	return getManagementKey(ctx, d.bus, i)
+}
+
 // AccessPQKey uses a preexsiting ECDSA key as a PQ
 // KEM seed slot. It should not be used to create new keys, since that would imply
 // reusing an ECDSA key as a PQKey, which is dangerous. However, it can be used safely
@@ -161,6 +171,13 @@ func (d *Dispatch) GenerateKeyHybrid(
 	return generateKeyHybrid(ctx, d.bus, i, slot, kemSlot, r, h, opts)
 }
 
+func (d *Dispatch) FindCardIDBySerial(
+	ctx context.Context,
+	serial proto.YubiSerial,
+) (*proto.YubiCardID, error) {
+	return findCardIDBySerial(ctx, d.bus, serial)
+}
+
 func (d *Dispatch) FindCardBySerial(
 	ctx context.Context,
 	serial proto.YubiSerial,
@@ -203,6 +220,16 @@ func (d *Dispatch) SetPIN(
 	return setPIN(ctx, d.bus, id, old, new)
 }
 
+func (d *Dispatch) ResetPINandPUK(
+	ctx context.Context,
+	id proto.YubiCardID,
+	mk proto.YubiManagementKey,
+	pin proto.YubiPIN,
+	puk proto.YubiPUK,
+) error {
+	return resetPINandPUK(ctx, d.bus, id, mk, pin, puk)
+}
+
 func (d *Dispatch) HasDefaultManagementKey(
 	ctx context.Context,
 	id proto.YubiCardID,
@@ -220,6 +247,15 @@ func (d *Dispatch) SetOrGetManagementKey(
 	error,
 ) {
 	return setOrGetManagementKey(ctx, d.bus, id, pin)
+}
+
+func (d *Dispatch) SetManagementKey(
+	ctx context.Context,
+	id proto.YubiCardID,
+	old *proto.YubiManagementKey,
+	new proto.YubiManagementKey,
+) error {
+	return setManagementKey(ctx, d.bus, id, old, new)
 }
 
 func (d *Dispatch) ClearSecrets() {

--- a/integration-tests/lib/reg_test.go
+++ b/integration-tests/lib/reg_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/client/libyubi"
 	"github.com/foks-proj/go-foks/integration-tests/common"
@@ -23,6 +22,7 @@ import (
 	"github.com/foks-proj/go-foks/proto/rem"
 	"github.com/foks-proj/go-foks/server/shared"
 	"github.com/foks-proj/go-snowpack-rpc/rpc"
+	"github.com/stretchr/testify/require"
 )
 
 var globalTestEnv *common.TestEnv
@@ -881,7 +881,7 @@ func (u *TestUser) ClientCertRobust(ctx context.Context, t *testing.T) *tls.Cert
 func (u *TestUser) ClientSubkeyCertRobust(ctx context.Context, t *testing.T) *tls.Certificate {
 	subkey := u.GetSubkey(t, ctx)
 
-	cli, closeFn, err := newRegClient(ctx)
+	cli, closeFn, err := u.newRegClient(ctx)
 	require.NoError(t, err)
 	defer closeFn()
 

--- a/proto-src/lcl/user.snowp
+++ b/proto-src/lcl/user.snowp
@@ -9,6 +9,7 @@ struct LocalUserIndexParsed {
     fqu @0 : lib.FQUserParsed;
     role @1 : lib.Role;
     keyGenus @2 : Option(lib.KeyGenus);
+    keyID @3 : lib.EntityID; // optional, for disambiguation
 }
 
 struct AgentStatus {

--- a/proto-src/lcl/yubi.snowp
+++ b/proto-src/lcl/yubi.snowp
@@ -95,4 +95,11 @@ protocol Yubi
         sessionId @0 : lib.UISessionID
     );
 
+    recoverManagementKey @16 (
+        serial @0 : lib.YubiSerial,
+        pin @1 : lib.YubiPIN,
+        puk @2 : lib.YubiPUK,
+        mk @3 : Option(lib.YubiManagementKey)
+    );
+
 }

--- a/proto-src/lib/yubi.snowp
+++ b/proto-src/lib/yubi.snowp
@@ -86,3 +86,10 @@ struct YubiSerialSlot {
 // even a quantum computer can't compute x. This is achieved simply via
 // one-way function, like SHA2.
 typedef YubiPQKeyID = Blob(32); 
+
+struct YubiManagementKeyBoxPayload @0xc939af74e0147c7a {
+    mk @0 : YubiManagementKey;
+    card @1 : YubiCardID;
+    slot @2 : YubiSlot;
+    yk @3 : YubiID;
+}

--- a/proto-src/rem/user.snowp
+++ b/proto-src/rem/user.snowp
@@ -123,6 +123,13 @@ struct TreeLocationPair {
     loc @1 : lib.TreeLocation;
 }
 
+struct YubiEncryptedManagementKey {
+    yk @0 : lib.YubiID;
+    box @1 : lib.SecretBox;
+    gen @2 : lib.Generation;
+    role @3 : lib.Role;
+}
+
 protocol User 
     errors lib.Status 
     argHeader lib.Header 
@@ -242,4 +249,13 @@ protocol User
 
     getDeviceNag @25 () -> lib.DeviceNagInfo;
     clearDeviceNag @26 ( cleared @0 : Bool );
+
+    putYubiManagementKey @27 (
+        ymk @0 : YubiEncryptedManagementKey
+    );
+    getYubiManagementKey @28 (
+        yk @0 : lib.YubiID
+    ) -> YubiEncryptedManagementKey;
+    getAllYubiManagementKeys @29 (
+    ) -> List(YubiEncryptedManagementKey);
 }

--- a/proto/lcl/user.go
+++ b/proto/lcl/user.go
@@ -16,6 +16,7 @@ type LocalUserIndexParsed struct {
 	Fqu      lib.FQUserParsed
 	Role     lib.Role
 	KeyGenus *lib.KeyGenus
+	KeyID    lib.EntityID
 }
 
 type LocalUserIndexParsedInternal__ struct {
@@ -23,6 +24,7 @@ type LocalUserIndexParsedInternal__ struct {
 	Fqu      *lib.FQUserParsedInternal__
 	Role     *lib.RoleInternal__
 	KeyGenus *lib.KeyGenusInternal__
+	KeyID    *lib.EntityIDInternal__
 }
 
 func (l LocalUserIndexParsedInternal__) Import() LocalUserIndexParsed {
@@ -51,6 +53,12 @@ func (l LocalUserIndexParsedInternal__) Import() LocalUserIndexParsed {
 			})(x)
 			return &tmp
 		})(l.KeyGenus),
+		KeyID: (func(x *lib.EntityIDInternal__) (ret lib.EntityID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(l.KeyID),
 	}
 }
 
@@ -64,6 +72,7 @@ func (l LocalUserIndexParsed) Export() *LocalUserIndexParsedInternal__ {
 			}
 			return (*x).Export()
 		})(l.KeyGenus),
+		KeyID: l.KeyID.Export(),
 	}
 }
 

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -4716,3 +4716,7 @@ func (m YubiManagementKey) IsZero() bool {
 func (k YubiManagementKey) Eq(i YubiManagementKey) bool {
 	return hmac.Equal(k[:], i[:])
 }
+
+func (i YubiCardID) Eq(i2 YubiCardID) bool {
+	return i.Name == i2.Name && i.Serial == i2.Serial
+}

--- a/proto/lib/yubi.go
+++ b/proto/lib/yubi.go
@@ -1001,3 +1001,82 @@ func (y *YubiPQKeyID) Decode(dec rpc.Decoder) error {
 func (y YubiPQKeyID) Bytes() []byte {
 	return (y)[:]
 }
+
+type YubiManagementKeyBoxPayload struct {
+	Mk   YubiManagementKey
+	Card YubiCardID
+	Slot YubiSlot
+	Yk   YubiID
+}
+
+type YubiManagementKeyBoxPayloadInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Mk      *YubiManagementKeyInternal__
+	Card    *YubiCardIDInternal__
+	Slot    *YubiSlotInternal__
+	Yk      *YubiIDInternal__
+}
+
+func (y YubiManagementKeyBoxPayloadInternal__) Import() YubiManagementKeyBoxPayload {
+	return YubiManagementKeyBoxPayload{
+		Mk: (func(x *YubiManagementKeyInternal__) (ret YubiManagementKey) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(y.Mk),
+		Card: (func(x *YubiCardIDInternal__) (ret YubiCardID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(y.Card),
+		Slot: (func(x *YubiSlotInternal__) (ret YubiSlot) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(y.Slot),
+		Yk: (func(x *YubiIDInternal__) (ret YubiID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(y.Yk),
+	}
+}
+
+func (y YubiManagementKeyBoxPayload) Export() *YubiManagementKeyBoxPayloadInternal__ {
+	return &YubiManagementKeyBoxPayloadInternal__{
+		Mk:   y.Mk.Export(),
+		Card: y.Card.Export(),
+		Slot: y.Slot.Export(),
+		Yk:   y.Yk.Export(),
+	}
+}
+
+func (y *YubiManagementKeyBoxPayload) Encode(enc rpc.Encoder) error {
+	return enc.Encode(y.Export())
+}
+
+func (y *YubiManagementKeyBoxPayload) Decode(dec rpc.Decoder) error {
+	var tmp YubiManagementKeyBoxPayloadInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*y = tmp.Import()
+	return nil
+}
+
+var YubiManagementKeyBoxPayloadTypeUniqueID = rpc.TypeUniqueID(0xc939af74e0147c7a)
+
+func (y *YubiManagementKeyBoxPayload) GetTypeUniqueID() rpc.TypeUniqueID {
+	return YubiManagementKeyBoxPayloadTypeUniqueID
+}
+
+func (y *YubiManagementKeyBoxPayload) Bytes() []byte { return nil }
+
+func init() {
+	rpc.AddUnique(YubiManagementKeyBoxPayloadTypeUniqueID)
+}

--- a/proto/rem/user.go
+++ b/proto/rem/user.go
@@ -1592,6 +1592,75 @@ func (t *TreeLocationPair) Decode(dec rpc.Decoder) error {
 
 func (t *TreeLocationPair) Bytes() []byte { return nil }
 
+type YubiEncryptedManagementKey struct {
+	Yk   lib.YubiID
+	Box  lib.SecretBox
+	Gen  lib.Generation
+	Role lib.Role
+}
+
+type YubiEncryptedManagementKeyInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Yk      *lib.YubiIDInternal__
+	Box     *lib.SecretBoxInternal__
+	Gen     *lib.GenerationInternal__
+	Role    *lib.RoleInternal__
+}
+
+func (y YubiEncryptedManagementKeyInternal__) Import() YubiEncryptedManagementKey {
+	return YubiEncryptedManagementKey{
+		Yk: (func(x *lib.YubiIDInternal__) (ret lib.YubiID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(y.Yk),
+		Box: (func(x *lib.SecretBoxInternal__) (ret lib.SecretBox) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(y.Box),
+		Gen: (func(x *lib.GenerationInternal__) (ret lib.Generation) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(y.Gen),
+		Role: (func(x *lib.RoleInternal__) (ret lib.Role) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(y.Role),
+	}
+}
+
+func (y YubiEncryptedManagementKey) Export() *YubiEncryptedManagementKeyInternal__ {
+	return &YubiEncryptedManagementKeyInternal__{
+		Yk:   y.Yk.Export(),
+		Box:  y.Box.Export(),
+		Gen:  y.Gen.Export(),
+		Role: y.Role.Export(),
+	}
+}
+
+func (y *YubiEncryptedManagementKey) Encode(enc rpc.Encoder) error {
+	return enc.Encode(y.Export())
+}
+
+func (y *YubiEncryptedManagementKey) Decode(dec rpc.Decoder) error {
+	var tmp YubiEncryptedManagementKeyInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*y = tmp.Import()
+	return nil
+}
+
+func (y *YubiEncryptedManagementKey) Bytes() []byte { return nil }
+
 var UserProtocolID rpc.ProtocolUniqueID = rpc.ProtocolUniqueID(0x823f0899)
 
 type PingArg struct {
@@ -2982,6 +3051,121 @@ func (c *ClearDeviceNagArg) Decode(dec rpc.Decoder) error {
 
 func (c *ClearDeviceNagArg) Bytes() []byte { return nil }
 
+type PutYubiManagementKeyArg struct {
+	Ymk YubiEncryptedManagementKey
+}
+
+type PutYubiManagementKeyArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Ymk     *YubiEncryptedManagementKeyInternal__
+}
+
+func (p PutYubiManagementKeyArgInternal__) Import() PutYubiManagementKeyArg {
+	return PutYubiManagementKeyArg{
+		Ymk: (func(x *YubiEncryptedManagementKeyInternal__) (ret YubiEncryptedManagementKey) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(p.Ymk),
+	}
+}
+
+func (p PutYubiManagementKeyArg) Export() *PutYubiManagementKeyArgInternal__ {
+	return &PutYubiManagementKeyArgInternal__{
+		Ymk: p.Ymk.Export(),
+	}
+}
+
+func (p *PutYubiManagementKeyArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(p.Export())
+}
+
+func (p *PutYubiManagementKeyArg) Decode(dec rpc.Decoder) error {
+	var tmp PutYubiManagementKeyArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*p = tmp.Import()
+	return nil
+}
+
+func (p *PutYubiManagementKeyArg) Bytes() []byte { return nil }
+
+type GetYubiManagementKeyArg struct {
+	Yk lib.YubiID
+}
+
+type GetYubiManagementKeyArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Yk      *lib.YubiIDInternal__
+}
+
+func (g GetYubiManagementKeyArgInternal__) Import() GetYubiManagementKeyArg {
+	return GetYubiManagementKeyArg{
+		Yk: (func(x *lib.YubiIDInternal__) (ret lib.YubiID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(g.Yk),
+	}
+}
+
+func (g GetYubiManagementKeyArg) Export() *GetYubiManagementKeyArgInternal__ {
+	return &GetYubiManagementKeyArgInternal__{
+		Yk: g.Yk.Export(),
+	}
+}
+
+func (g *GetYubiManagementKeyArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(g.Export())
+}
+
+func (g *GetYubiManagementKeyArg) Decode(dec rpc.Decoder) error {
+	var tmp GetYubiManagementKeyArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*g = tmp.Import()
+	return nil
+}
+
+func (g *GetYubiManagementKeyArg) Bytes() []byte { return nil }
+
+type GetAllYubiManagementKeysArg struct {
+}
+
+type GetAllYubiManagementKeysArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+}
+
+func (g GetAllYubiManagementKeysArgInternal__) Import() GetAllYubiManagementKeysArg {
+	return GetAllYubiManagementKeysArg{}
+}
+
+func (g GetAllYubiManagementKeysArg) Export() *GetAllYubiManagementKeysArgInternal__ {
+	return &GetAllYubiManagementKeysArgInternal__{}
+}
+
+func (g *GetAllYubiManagementKeysArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(g.Export())
+}
+
+func (g *GetAllYubiManagementKeysArg) Decode(dec rpc.Decoder) error {
+	var tmp GetAllYubiManagementKeysArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*g = tmp.Import()
+	return nil
+}
+
+func (g *GetAllYubiManagementKeysArg) Bytes() []byte { return nil }
+
 type UserInterface interface {
 	Ping(context.Context) (lib.UID, error)
 	SetPassphrase(context.Context, SetPassphraseArg) error
@@ -3009,6 +3193,9 @@ type UserInterface interface {
 	GetHostConfig(context.Context) (lib.HostConfig, error)
 	GetDeviceNag(context.Context) (lib.DeviceNagInfo, error)
 	ClearDeviceNag(context.Context, bool) error
+	PutYubiManagementKey(context.Context, YubiEncryptedManagementKey) error
+	GetYubiManagementKey(context.Context, lib.YubiID) (YubiEncryptedManagementKey, error)
+	GetAllYubiManagementKeys(context.Context) ([]YubiEncryptedManagementKey, error)
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h lib.Header) error
 
@@ -3651,6 +3838,95 @@ func (c UserClient) ClearDeviceNag(ctx context.Context, cleared bool) (err error
 			return
 		}
 	}
+	return
+}
+
+func (c UserClient) PutYubiManagementKey(ctx context.Context, ymk YubiEncryptedManagementKey) (err error) {
+	arg := PutYubiManagementKeyArg{
+		Ymk: ymk,
+	}
+	warg := &rpc.DataWrap[lib.Header, *PutYubiManagementKeyArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[lib.Header, interface{}]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(UserProtocolID, 27, "User.putYubiManagementKey"), warg, &tmp, 0*time.Millisecond, userErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (c UserClient) GetYubiManagementKey(ctx context.Context, yk lib.YubiID) (res YubiEncryptedManagementKey, err error) {
+	arg := GetYubiManagementKeyArg{
+		Yk: yk,
+	}
+	warg := &rpc.DataWrap[lib.Header, *GetYubiManagementKeyArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[lib.Header, YubiEncryptedManagementKeyInternal__]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(UserProtocolID, 28, "User.getYubiManagementKey"), warg, &tmp, 0*time.Millisecond, userErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	res = tmp.Data.Import()
+	return
+}
+
+func (c UserClient) GetAllYubiManagementKeys(ctx context.Context) (res []YubiEncryptedManagementKey, err error) {
+	var arg GetAllYubiManagementKeysArg
+	warg := &rpc.DataWrap[lib.Header, *GetAllYubiManagementKeysArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[lib.Header, [](*YubiEncryptedManagementKeyInternal__)]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(UserProtocolID, 29, "User.getAllYubiManagementKeys"), warg, &tmp, 0*time.Millisecond, userErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	res = (func(x *[](*YubiEncryptedManagementKeyInternal__)) (ret []YubiEncryptedManagementKey) {
+		if x == nil || len(*x) == 0 {
+			return nil
+		}
+		ret = make([]YubiEncryptedManagementKey, len(*x))
+		for k, v := range *x {
+			if v == nil {
+				continue
+			}
+			ret[k] = (func(x *YubiEncryptedManagementKeyInternal__) (ret YubiEncryptedManagementKey) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(v)
+		}
+		return ret
+	})(&tmp.Data)
 	return
 }
 
@@ -4394,6 +4670,103 @@ func UserProtocol(i UserInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "clearDeviceNag",
+			},
+			27: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[lib.Header, *PutYubiManagementKeyArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[lib.Header, *PutYubiManagementKeyArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[lib.Header, *PutYubiManagementKeyArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						err := i.PutYubiManagementKey(ctx, (typedArg.Import()).Ymk)
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[lib.Header, interface{}]{
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "putYubiManagementKey",
+			},
+			28: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[lib.Header, *GetYubiManagementKeyArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[lib.Header, *GetYubiManagementKeyArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[lib.Header, *GetYubiManagementKeyArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						tmp, err := i.GetYubiManagementKey(ctx, (typedArg.Import()).Yk)
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[lib.Header, *YubiEncryptedManagementKeyInternal__]{
+							Data:   tmp.Export(),
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "getYubiManagementKey",
+			},
+			29: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[lib.Header, *GetAllYubiManagementKeysArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[lib.Header, *GetAllYubiManagementKeysArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[lib.Header, *GetAllYubiManagementKeysArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						tmp, err := i.GetAllYubiManagementKeys(ctx)
+						if err != nil {
+							return nil, err
+						}
+						lst := (func(x []YubiEncryptedManagementKey) *[](*YubiEncryptedManagementKeyInternal__) {
+							if len(x) == 0 {
+								return nil
+							}
+							ret := make([](*YubiEncryptedManagementKeyInternal__), len(x))
+							for k, v := range x {
+								ret[k] = v.Export()
+							}
+							return &ret
+						})(tmp)
+						ret := rpc.DataWrap[lib.Header, [](*YubiEncryptedManagementKeyInternal__)]{
+							Header: i.MakeResHeader(),
+						}
+						if lst != nil {
+							ret.Data = *lst
+						}
+						return &ret, nil
+					},
+				},
+				Name: "getAllYubiManagementKeys",
 			},
 		},
 		WrapError: UserMakeGenericErrorWrapper(i.ErrorWrapper()),

--- a/server/sql/foks_users.sql
+++ b/server/sql/foks_users.sql
@@ -888,3 +888,16 @@ CREATE TABLE data_loss_nag (
     cleared BOOLEAN NOT NULL,
     PRIMARY KEY(short_host_id, uid)
 );
+
+CREATE TABLE yubi_mgmt_keys (
+    short_host_id SMALLINT NOT NULL,
+    uid BYTEA NOT NULL,
+    key_id BYTEA NOT NULL,
+    box BYTEA NOT NULL,
+    puk_gen INTEGER NOT NULL,
+    puk_role_type SMALLINT NOT NULL,
+    puk_viz_level SMALLINT NOT NULL,
+    ctime TIMESTAMP NOT NULL,
+    mtime TIMESTAMP NOT NULL,
+    PRIMARY KEY(short_host_id, uid, key_id)
+);


### PR DESCRIPTION
- write a PUK-encrypted box of the management key to the server
  - db tables, proto and CRUD for storing encrypted management keys on the server
- push on pin-unlock, since we need the pin to get the management key off the yubi
  - push a new management key when the PUK rotates
  - also push a new management key if the management key chages. i'm not sure when this will come up, but we should deal with it
- fetch in `yubi recover`
- e2e testing of this in lib and cli
- strip out deprecated pin table, wasn't being used
- fix a bug in test where ClientSubkeyCertRobust wasn't correctly selecting a vhost
- fix `foks key switch -u` to disambiguate by keyID too
- close #1