### PR TITLE
cli: actually invert git-bash style path rewrites

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -6,6 +6,10 @@ changelog:
     urgency: low
     stable: false
     changes:
+      - desc: Actually try to rewrite the git-bash-mangled paths, rather than just warn; easy to backout if it's a flop
+        closes: ["#62"]
+      - desc: Online documentation for dealing with weird path translation in git bash
+        closes: ["#60"]
       - desc: Remove old version clash warning
         closes: ["#48"]
       - desc: Retire TypeScript-based snowpack compiler; move over to Go-based compiler

--- a/client/libclient/errors.go
+++ b/client/libclient/errors.go
@@ -6,9 +6,6 @@ package libclient
 import (
 	"errors"
 	"fmt"
-	"os"
-	"regexp"
-	"runtime"
 
 	"github.com/foks-proj/go-foks/lib/core"
 )
@@ -34,15 +31,7 @@ func ErrToStringCLI(e error) string {
 			)
 
 		case core.KVAbsPathError:
-			windowsAbsRxx := regexp.MustCompile(`^[a-zA-Z]:/`)
-			msys := map[string]bool{
-				"MSYS":    true,
-				"MINGW32": true,
-				"MINGW64": true,
-			}
-			if runtime.GOOS == "windows" &&
-				windowsAbsRxx.MatchString(te.Path.String()) &&
-				msys[os.Getenv("MSYSTEM")] {
+			if IsGitBashEnv() && IsWindowsDrivePath(te.Path) {
 				return "Need an absolute path unix-style path (e.g. /a/b/c) but got \"" +
 					te.Path.String() + "\"; note that Git Bash translates unix-style paths " +
 					"to absolute Windows-style paths, but you can use " +

--- a/client/libclient/gitbash.go
+++ b/client/libclient/gitbash.go
@@ -1,0 +1,70 @@
+package libclient
+
+import (
+	"os"
+	"runtime"
+	"strings"
+
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+func IsGitBashEnv() bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	msys := map[string]bool{
+		"MSYS":    true,
+		"MINGW32": true,
+		"MINGW64": true,
+	}
+	return msys[os.Getenv("MSYSTEM")]
+}
+
+func IsWindowsDrivePath(path proto.KVPath) bool {
+	if len(path) < 3 {
+		return false
+	}
+	if !(path[0] >= 'a' && path[0] <= 'z' || path[0] >= 'A' && path[0] <= 'Z') {
+		return false
+	}
+	if path[1] != ':' {
+		return false
+	}
+	if path[2] != '/' {
+		return false
+	}
+	return true
+}
+
+// GitBashAbsPathInvert tries to undo what git bash does to paths. If conditions
+// are not met, it returns the original path.
+func GitBashAbsPathInvert(path proto.KVPath) proto.KVPath {
+	if !IsGitBashEnv() {
+		return path
+	}
+	if !IsWindowsDrivePath(path) {
+		return path
+	}
+
+	// Will be of the form "C:\\Program Files\Git"
+	exePrfx :=
+		strings.ReplaceAll(
+			strings.ToLower(
+				os.Getenv("EXEPATH"),
+			),
+			"\\",
+			"/",
+		)
+	pathLower := strings.ToLower(string(path))
+
+	if strings.HasPrefix(pathLower, strings.ToLower(exePrfx)) {
+		return proto.KVPath(path.String()[len(exePrfx):])
+	}
+
+	// Do not attempt to convert paths of the form "a:/b/c" to back to "/a/b/c"
+	// since we are not certain the above check will always work. In this case,
+	// we'll likely get an error further downstream, but with documentation on
+	// how to change it.
+
+	return path
+}


### PR DESCRIPTION
- err on the side of caution and don't rewrite a:/b/c -> /a/b/c since we don't know if we got here only becuase our EXEPATH check didn't work
- this is slightly confusing as the user will have to `kv ls //a/b` but will not need to in the case of `kv ls /allo/eee` (since the second path component has >1 characters and the first has exactly one character)
- we might revisit this later
- close #62
