### PR TITLE
windows: home fixes; proto build fixes

### DIFF
--- a/make/client.mk
+++ b/make/client.mk
@@ -19,6 +19,11 @@ client-signed:
 client-proto: proto client
 full: client-proto
 
+.PHONY: client-win-amd64
+client-win-amd64:
+	./scripts/win-compile.bash -p amd64 -l
+	@echo "Client binary is ready: $$(scripts/gowhere.sh)/foks.exe"
+
 .PHONY: client-linux-arm64
 client-linux-arm64: build/foks.linux-arm64
 	@echo "Client binary for linux/arm64 is ready: $<"
@@ -101,8 +106,8 @@ release-all: deb rpm darwin-zip
 
 .PHONY: proto
 proto: 
-	(cd proto-src && go run ../tools/snowp-checker)
 	go generate ./...
+	(cd proto-src && go run ../tools/snowp-checker)
 
 build/foks.linux-arm64: proto
 	./scripts/cross-compile.sh -p linux-arm64
@@ -129,3 +134,7 @@ build/darwin-arm64/foks.zip: build/darwin-arm64/foks
 	./scripts/macos-sign.bash $<
 	./scripts/macos-ditto.bash $$(dirname $<)
 
+build/win-amd64/foks.exe: proto
+	./scripts/win-compile.bash -p amd64 -s
+build/win-arm64/foks.exe: proto
+	./scripts/win-compile.bash -p arm64 -s

--- a/proto/infra/gen.go
+++ b/proto/infra/gen.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 ne43, Inc.
 // Licensed under the MIT License. See LICENSE in the project root for details.
 
-//go:build !windows
-
 package infra
 
 //go:generate go tool github.com/foks-proj/go-snowpack-compiler/snowpc -l go -p infra -I ../../proto-src/infra -O . -v

--- a/proto/infra/gen_windows.go
+++ b/proto/infra/gen_windows.go
@@ -1,9 +1,0 @@
-// Copyright (c) 2025 ne43, Inc.
-// Licensed under the MIT License. See LICENSE in the project root for details.
-
-//go:build windows
-
-package infra
-
-//go:generate ..\..\node_modules\.bin\snowpc -l go -p infra -d ../../proto-src/infra -D .
-//go:generate go fmt .

--- a/proto/lcl/extras.go
+++ b/proto/lcl/extras.go
@@ -116,8 +116,14 @@ func (s StoredSecretKeyBundle) StripSecrets() (StoredSecretKeyBundle, error) {
 		pp := s.EncPassphrase()
 		pp.SecretBox = lib.SecretBox{}
 		return NewStoredSecretKeyBundleWithEncPassphrase(pp), nil
+	case lib.SecretKeyStorageType_ENC_KEYCHAIN:
+		kc := s.EncKeychain()
+		kc.SecretBox = lib.SecretBox{}
+		return NewStoredSecretKeyBundleWithEncKeychain(kc), nil
 	default:
-		return s, lib.DataError("bad type of secret key bundle")
+		return s, lib.DataError(
+			fmt.Sprintf("bad type of secret key bundle (%d)", t),
+		)
 	}
 }
 

--- a/proto/lcl/gen.go
+++ b/proto/lcl/gen.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 ne43, Inc.
 // Licensed under the MIT License. See LICENSE in the project root for details.
 
-//go:build !windows
-
 package lcl
 
 //go:generate go tool github.com/foks-proj/go-snowpack-compiler/snowpc -l go -p lcl -I ../../proto-src/lcl -O . -v

--- a/proto/lcl/gen_windows.go
+++ b/proto/lcl/gen_windows.go
@@ -1,9 +1,0 @@
-// Copyright (c) 2025 ne43, Inc.
-// Licensed under the MIT License. See LICENSE in the project root for details.
-
-//go:build windows
-
-package lcl
-
-//go:generate ..\..\node_modules\.bin\snowpc -l go -p lcl -d ../../proto-src/lcl -D .
-//go:generate go fmt .

