### PR TITLE
build: initial scripts for build/x-compile of rpms

### DIFF
--- a/dockerfiles/rpm-pkg.dev
+++ b/dockerfiles/rpm-pkg.dev
@@ -1,0 +1,34 @@
+FROM almalinux:8
+
+# Using almalinux:8 gets us a pretty early version of glibc (2.17)
+# Much easier to build on fedora:42, which has an up-to-date golang too,
+# but then we get a glibc at version 2.37. There are other solutions using
+# mock, but this is the simplest for now.
+
+# on almalinux, these magical incantations are needed to get
+# pcsc-lite-devel. They are not needed on fedora:36+
+RUN dnf install -y dnf-plugins-core
+RUN dnf config-manager --set-enabled powertools
+
+# Install build tools
+RUN dnf install -y \
+      rpmdevtools \
+      rpm-build \
+      yum-utils \
+      pcsc-lite-devel \
+      gcc \
+    && dnf clean all
+
+ARG PLAT=arm64
+
+WORKDIR /root
+
+RUN (cd /root && \
+    curl -fSsL https://go.dev/dl/go1.24.2.linux-${PLAT}.tar.gz > go.tgz && \
+    tar -xzf go.tgz && \
+    rm -f go.tgz && \
+    mv go /usr/local/go)
+
+RUN rpmdev-setuptree
+
+ENTRYPOINT ["/bin/bash"]

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/firefart/nonamedreturns v1.0.5 // indirect
-	github.com/foks-proj/go-tools v0.0.2 // indirect
+	github.com/foks-proj/go-tools v0.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.9 // indirect
@@ -335,6 +335,6 @@ require (
 tool (
 	github.com/a-h/templ/cmd/templ
 	github.com/air-verse/air
-	github.com/foks-proj/go-tools/changelog-deb
+	github.com/foks-proj/go-tools/changelog-linux-pkg
 	github.com/golangci/golangci-lint/cmd/golangci-lint
 )

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/foks-proj/go-git-remhelp v0.0.2 h1:DPAJAm26TdK2KOVdu66ZvleOLsQ1LlXCGi
 github.com/foks-proj/go-git-remhelp v0.0.2/go.mod h1:64ubmkraJ8SDpgHcsnSyTapwpZgYF/NXZHN8Jx0f1FM=
 github.com/foks-proj/go-snowpack-rpc v0.0.1 h1:09W2R8yafo67a7JFQCUq6u7KIbouniet3t9O6AvuxI0=
 github.com/foks-proj/go-snowpack-rpc v0.0.1/go.mod h1:onRQ6P75yEUMz3+GLv6jLFGrLA5DukztDz4IRJi1++Y=
-github.com/foks-proj/go-tools v0.0.2 h1:BXN+d7nbXhcvA2k95aywfDBudFJe8X6FV//eecoHuag=
-github.com/foks-proj/go-tools v0.0.2/go.mod h1:tnzyQe9kulfDHpab+L5MglWp2Y4g1tscSUj6XMB7yog=
+github.com/foks-proj/go-tools v0.0.3 h1:lgWJgBOEaBvYZWUITuJ/A6KUuc3QZ3WuKsKr5OQeQ1w=
+github.com/foks-proj/go-tools v0.0.3/go.mod h1:tnzyQe9kulfDHpab+L5MglWp2Y4g1tscSUj6XMB7yog=
 github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
 github.com/frankban/quicktest v1.14.2/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -104,7 +104,7 @@ make_changelog() {
         echo "Version in changelog.yml ($cl_vers) does not match version ($version)"
         exit 1
     fi
-    go tool github.com/foks-proj/go-tools/changelog-deb < changelog.yml | gzip -n9c > build/changelog.debian-${version}.gz
+    go tool github.com/foks-proj/go-tools/changelog-linux-pkg deb < changelog.yml | gzip -n9c > build/changelog.debian-${version}.gz
 }
 
 build_deb() {

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -1,0 +1,212 @@
+#!/bin/sh
+# Copyright (c) 2025 ne43, Inc.
+# Licensed under the MIT License. See LICENSE in the project root for details.
+
+# This script builds a debian package for foks via docker, so should work on most platforms.
+
+
+usage() {
+    echo "Usage: $0 -p {arm64|amd64}"
+    exit 1
+}
+
+while getopts ":p:" opt; do
+    case $opt in
+        p)
+            plat=$OPTARG
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND -1))
+
+if [ $# -ne 0 ]; then
+   usage
+fi
+
+if [ ! -f ".top" ]; then
+    echo "This script must be run from the root of the foks repository."
+    exit 1
+fi
+
+arch_sffx=""
+case $plat in
+    arm64)
+        arch_sffx="aarch64"
+        ;;
+    amd64)
+        arch_sffx="x86_64"
+        ;;
+    *)
+        echo "Invalid platform: $plat"
+        usage
+        ;;
+esac
+
+(git diff --quiet && git diff --cached --quiet)
+if [ $? -ne 0 ]; then
+    echo "Working directory is dirty. Please commit or stash changes before building."
+    exit 1
+fi
+
+docker_plat=linux/${arch_sffx}
+if [ "$plat" != "arm64" ] && [ "$plat" != "amd64" ]; then
+    usage
+fi
+
+vversion=$(git tag --list | grep -E '^v[0-9]+\.' | sort -V | tail -1)
+version=$(echo $vversion | sed 's/^v//')
+
+if [ -z "$version" ]; then
+    echo "No version found. Please tag the commit with a version."
+    exit 1
+fi
+
+echo "Building foks version $version for ${docker_plat}"
+
+docker_tag=foks-rpm-${version}-${arch_sffx}
+
+workdir=build/rpm
+
+build_docker() {
+    docker build \
+        -f dockerfiles/rpm-pkg.dev \
+        --build-arg PLAT=${plat} \
+        --platform=${docker_plat} \
+        -t ${docker_tag} \
+        .
+}
+
+run_docker() {
+    docker run \
+        --rm \
+        --platform=${docker_plat} \
+        -v $(pwd)/build/rpm:/root/workspace \
+        ${docker_tag} \
+        -c "\
+        cd /root && \
+        cp workspace/*.tar.gz rpmbuild/SOURCES/ && \
+        cp workspace/*.spec rpmbuild/SPECS/ && \
+        rpmbuild -ba rpmbuild/SPECS/foks.spec && \
+        rpmbuild -bs rpmbuild/SPECS/foks.src.spec && \
+        cp rpmbuild/RPMS/*/*.rpm workspace && \
+        cp rpmbuild/SRPMS/*.rpm workspace"
+}
+
+make_tarball() {
+    tmp=$(mktemp -d)
+    git archive --format=tar.gz --output=${tmp}/x.tar.gz HEAD
+    (cd ${tmp} && \
+        mkdir foks-${version} &&  \
+        cd foks-${version} &&  \
+        tar -xzf ../x.tar.gz &&  \
+        cd .. && \
+        rm -f x.tar.gz && \
+        tar -czf foks-${version}.tar.gz foks-${version}
+    )
+    cp ${tmp}/foks-${version}.tar.gz ${workdir}/foks-${version}.tar.gz
+}
+
+make_spec() {
+    local is_src=$1
+    filename=foks.spec
+    if [ $is_src -eq 1 ]; then
+        filename=foks.src.spec
+    fi
+    path=build/rpm/${filename}
+    cat <<EOF > ${path}
+%define debugsource_package %{nil}
+%global _debugsource_template %{nil}
+Name: foks
+Version: ${version}
+Release: 1%{?dist}
+Summary: Access the Federated Open Key Service (FOKS) 
+
+License: MIT
+URL: https://github.com/foks-proj/go-foks
+Source0: %{name}-%{version}.tar.gz
+
+BuildRequires: pcsc-lite-devel
+EOF
+    if [ $is_src -eq 1 ]; then
+        cat <<EOF >> ${path}
+BuildRequires: golang >= 1.23
+EOF
+    fi
+    cat <<EOF >> ${path}
+Requires: pcsc-lite-devel
+
+%description
+FOKS is a federated protocol that allows for online public key advertisement,
+sharing, and rotation. It works for a user and their many devices, for many users who want
+to form a group, for groups of groups etc. The core primitive is that several
+private key holders can conveniently share a private key; and that private key
+can simply correspond to another public/private key pair, which can be members
+of a group one level up. This pattern can continue recursively forming a tree.
+
+Crucially, if any private key is removed from a key share, all shares rooted at
+that key must rotate. FOKS implements that rotation.
+
+Like email or the Web, the world consists of multiple FOKS servers, administrated
+independently and speaking the same protocol. Groups can span multiple federated
+services.
+
+Many applications can be built on top of this primitive but best suited are those
+that share encrypted, persistent information across groups of users with multiple
+devices. For instance, files and git hosting.
+
+%prep
+%autosetup # unpacks Source0 into %{_builddir}/%{name}-%{version}
+
+%build
+EOF
+    if [ $is_src -eq 0 ]; then
+        cat <<EOF >> ${path}
+export PATH=/usr/local/go/bin:\$PATH
+EOF
+    fi
+    cat <<EOF >> ${path}
+export GOPATH=\$(mktemp -d)
+mkdir -p \$GOPATH/src/github.com/foks-proj
+ln -sf %{_builddir}/%{name}-%{version} \$GOPATH/src/github.com/foks-proj/go-foks
+pushd \$GOPATH/src/github.com/foks-proj/go-foks/client/foks
+go build -o %{name}
+mv %{name} ../..
+popd
+
+%install
+mkdir -p %{buildroot}/%{_bindir}
+install -m 0755 %{name} %{buildroot}/%{_bindir}/%{name}
+pushd %{buildroot}/%{_bindir}
+ln -s %{name} git-remote-foks
+popd
+
+%files
+%{_bindir}/%{name}
+%{_bindir}/git-remote-foks
+
+%changelog
+EOF
+    go tool github.com/foks-proj/go-tools/changelog-linux-pkg rpm < changelog.yml >> ${path}
+
+}
+
+clean_house() {
+    mv build/rpm/*.rpm build/
+    rm -rf build/rpm
+}
+
+mkdir -p ${workdir}
+build_docker
+make_tarball
+make_spec 1
+make_spec 0
+run_docker
+clean_house


### PR DESCRIPTION
- use almalinux:8 so we get an old glibc depenency
- build separate source and binary specs, since we get an up-to-date golang, and building needs system golang
- tested on fedora42, seems to work
- changelog tool expanded for rpm (in addition to deb)