### PR TITLE
skm: clean out old keychain V1 material

### DIFF
--- a/proto-src/lcl/secret_key.snowp
+++ b/proto-src/lcl/secret_key.snowp
@@ -14,7 +14,6 @@ variant SecretKeyBundle switch (v : SecretKeyBundleVersion) @0x8456933bbb8a54ae 
 }
 
 enum SecretStoreVersion {
-    V1 @1;
     V2 @2;
 }
 
@@ -27,9 +26,10 @@ struct PassphraseEncryptedSecretKeyBundle {
 
 // The 32-byte key for this secretBox is stored in the OS keychain, under
 // server + account. The account is the base62-encoding of the fully-qualified
-// user (meaning user + hostname). Service for now is always going to be "foks"
+// user (meaning user + hostname). See lcl.SecretKeyKeychainLabelV2{}.StringErr().
+// Service for now is always going to be "foks"
 struct MacOSKeychainEncryptedSecretBundle {
-    account @0 : Text; // 2025.03.04 -- Deprecated, do not use
+    account @0 : Text;
     service @1 : Text;
     secretBox @2 : lib.SecretBox;
 }

--- a/proto/lcl/secret_key.go
+++ b/proto/lcl/secret_key.go
@@ -135,17 +135,14 @@ func (s *SecretKeyBundle) Bytes() []byte { return nil }
 type SecretStoreVersion int
 
 const (
-	SecretStoreVersion_V1 SecretStoreVersion = 1
 	SecretStoreVersion_V2 SecretStoreVersion = 2
 )
 
 var SecretStoreVersionMap = map[string]SecretStoreVersion{
-	"V1": 1,
 	"V2": 2,
 }
 
 var SecretStoreVersionRevMap = map[SecretStoreVersion]string{
-	1: "V1",
 	2: "V2",
 }
 


### PR DESCRIPTION
- remove some aged comments about not needing the Account field, which we do