### PR TITLE
kv: better permission denied message mkdir("/")

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -6,6 +6,8 @@ changelog:
     urgency: low
     stable: false
     changes:
+      - desc: Better error message for confusing case; team admin or above needed to make KV root
+        closes: ["#67"]
       - desc: Actually try to rewrite the git-bash-mangled paths, rather than just warn; easy to backout if it's a flop
         closes: ["#62"]
       - desc: Online documentation for dealing with weird path translation in git bash

--- a/server/kv-store/root.go
+++ b/server/kv-store/root.go
@@ -69,7 +69,7 @@ func putRoot(
 	role proto.Role,
 	arg rem.KvPutRootArg,
 ) error {
-	err := assertAdmin(role)
+	err := assertAdmin(role, "creating KV root")
 	if err != nil {
 		return err
 	}

--- a/server/kv-store/server.go
+++ b/server/kv-store/server.go
@@ -5,6 +5,7 @@ package kvStore
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/foks-proj/go-foks/lib/core"
@@ -202,13 +203,15 @@ func assertAtOrAbove(r1 proto.Role, r2 proto.Role, op proto.KVOp, rsrc proto.KVN
 	return nil
 }
 
-func assertAdmin(role proto.Role) error {
+func assertAdmin(role proto.Role, what string) error {
 	ok, err := role.IsAdminOrAbove()
 	if err != nil {
 		return err
 	}
 	if !ok {
-		return core.AuthError{}
+		return core.PermissionError(
+			fmt.Sprintf("team admin permission needed for %s", what),
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
- only admin or above can make a root node on a KV store, for now
- maybe change this, but give a better error in this case
- Close #67
- There's another part of #67 we do not close