--- a/proto/lib/gen.go
+++ b/proto/lib/gen.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 ne43, Inc.
 // Licensed under the MIT License. See LICENSE in the project root for details.
 
-//go:build !windows
-
 package lib
 
 //go:generate go tool github.com/foks-proj/go-snowpack-compiler/snowpc -l go -p lib -I ../../proto-src/lib -O . -v

--- a/proto/lib/gen_windows.go
+++ b/proto/lib/gen_windows.go
@@ -1,9 +1,0 @@
-// Copyright (c) 2025 ne43, Inc.
-// Licensed under the MIT License. See LICENSE in the project root for details.
-
-//go:build windows
-
-package lib
-
-//go:generate ..\..\node_modules\.bin\snowpc -l go -p lib -d ../../proto-src/lib -D .
-//go:generate go fmt .

--- a/proto/rem/gen.go
+++ b/proto/rem/gen.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2025 ne43, Inc.
 // Licensed under the MIT License. See LICENSE in the project root for details.
 
-//go:build !windows
-
 package rem
 
 //go:generate go tool github.com/foks-proj/go-snowpack-compiler/snowpc -l go -p rem -I ../../proto-src/rem -O . -v

--- a/proto/rem/gen_windows.go
+++ b/proto/rem/gen_windows.go
@@ -1,9 +1,0 @@
-// Copyright (c) 2025 ne43, Inc.
-// Licensed under the MIT License. See LICENSE in the project root for details.
-
-//go:build windows
-
-package rem
-
-//go:generate ..\..\node_modules\.bin\snowpc -l go -p rem -d ../../proto-src/rem -D .
-//go:generate go fmt .

--- a/scripts/win-compile.bash
+++ b/scripts/win-compile.bash
@@ -5,12 +5,12 @@ set -euo pipefail
 version=$(git describe --tags --always)
 
 usage() {
-    echo "Usage: $0 -p {arm64|amd64} [-sbl]"
+    echo "Usage: $0 -p {arm64|amd64} [-scl]"
     exit 1
 }
 
 strip=0
-brew=0
+choco=0
 lcl=0
 plat="arm64"
 packaging="darwin-zip"
@@ -18,7 +18,7 @@ packaging="darwin-zip"
 # take two arguments: -p which can be arm64 or amd64, and also
 # -s, which is a boolean flag that means to strip the binary
 # use getopt to parse the arguments::
-while getopts ":p:sbl" opt; do
+while getopts ":p:scl" opt; do
     case $opt in
         p)
             plat=$OPTARG
@@ -26,9 +26,9 @@ while getopts ":p:sbl" opt; do
         s)
             strip=1
             ;;
-        b) 
-            brew=1
-            packaging="brew"
+        c) 
+            choco=1
+            packaging="choco"
             ;;
         l)
             lcl=1
@@ -57,10 +57,10 @@ fi
 echo "Building darwin version $version"
 echo "  - platform: $plat"
 echo "  - stripping: $strip"
-echo "  - brew: $brew"
+echo "  - choco: $choco"
 echo "  - local: $lcl"
 
-targ="build/darwin-${plat}/foks"
+targ="build/win-${plat}/foks"
 mkdir -p $(dirname ${targ})
 
 src="./client/foks"
@@ -77,7 +77,7 @@ fi
 set -x
 
 export CGO_ENABLED=1
-export GOOS=darwin
+export GOOS=windows
 export GOARCH=${plat} 
 
 build_mode="build -o ${targ}"


### PR DESCRIPTION
- build windows protocol files as we do mac and linux, follow-on to upgrade to go tool
- dir for foks changed to %LocalAppData%\foks for everything, cache, hard-data, etc
  - see comment as to why we're not using the Go built-ins for this
- better ordering of proto check etc
- handle windows case for `skm info`
- windows compile scripts
- close #50
