### PR TITLE
user_loader: fix panic in some resolve username cases

### DIFF
--- a/integration-tests/lib/user_loader_test.go
+++ b/integration-tests/lib/user_loader_test.go
@@ -781,3 +781,19 @@ func TestUsernameLookup(t *testing.T) {
 	require.Nil(t, uid)
 	require.Equal(t, core.RowNotFoundError{}, err)
 }
+
+func TestReloadByUsername(t *testing.T) {
+	tew := testEnvBeta(t)
+	a := tew.NewTestUser(t)
+	b := tew.NewTestUser(t)
+	tew.DirectMerklePoke(t)
+
+	bcli := tew.userCli(t, b)
+	grantViewPermission(t, *bcli, b.uid, a.uid)
+	ma := tew.NewClientMetaContext(t, a)
+
+	for i := 0; i < 2; i++ {
+		_, err := libclient.LoadUser(ma, libclient.LoadUserArg{Username: b.name, LoadMode: libclient.LoadModeOthers})
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
- repro of the issue in user_loader_test
- close issue #52, we might not get usernames back from the server if we previously did previously
- implement resolution on a local host if permitted via local_view_permission, came up in testing
  - might actually break existing code paths, need to check carefully
