### PR TITLE
choco: implement guidlines from review

### DIFF
--- a/scripts/choco-gen.bash
+++ b/scripts/choco-gen.bash
@@ -20,7 +20,7 @@ cat <<EOF >pkg/choco/foks.nuspec
     <owners>Maxwell Krohn</owners>
     <title>foks (Install)</title>
     <authors>Maxwell Krohn</authors>
-    <projectUrl>https://github.com/foks-proj/go-foks</projectUrl>
+    <projectUrl>https://foks.pub</projectUrl>
     <iconUrl>https://foks.pub/img/foks.png</iconUrl>
     <copyright>2025 ne43, Inc.</copyright>
     <licenseUrl>https://github.com/foks-proj/go-foks/blob/main/LICENSE</licenseUrl>
@@ -48,6 +48,7 @@ Many applications can be built on top of this primitive but best suited are thos
 that share end-to-end encrypted, persistent information across groups of users with multiple
 devices. For instance, files and git hosting.
     </description>
+    <releaseNotes>https://github.com/foks-proj/go-foks/releases</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
- from the review:
	- Guidelines are strong suggestions that improve the quality of a package version. These are considered something to fix for next time to increase the quality of the package. Over time Guidelines can become Requirements. A package version can be approved without addressing Guideline comments but will reduce the quality of the package.
		- ProjectUrl and ProjectSourceUrl are typically different, but not always. Please ensure that projectSourceUrl is pointing to software source code or remove the field from the nuspec.
		- Release Notes (releaseNotes) are a short description of changes in each version of a package. Please include releasenotes in the nuspec. NOTE: To prevent the need to continually update this field, providing a URL to an external list of Release Notes is perfectly acceptable.
- what we did:
	- change ProjectUrl to point to https://foks.pub
	- Change Release notes to point to GH release notes
