### PR TITLE
libclient: protect the fields of UserPrivKeys with locks

### DIFF
--- a/client/agent/device.go
+++ b/client/agent/device.go
@@ -111,12 +111,10 @@ func (c *AgentConn) SelfProvision(ctx context.Context, arg lcl.SelfProvisionArg)
 	info.Key = newKeyEID
 
 	uc := libclient.UserContext{
-		Info: info,
-		PrivKeys: libclient.UserPrivateKeys{
-			Devkey: newKey,
-		},
+		Info:    info,
 		Devname: arg.Dln.Name,
 	}
+	uc.PrivKeys.SetDevkey(newKey)
 	uc.SetHomeServer(au.HomeServer())
 	uc.SetSkmm(skm)
 
@@ -125,7 +123,7 @@ func (c *AgentConn) SelfProvision(ctx context.Context, arg lcl.SelfProvisionArg)
 	if err != nil {
 		return err
 	}
-	uc.PrivKeys.Puks = pukset.All()
+	uc.PrivKeys.SetPUKs(pukset)
 
 	var ltx libclient.LocalDbTx
 	err = ltx.PutUser(info, false)

--- a/client/agent/kex.go
+++ b/client/agent/kex.go
@@ -570,7 +570,7 @@ func (a *AgentConn) AssistStartKex(ctx context.Context, id proto.UISessionID) (p
 		cu.Info.Fqu.Uid,
 		cu.Info.Fqu.HostID,
 		role,
-		cu.PrivKeys.Devkey,
+		cu.PrivKeys.GetDevkey(),
 	)
 	hesp, err := sess.kexEng.kexCommonEngine.runKex(m, kex)
 	if err != nil {
@@ -646,7 +646,7 @@ func (a *AgentConn) finishKexProvision(ctx context.Context, sess *SignupSession)
 	if err != nil {
 		return err
 	}
-	uc.PrivKeys.Puks = pukset.All()
+	uc.PrivKeys.SetPUKs(pukset)
 
 	if sess.skm == nil {
 		return core.InternalError("no secret key manager in finishKexProvision")

--- a/client/agent/passphrase.go
+++ b/client/agent/passphrase.go
@@ -38,7 +38,7 @@ func (c *AgentConn) PassphraseSet(ctx context.Context, pp lcl.PassphraseSetArg) 
 	if pp.First {
 		err = pm.SetPassphrase(ctx, psi, pp.Passphrase, puk)
 	} else {
-		err = pm.ChangePassphraseWithPUK(ctx, psi, pp.Passphrase, au.PrivKeys.Puks)
+		err = pm.ChangePassphraseWithPUK(ctx, psi, pp.Passphrase, au.PrivKeys.GetPUKs())
 	}
 	if err != nil {
 		return err

--- a/client/agent/signup.go
+++ b/client/agent/signup.go
@@ -82,13 +82,16 @@ func (s *SignupSession) UserContext() (*libclient.UserContext, error) {
 			KeyGenus: kg,
 			Key:      keyID,
 		},
-		PrivKeys: libclient.UserPrivateKeys{
-			Devkey: s.privKey,
-		},
 		Devname: s.deviceName,
 	}
+	ret.PrivKeys.SetDevkey(s.privKey)
 	if s.puk != nil {
-		ret.PrivKeys.Puks = []core.SharedPrivateSuiter{s.puk}
+		ret.PrivKeys.SetPUKs(
+			libclient.NewPUKSet(
+				[]core.SharedPrivateSuiter{s.puk},
+				s.fqu.HostID,
+			),
+		)
 	}
 
 	if !s.selfTok.IsZero() {

--- a/client/agent/user.go
+++ b/client/agent/user.go
@@ -356,7 +356,7 @@ func (c *AgentConn) LoginWaitForSsoLogin(
 		return ret, err
 	}
 	sess.oauth2.Idtok = idtok
-	ssoArg, err := c.signSSOArgs(m, sess.oauth2, au.PrivKeys.Devkey, au.HostID())
+	ssoArg, err := c.signSSOArgs(m, sess.oauth2, au.PrivKeys.GetDevkey(), au.HostID())
 	if err != nil {
 		return ret, err
 	}

--- a/client/agent/yubi.go
+++ b/client/agent/yubi.go
@@ -188,10 +188,8 @@ func populateUserContext(
 			KeyGenus: kg,
 			Key:      keyID,
 		},
-		PrivKeys: libclient.UserPrivateKeys{
-			Devkey: dev,
-		},
 	}
+	uctx.PrivKeys.SetDevkey(dev)
 	if yinf != nil {
 		uctx.Info.YubiInfo = yinf
 		uctx.Yubi = dev

--- a/client/foks/cmd/base.go
+++ b/client/foks/cmd/base.go
@@ -60,7 +60,7 @@ func quickStartLambda[
 	opts *agent.StartupOpts,
 	fn func(T) error,
 ) error {
-	cli, clean, err := quickStart[T, U, A, R](m, opts)
+	cli, clean, err := quickStart[T](m, opts)
 	if err != nil {
 		return err
 	}

--- a/client/libclient/puk_minder.go
+++ b/client/libclient/puk_minder.go
@@ -25,6 +25,10 @@ type PUKSet struct {
 	host proto.HostID
 }
 
+func NewPUKSet(l []core.SharedPrivateSuiter, h proto.HostID) *PUKSet {
+	return &PUKSet{l: l, host: h}
+}
+
 func (p PUKSet) All() []core.SharedPrivateSuiter {
 	return p.l
 }

--- a/client/libclient/team_minder.go
+++ b/client/libclient/team_minder.go
@@ -420,7 +420,7 @@ func (t *TeamMinder) postMembershipLink(
 	glink, err := core.MakeGenericLink(
 		t.au.UID().EntityID(),
 		fqt.Host,
-		t.au.PrivKeys.Devkey,
+		t.au.PrivKeys.GetDevkey(),
 		glp,
 		seqno,
 		prev,

--- a/client/libclient/team_minder_inbox.go
+++ b/client/libclient/team_minder_inbox.go
@@ -276,7 +276,7 @@ func (t *TeamMinder) makeMembershipChainLink(
 
 	if asTeam == nil {
 		eid = au.FQU().Uid.EntityID()
-		key = au.PrivKeys.Devkey
+		key = au.PrivKeys.GetDevkey()
 		tmw, err = t.refreshUserTML(m)
 		if err != nil {
 			return nil, err
@@ -400,7 +400,7 @@ func (t *TeamMinder) acceptInviteForTeamLocal(
 		return err
 	}
 	ptks := tm.Tw().KeyRing().KeysForRole(core.AdminRole)
-	if ptks == nil || ptks.LastGen() < 0 {
+	if ptks == nil || !ptks.LastGen().IsValid() {
 		return core.KeyNotFoundError{Which: "admin PUK"}
 	}
 	ptk := ptks.Current()
@@ -622,7 +622,7 @@ func (t *TeamMinder) acceptInviteForTeamRemote(
 	joinerParty := joinerFqt.FQParty()
 	ptkRole := core.AdminRole
 	ptks := tm.Tw().KeyRing().KeysForRole(ptkRole)
-	if ptks == nil || ptks.LastGen() < 0 {
+	if ptks == nil || !ptks.LastGen().IsValid() {
 		return nil, core.KeyNotFoundError{Which: "admin PTK"}
 	}
 	joinerPtk := ptks.Current()

--- a/client/libclient/user_loader.go
+++ b/client/libclient/user_loader.go
@@ -14,7 +14,6 @@ import (
 	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/lib/merkle"
 	"github.com/foks-proj/go-foks/proto/lcl"
-	"github.com/foks-proj/go-foks/proto/lib"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
 )
@@ -422,17 +421,6 @@ func (u *UserLoader) resolveHost(m MetaContext, hid proto.HostID) error {
 		return err
 	}
 	u.probe = res.Probe
-	cas, err := m.G().ProbeRootCAs(m.Ctx())
-	if err != nil {
-		return err
-	}
-	var base LoadUserHost
-	if u.arg.Host != nil {
-		base = *u.arg.Host
-	}
-
-	base.Addr = res.Addr
-	base.CAs = cas
 	return nil
 }
 
@@ -513,7 +501,7 @@ func (u *UserLoader) loadUserFromServer(m MetaContext) error {
 
 	arg := rem.LoadUserChainArg{
 		Uid:   u.arg.Uid,
-		Start: lib.ChainEldestSeqno,
+		Start: proto.ChainEldestSeqno,
 	}
 
 	var auth rem.LoadUserChainAuth
@@ -1183,7 +1171,7 @@ func (u *UserLoader) checkRes(m MetaContext) error {
 }
 
 func (u *UserLoader) checkUsername(m MetaContext) error {
-	var existingName *lib.NameAndSeqnoBundle
+	var existingName *proto.NameAndSeqnoBundle
 	if u.existing != nil {
 		existingName = &u.existing.Username
 	}

--- a/client/libclient/ymk_mgr.go
+++ b/client/libclient/ymk_mgr.go
@@ -5,7 +5,6 @@ package libclient
 
 import (
 	"github.com/foks-proj/go-foks/lib/core"
-	"github.com/foks-proj/go-foks/proto/lib"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
 )
@@ -114,7 +113,7 @@ func (y *ymkMgrKey) unbox(m MetaContext, uc *UserContext) error {
 
 	key := puk.SecretBoxKey()
 
-	var payload lib.YubiManagementKeyBoxPayload
+	var payload proto.YubiManagementKeyBoxPayload
 	err = core.OpenSecretBoxInto(&payload, y.raw.Box, &key)
 	if err != nil {
 		return err
@@ -264,8 +263,8 @@ func (y *YMKPush) checkEncFresh(m MetaContext, mk *proto.YubiManagementKey) erro
 	return nil
 }
 
-func (y *YMKPush) box(m MetaContext, mk *lib.YubiManagementKey) error {
-	pylod := lib.YubiManagementKeyBoxPayload{
+func (y *YMKPush) box(m MetaContext, mk *proto.YubiManagementKey) error {
+	pylod := proto.YubiManagementKeyBoxPayload{
 		Mk:   *mk,
 		Card: y.yi.Card,
 		Slot: y.yi.Key.Slot,

--- a/integration-tests/cli/git_test.go
+++ b/integration-tests/cli/git_test.go
@@ -33,10 +33,6 @@ func (g *gitTestEnv) socket() string {
 	return filepath.Join(g.Dir, "foks.sock")
 }
 
-func (g *gitTestEnv) newAgent(t *testing.T) *testAgent {
-	return newTestAgentWithOpts(t, agentOpts{socketFile: g.socket()})
-}
-
 func (g *gitTestEnv) newAgentAndUser(t *testing.T) *userAgentBundle {
 	rn, err := core.RandomBase36String(8)
 	require.NoError(t, err)

--- a/integration-tests/cli/signup_test.go
+++ b/integration-tests/cli/signup_test.go
@@ -122,11 +122,6 @@ func (m *mockSignupUI) withYubiCardPos(p int) *mockSignupUI {
 	return m
 }
 
-func (m *mockSignupUI) withDeviceErr(e error) *mockSignupUI {
-	m.deviceErr = e
-	return m
-}
-
 func (m *mockSignupUI) withInviteCode(i *rem.InviteCode) *mockSignupUI {
 	m.invite = i
 	return m

--- a/integration-tests/lib/reg_test.go
+++ b/integration-tests/lib/reg_test.go
@@ -452,10 +452,8 @@ func (u *TestUser) exportToUserContext(t *testing.T) *libclient.UserContext {
 				NameUtf8: u.name,
 			},
 		},
-		PrivKeys: libclient.UserPrivateKeys{
-			Devkey: u.devices[0],
-		},
 	}
+	ret.PrivKeys.SetDevkey(u.devices[0])
 
 	return ret
 }

--- a/integration-tests/lib/user_loader_test.go
+++ b/integration-tests/lib/user_loader_test.go
@@ -368,9 +368,6 @@ func addUserToGlobalContext(
 	keyId, err := d.EntityID()
 	require.NoError(t, err)
 	uc := &libclient.UserContext{
-		PrivKeys: libclient.UserPrivateKeys{
-			Devkey: d,
-		},
 		Info: proto.UserInfo{
 			Fqu: u.FQUser(),
 			Username: proto.NameBundle{
@@ -381,6 +378,7 @@ func addUserToGlobalContext(
 			Key:  keyId,
 		},
 	}
+	uc.PrivKeys.SetDevkey(d)
 	uc.SetHomeServer(probe)
 	yi, err := d.ExportToYubiKeyInfo(cm.Ctx())
 	require.NoError(t, err)
@@ -548,7 +546,7 @@ func TestUserLoadChangeUsername(t *testing.T) {
 func storePrivateKey(t *testing.T, m libclient.MetaContext) {
 	au := m.G().ActiveUser()
 	require.NotNil(t, au)
-	k := au.PrivKeys.Devkey
+	k := au.PrivKeys.GetDevkey()
 	k25519, ok := k.(*core.PrivateSuite25519)
 	require.True(t, ok)
 	require.NotNil(t, k)
@@ -579,8 +577,8 @@ func storePrivateKey(t *testing.T, m libclient.MetaContext) {
 
 func checkActiveUser(t *testing.T, u *libclient.UserContext) {
 	require.NotNil(t, u)
-	require.NotNil(t, u.PrivKeys.Devkey)
-	require.NotZero(t, len(u.PrivKeys.Puks))
+	require.NotNil(t, u.PrivKeys.GetDevkey())
+	require.NotZero(t, len(u.PrivKeys.GetPUKs()))
 }
 
 func TestLoadActiveUser(t *testing.T) {

--- a/lib/core/context.go
+++ b/lib/core/context.go
@@ -82,10 +82,6 @@ func (m MetaContext) Errorf(format string, args ...interface{}) {
 	m.logWithSkip().Errorf(format, args...)
 }
 
-func (m MetaContext) addCtxLog(keysAndValues ...interface{}) []interface{} {
-	return AddCtxLog(m.ctx, keysAndValues...)
-}
-
 func (m MetaContext) Warnw(msg string, keysAndValues ...interface{}) {
 	m.logWithSkip().Warnw(msg, AddCtxLog(m.ctx, keysAndValues...)...)
 }

--- a/server/engine/merkle_signer.go
+++ b/server/engine/merkle_signer.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"flag"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/foks-proj/go-foks/lib/core"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/server/shared"
 	"github.com/foks-proj/go-snowpack-rpc/rpc"
+	"github.com/jackc/pgx/v5"
 )
 
 type MerkleSignerVHostState struct {
@@ -245,7 +245,7 @@ func (s *MerkleSignerServer) doOnePollForHost(m shared.MetaContext) error {
 	defer tx.Rollback(m.Ctx())
 	var lst *rootAndEpno
 	for _, root := range roots {
-		sig, blob, err := core.Sign2[*proto.MerkleRootBlob](vhs.key, &root.root)
+		sig, blob, err := core.Sign2(vhs.key, &root.root)
 		if err != nil {
 			return err
 		}

--- a/server/engine/reg.go
+++ b/server/engine/reg.go
@@ -348,16 +348,6 @@ func (c *RegClientConn) signupInsertPassphrase(
 	return nil
 }
 
-func (c *RegClientConn) signupInsertYubiPHHint(
-	m shared.MetaContext,
-	tx pgx.Tx,
-	uid proto.UID,
-	signer proto.EntityID,
-	hint *proto.YubiSlotAndPQKeyID,
-) error {
-	return shared.InsertYubiPQHint(m, tx, uid, signer, hint)
-}
-
 func (c *RegClientConn) signupTryTx(m shared.MetaContext, tx pgx.Tx, arg rem.SignupArg) error {
 
 	hostId := m.HostID().Id


### PR DESCRIPTION
- we can clear() them in one go-route, and access them from another, so make sure it's race-free via RWMutex
- fix various go-vet errors that had piled up (removing dead code etc)
- add a lock into UserPrivateKeys
- hide PUK, devkey, subkey and cert access behind the lock and accessors
- close #3