### PR TITLE
teams: limit # of roles per team to 16

### DIFF
--- a/lib/core/constants.go
+++ b/lib/core/constants.go
@@ -7,3 +7,4 @@ var RpcMaxSz = int32(0x1000000)
 
 var InviteCodeBytes = 10
 var MultiUseInviteCodeBytes = 6
+var MaxRolesPerTeam = 16

--- a/lib/team/core.go
+++ b/lib/team/core.go
@@ -4,6 +4,8 @@
 package team
 
 import (
+	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/foks-proj/go-foks/lib/core"
@@ -43,9 +45,7 @@ type MemberSet map[MemberID]bool
 
 func (m MemberSet) Copy() MemberSet {
 	ret := make(MemberSet)
-	for k, v := range m {
-		ret[k] = v
-	}
+	maps.Copy(ret, m)
 	return ret
 }
 
@@ -522,6 +522,15 @@ func (d ChangeSet) Gameplan(
 	rPost = rPre.Clone().Apply(d)
 
 	sched, keysPost = rPre.planChangesLocked(d, keysPre, rPost, forcedNewKeyGens)
+
+	if len(keysPost) > core.MaxRolesPerTeam {
+		return nil, nil, nil, core.TeamRosterError(
+			fmt.Sprintf("too many roles in team (current max=%d)",
+				core.MaxRolesPerTeam,
+			),
+		)
+	}
+
 	return rPost, sched, keysPost, nil
 }
 


### PR DESCRIPTION
- there are degenerate cases where there are 64k or so role types, that would make for a very bad experience
- limit the # to 16 for now and if that proves insufficient, we can revisit this limitation
- addresses #34
- it's hard to test it, so no tests just yet
- another attempt at a fix might be to have this check kick in higher up the stack, so we have GlobalContexts etc to check against
- but then we have to worry about client and server having different values configured for the limit