### PR TITLE
team: change loader to reuse merkle query connection

### DIFF
--- a/client/libclient/config.go
+++ b/client/libclient/config.go
@@ -860,7 +860,7 @@ func (c *Config) AgentProcessLabel() (string, error) {
 		c.fl.agent.processLabel,
 		prefixed("AGENT_PROCESS_LABEL"),
 		c.file.Data.Agent.ProcessLabel,
-		"pub.ne43.foks.agent",
+		"com.ne43.foks.agent",
 	), nil
 }
 

--- a/client/libclient/team_loader.go
+++ b/client/libclient/team_loader.go
@@ -1844,9 +1844,7 @@ func (l *TeamLoader) resetState() {
 	l.linkHashes = nil
 }
 
-func (l *TeamLoader) Shutdown() {
-
-}
+func (l *TeamLoader) Shutdown() {}
 
 func (l *TeamLoader) Existing() *lcl.TeamChainState {
 	return l.existing

--- a/lib/merkle/agent.go
+++ b/lib/merkle/agent.go
@@ -110,10 +110,7 @@ func (a *Agent) HostID() proto.HostID {
 	return a.hostID
 }
 
-func (a *Agent) Shutdown() {
-	a.gcli.Shutdown()
-	a.gcli = nil
-}
+func (a *Agent) Shutdown() {}
 
 func (a *Agent) Reset() {
 	a.gcli.Reset()


### PR DESCRIPTION
- we were previously spam-creating xp-sever loops for merkle query
- now reuse them
- we might want to go back and check if we can do better about cleaning up merkle agents, but for now, make minimal changes
- merkle agent shutdown() becomes a noop
- change agent plist to "com.ne43.foks.agent.plist"
- close #41