### PR TITLE
cmd: fix bug in kvput for large objects and teams

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -12,6 +12,10 @@ changelog:
         closes : []
       - desc: Fix panic in `team add` from failing to load a user by username a second time
         closes: ["#52"]
+      - desc: Fix bug in kv-store big objects as a team
+        closes: ["#58"]
+      - desc: Clean up leaky debug in KV mkroot 
+        closes: ["#57"]
   - version: 0.0.19
     urgency: low
     stable: false

--- a/client/foks/cmd/kv.go
+++ b/client/foks/cmd/kv.go
@@ -534,6 +534,7 @@ func kvPutWithArgs(
 		},
 		func(id proto.FileID, data []byte, offset proto.Offset, final bool) error {
 			arg := lcl.ClientKVPutChunkArg{
+				Cfg:    cfg,
 				Id:     id,
 				Chunk:  data,
 				Offset: offset,

--- a/client/libkv/minder.go
+++ b/client/libkv/minder.go
@@ -869,7 +869,7 @@ func (k *Minder) mkRoot(
 		return nil, err
 	}
 
-	m.Infow("created new root dir", "fqp", ret.Id, "dir", *ret)
+	m.Infow("created new root dir", "id", ret.Id())
 
 	auth, cli, err := k.client(m, kvp)
 	if err != nil {


### PR DESCRIPTION
- not passing through the configuration resulted in falling back to per-user rather than per-team state
- close #58
- also close #57 -- clean up leaky debug statement
