### PR TITLE
srv: columns for viewer role in local_view_permissions

### DIFF
--- a/client/libclient/team_minder_edit.go
+++ b/client/libclient/team_minder_edit.go
@@ -654,7 +654,7 @@ func (t *TeamEditor) prepareAllRemovals(m MetaContext) error {
 	return nil
 }
 
-func (t *TeamEditor) boxRmvt(
+func (t *TeamEditor) boxOneRemoteMemberViewToken(
 	m MetaContext,
 	rtp RemoteTokenPackage,
 	ptk core.SharedPrivateSuiter,
@@ -681,7 +681,7 @@ func (t *TeamEditor) boxRmvt(
 	return nil
 }
 
-func (t *TeamEditor) boxRemoteMemberViewTokens(m MetaContext) error {
+func (t *TeamEditor) boxAllRemoteMemberViewTokens(m MetaContext) error {
 	if len(t.rtps) == 0 {
 		return nil
 	}
@@ -690,7 +690,7 @@ func (t *TeamEditor) boxRemoteMemberViewTokens(m MetaContext) error {
 		return core.KeyNotFoundError{Which: "PTK"}
 	}
 	for _, rtp := range t.rtps {
-		err := t.boxRmvt(m, rtp, ptk)
+		err := t.boxOneRemoteMemberViewToken(m, rtp, ptk)
 		if err != nil {
 			return err
 		}
@@ -820,7 +820,7 @@ func (t *TeamEditor) Run(m MetaContext) error {
 		return err
 	}
 
-	err = t.boxRemoteMemberViewTokens(m)
+	err = t.boxAllRemoteMemberViewTokens(m)
 	if err != nil {
 		return err
 	}

--- a/integration-tests/lib/user_loader_evil_test.go
+++ b/integration-tests/lib/user_loader_evil_test.go
@@ -146,7 +146,15 @@ func newEvilServerTestHarness(
 	uid proto.UID,
 	loggedInUID *proto.UID,
 ) *evilServerTestHarness {
-	srv := shared.NewUserLoader(loggedInUID)
+	var role *proto.Role
+
+	// for now, assume that all user devices are at owner level
+	if loggedInUID != nil {
+		tmp := proto.OwnerRole
+		role = &tmp
+	}
+
+	srv := shared.NewUserLoader(loggedInUID, role)
 	var loadMode libclient.LoadMode
 	if loggedInUID != nil && uid.Eq(*loggedInUID) {
 		loadMode = libclient.LoadModeSelf

--- a/lib/core/role.go
+++ b/lib/core/role.go
@@ -195,3 +195,5 @@ func (k LocalUserIndex) Export() proto.LocalUserIndex {
 		},
 	}
 }
+
+var TemporaryDefaultViewerRole = proto.AdminRole

--- a/lib/team/chain.go
+++ b/lib/team/chain.go
@@ -231,7 +231,7 @@ func OpenTeamLink(
 
 	var tnc *proto.Commitment
 	var rng *core.RationalRange
-	// Open link metadata -- only team name changes are supported now.
+	// Open link metadata -- only team name changes are supported now, and team index range changes are supported.
 	for _, md := range gc.Metadata {
 		typ, err := md.GetT()
 		if err != nil {

--- a/proto-src/rem/user.snowp
+++ b/proto-src/rem/user.snowp
@@ -71,6 +71,11 @@ struct GrantLocalViewPermissionPayload @0xf620e4a9845fa063 {
     viewee @0 : lib.PartyID;
     viewer @1 : lib.PartyID;
     tm @2 : lib.Time;
+
+    // The min role the member has to have in the viewer to use the permission.
+    // Was NULL prior to v0.0.20; for NULL, assume default value of ADMIN, since that's
+    // the behavior, essentially, pre-v0.0.20.
+    viewerRole @3 : Option(lib.Role); 
 }
 
 struct ChangedUsernameFullUpdateArg {

--- a/proto/rem/user.go
+++ b/proto/rem/user.go
@@ -797,15 +797,17 @@ func (s *SetPassphraseAnnex) Decode(dec rpc.Decoder) error {
 func (s *SetPassphraseAnnex) Bytes() []byte { return nil }
 
 type GrantLocalViewPermissionPayload struct {
-	Viewee lib.PartyID
-	Viewer lib.PartyID
-	Tm     lib.Time
+	Viewee     lib.PartyID
+	Viewer     lib.PartyID
+	Tm         lib.Time
+	ViewerRole *lib.Role
 }
 type GrantLocalViewPermissionPayloadInternal__ struct {
-	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
-	Viewee  *lib.PartyIDInternal__
-	Viewer  *lib.PartyIDInternal__
-	Tm      *lib.TimeInternal__
+	_struct    struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Viewee     *lib.PartyIDInternal__
+	Viewer     *lib.PartyIDInternal__
+	Tm         *lib.TimeInternal__
+	ViewerRole *lib.RoleInternal__
 }
 
 func (g GrantLocalViewPermissionPayloadInternal__) Import() GrantLocalViewPermissionPayload {
@@ -828,6 +830,18 @@ func (g GrantLocalViewPermissionPayloadInternal__) Import() GrantLocalViewPermis
 			}
 			return x.Import()
 		})(g.Tm),
+		ViewerRole: (func(x *lib.RoleInternal__) *lib.Role {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *lib.RoleInternal__) (ret lib.Role) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(g.ViewerRole),
 	}
 }
 func (g GrantLocalViewPermissionPayload) Export() *GrantLocalViewPermissionPayloadInternal__ {
@@ -835,6 +849,12 @@ func (g GrantLocalViewPermissionPayload) Export() *GrantLocalViewPermissionPaylo
 		Viewee: g.Viewee.Export(),
 		Viewer: g.Viewer.Export(),
 		Tm:     g.Tm.Export(),
+		ViewerRole: (func(x *lib.Role) *lib.RoleInternal__ {
+			if x == nil {
+				return nil
+			}
+			return (*x).Export()
+		})(g.ViewerRole),
 	}
 }
 func (g *GrantLocalViewPermissionPayload) Encode(enc rpc.Encoder) error {

--- a/server/engine/reg.go
+++ b/server/engine/reg.go
@@ -1101,7 +1101,7 @@ func (c *RegClientConn) CheckNameExists(ctx context.Context, arg proto.Name) err
 
 func (c *RegClientConn) LoadUserChain(ctx context.Context, arg rem.LoadUserChainArg) (rem.UserChain, error) {
 	m := shared.NewMetaContextConn(ctx, c)
-	return shared.LoadUserChain(m, nil, arg)
+	return shared.LoadUserChain(m, nil, nil, arg)
 }
 
 func (c *RegClientConn) ErrorWrapper() func(error) proto.Status {

--- a/server/engine/user.go
+++ b/server/engine/user.go
@@ -723,7 +723,7 @@ func (c *UserClientConn) TestQueueService(ctx context.Context, arg infra.TestQue
 
 func (c *UserClientConn) LoadUserChain(ctx context.Context, arg rem.LoadUserChainArg) (rem.UserChain, error) {
 	m := shared.NewMetaContextConn(ctx, c)
-	return shared.LoadUserChain(m, m.UIDp(), arg)
+	return shared.LoadUserChain(m, m.UIDp(), m.Rolep(), arg)
 }
 
 func (c *UserClientConn) ResolveUsername(ctx context.Context, arg rem.ResolveUsernameArg) (proto.UID, error) {

--- a/server/foks-tool/init_db.go
+++ b/server/foks-tool/init_db.go
@@ -5,11 +5,9 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/foks-proj/go-foks/lib/core"
-	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/server/shared"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
@@ -100,36 +98,11 @@ func (i *InitDB) runDrop(m shared.MetaContext) error {
 }
 
 func allShards(m shared.MetaContext) ([]shared.KVShardDescriptor, error) {
-	shcfg, err := m.G().Config().KVShardsConfig(m.Ctx())
-	if err != nil {
-		return nil, err
-	}
-	all := shcfg.All()
-	var ret []shared.KVShardDescriptor
-	for _, shard := range all {
-		ret = append(ret, shared.KVShardDescriptor{
-			Index:  shard.Id(),
-			Active: shard.IsActive(),
-			Name:   shard.Name(),
-		})
-	}
-	return ret, nil
+	return shared.AllShards(m)
 }
 
 func someShards(m shared.MetaContext, indices []int) ([]shared.KVShardDescriptor, error) {
-	shcfg, err := m.G().Config().KVShardsConfig(m.Ctx())
-	if err != nil {
-		return nil, err
-	}
-	var ret []shared.KVShardDescriptor
-	for _, id := range indices {
-		shard := shcfg.Get(proto.KVShardID(id))
-		if shard == nil {
-			return nil, fmt.Errorf("no such shard: %d", id)
-		}
-		ret = append(ret, shared.MakeShardDescriptor(shard))
-	}
-	return ret, nil
+	return shared.SomeShards(m, indices)
 }
 
 func (i *InitDB) Run(m shared.MetaContext) error {

--- a/server/foks-tool/patch_db.go
+++ b/server/foks-tool/patch_db.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/server/shared"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+)
+
+type DbType struct {
+	shared.DbType
+}
+
+func (d *DbType) Set(s string) error {
+	tmp, err := shared.ParseDbType(s)
+	if err != nil {
+		return err
+	}
+	d.DbType = tmp
+	return nil
+}
+
+func (d *DbType) String() string {
+	return d.ToString()
+}
+
+func (d *DbType) Type() string {
+	return "DbType"
+}
+
+type PatchDB struct {
+	CLIAppBase
+	db     DbType
+	eng    *shared.PatchDBEng
+	shards []int
+}
+
+func (p *PatchDB) CobraConfig() *cobra.Command {
+	ret := &cobra.Command{
+		Use:   "patch-db",
+		Short: "Apply patches to the FOKS database",
+	}
+	ret.Flags().Var(&p.db, "db", "database to patch")
+	ret.Flags().IntSliceVar(&p.shards, "shard", nil, "shard(s) to patch")
+	return ret
+}
+
+func (p *PatchDB) CheckArgs(args []string) error {
+	if len(args) != 0 {
+		return core.BadArgsError("no args allowed")
+	}
+	if p.db.DbType == shared.DbTypeNone {
+		return core.BadArgsError("must specify a database to patch with --db")
+	}
+	if len(p.shards) > 0 && p.db.DbType != shared.DbTypeKVStore {
+		return core.BadArgsError("shards can only be specified for KV shards")
+	}
+	p.eng = &shared.PatchDBEng{
+		Which:       p.db.DbType,
+		Shards:      p.shards,
+		ConfirmHook: p.Confirm,
+	}
+	return nil
+}
+
+func (p *PatchDB) Confirm(m shared.MetaContext, ps *shared.PatchSummary) error {
+	fmt.Printf("Patches are ready to go:\n\n")
+
+	for _, patch := range ps.Desc() {
+		fmt.Printf(" - %s\n", patch)
+	}
+	fmt.Println("")
+	prompt := promptui.Select{
+		Label: "Confirm patch application",
+		Items: []string{"NO", "Yes, I'm sure"},
+	}
+
+	sel, _, err := prompt.Run()
+
+	if err != nil {
+		return err
+	}
+
+	if sel != 1 {
+		return errors.New("patch application aborted by user")
+	}
+	return nil
+}
+
+func (p *PatchDB) Run(m shared.MetaContext) error {
+	return p.eng.Run(m)
+}
+
+func (p *PatchDB) SetGlobalContext(g *shared.GlobalContext) {}
+
+var _ shared.CLIApp = (*PatchDB)(nil)
+
+func init() {
+	AddCmd(&PatchDB{})
+}

--- a/server/shared/patch.go
+++ b/server/shared/patch.go
@@ -1,0 +1,327 @@
+package shared
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/server/sql"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type patch struct {
+	id  int
+	sql string
+}
+
+type patchSingleDB struct {
+	which   DbType
+	conn    *pgxpool.Conn
+	applied map[int]bool // map of applied patch IDs
+	needed  []patch      // patches that need to be applied
+	shdesc  *KVShardDescriptor
+}
+
+func (p *patchSingleDB) cleanup() {
+	if p.conn != nil {
+		p.conn.Release()
+		p.conn = nil
+	}
+}
+
+type PatchDBEng struct {
+	Which       DbType
+	Shards      []int
+	shards      []KVShardDescriptor
+	dbs         []*patchSingleDB
+	ConfirmHook func(m MetaContext, ps *PatchSummary) error
+}
+
+func (p *PatchDBEng) loadShards(m MetaContext) error {
+	if p.Which != DbTypeKVStore {
+		return nil
+	}
+	if len(p.Shards) == 0 {
+		shards, err := AllShards(m)
+		if err != nil {
+			return err
+		}
+		p.shards = shards
+		return nil
+	}
+	shards, err := SomeShards(m, p.Shards)
+	if err != nil {
+		return err
+	}
+	p.shards = shards
+	return nil
+}
+
+func (p *PatchDBEng) getDBs(m MetaContext) error {
+
+	if p.Which != DbTypeKVStore {
+		db, err := m.Db(p.Which)
+		if err != nil {
+			return err
+		}
+		p.dbs = []*patchSingleDB{{which: p.Which, conn: db}}
+	} else {
+		for _, shard := range p.shards {
+			db, err := m.KVShardByID(shard.Index)
+			if err != nil {
+				return err
+			}
+			p.dbs = append(p.dbs,
+				&patchSingleDB{
+					which:  p.Which,
+					conn:   db,
+					shdesc: &shard,
+				})
+		}
+	}
+	return nil
+}
+
+func (p *PatchDBEng) cleanup() {
+	for _, db := range p.dbs {
+		db.cleanup()
+	}
+	p.dbs = nil
+	p.shards = nil
+}
+
+func (p *patchSingleDB) makeSchemaPatchesTable(m MetaContext) error {
+	// Create the schema_patches table if it doesn't exist
+	_, err := p.conn.Exec(
+		m.Ctx(),
+		`CREATE TABLE IF NOT EXISTS schema_patches (
+			id INT PRIMARY KEY,
+			ctime TIMESTAMP NOT NULL
+		)`,
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *patchSingleDB) loadCurrentPatchState(m MetaContext) error {
+	rows, err := p.conn.Query(
+		m.Ctx(),
+		"SELECT id FROM schema_patches",
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	p.applied = make(map[int]bool)
+	for rows.Next() {
+		var id int
+		err = rows.Scan(&id)
+		if err != nil {
+			return err
+		}
+		p.applied[id] = true
+	}
+	return nil
+}
+
+type PatchSummary struct {
+	totPatches int
+	descs      []string
+}
+
+func (p *PatchSummary) Desc() []string {
+	return p.descs
+}
+
+func (ps *PatchSummary) addPatches(n int, desc string) {
+	if n == 0 {
+		return
+	}
+	ps.totPatches += n
+	ps.descs = append(ps.descs, desc)
+}
+
+func (p *patchSingleDB) prepare(m MetaContext, ps *PatchSummary) error {
+	err := p.makeSchemaPatchesTable(m)
+	if err != nil {
+		return err
+	}
+	err = p.loadCurrentPatchState(m)
+	if err != nil {
+		return err
+	}
+	all := sql.Patches[p.which.ToString()]
+	for id, sql := range all {
+		if _, ok := p.applied[id]; ok {
+			continue // already applied
+		}
+		p.needed = append(p.needed, patch{id: id, sql: sql})
+	}
+
+	// Sort the patches by ID, lowest ID first
+	slices.SortFunc(p.needed, func(a, b patch) int {
+		return (a.id - b.id)
+	})
+
+	ps.addPatches(len(p.needed), p.String())
+	return nil
+}
+
+func (p *patchSingleDB) String() string {
+	if len(p.needed) == 0 {
+		return ""
+	}
+	var patches []string
+	for _, patch := range p.needed {
+		patches = append(patches, fmt.Sprintf("p%d", patch.id))
+	}
+	parts := []string{p.which.ToString()}
+	if p.shdesc != nil {
+		parts = append(parts, fmt.Sprintf("(shard %d)", p.shdesc.Index))
+	}
+	parts = append(parts, ": ")
+	parts = append(parts, strings.Join(patches, ", "))
+
+	return strings.Join(parts, "")
+}
+
+func (p *patchSingleDB) w() []any {
+	var ret []any
+	ret = append(ret, "db", p.which.ToString())
+	if p.shdesc != nil {
+		ret = append(ret, "shard-name", p.shdesc.Name,
+			"shard-index", p.shdesc.Index)
+	}
+	ret = append(ret, "numPatches", len(p.needed))
+	return ret
+}
+
+func trunc(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\n", " ")
+	n := 35
+	if len(s) > n {
+		return s[:n] + "..."
+	}
+	return s
+}
+
+func (p *patchSingleDB) doSinglePatch(m MetaContext, patch patch) (err error) {
+	m = m.WithLogTag("ptch")
+	m.Infow("applying patch", "id", patch.id, "sql", trunc(patch.sql))
+
+	var tx pgx.Tx
+	tx, err = p.conn.Begin(m.Ctx())
+	if err != nil {
+		return err
+	}
+
+	stmnts := SplitSQLStatements(patch.sql)
+	for _, stmnt := range stmnts {
+
+		if strings.TrimSpace(stmnt) == "" {
+			continue // skip empty statements
+		}
+
+		m.Infow("executing statement", "stmt", trunc(stmnt))
+
+		_, err = tx.Exec(m.Ctx(), stmnt)
+		if err != nil {
+			m.Errorw("patch failed", "id", patch.id, "stmt", trunc(stmnt), "error", err)
+			return err
+		}
+	}
+
+	// insert the patch into the schema_patches table
+	var tag pgconn.CommandTag
+	tag, err = tx.Exec(
+		m.Ctx(),
+		"INSERT INTO schema_patches (id, ctime) VALUES ($1, NOW())",
+		patch.id,
+	)
+	if err != nil {
+		m.Errorw("failed to insert patch record", "id", patch.id, "error", err)
+		return err
+	}
+
+	if tag.RowsAffected() != 1 {
+		m.Errorw("failed to insert patch record", "id", patch.id, "rowsAffected", tag.RowsAffected())
+		return core.InsertError("failed to insert patch record")
+	}
+
+	defer func() {
+		if err != nil {
+			rberr := tx.Rollback(m.Ctx())
+			if rberr != nil {
+				m.Errorw("rollback failed", "error", rberr)
+			}
+			m.Errorw("patch failed", "id", patch.id, "error", err)
+			return
+		}
+		err = tx.Commit(m.Ctx())
+		if err != nil {
+			m.Errorw("commit failed", "id", patch.id, "error", err)
+		}
+		m.Infow("patch commited", "id", patch.id)
+	}()
+
+	return nil
+
+}
+
+func (p *patchSingleDB) doAllPatches(m MetaContext) error {
+	for _, patch := range p.needed {
+		err := p.doSinglePatch(m, patch)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *PatchDBEng) Run(m MetaContext) error {
+	err := p.loadShards(m)
+	if err != nil {
+		return err
+	}
+	err = p.getDBs(m)
+	if err != nil {
+		return err
+	}
+	defer p.cleanup()
+
+	var ps PatchSummary
+	for _, db := range p.dbs {
+		err = db.prepare(m, &ps)
+		if err != nil {
+			return err
+		}
+	}
+
+	if ps.totPatches == 0 {
+		return core.NotFoundError("no patches to apply")
+	}
+
+	err = p.ConfirmHook(m, &ps)
+	if err != nil {
+		return err
+	}
+
+	for _, db := range p.dbs {
+		whch := db.w()
+		m := m.WithLogTag("db")
+		m.Infow("patching DB", whch...)
+		err := db.doAllPatches(m)
+		if err != nil {
+			return err
+		}
+		m.Infow("DB patched", whch...)
+	}
+
+	return nil
+}

--- a/server/shared/team.go
+++ b/server/shared/team.go
@@ -1540,7 +1540,12 @@ func acceptInviteLocal(
 	if !certPayload.Team.Host.Eq(m.HostID().Id) {
 		return nil, core.HostMismatchError{}
 	}
-	tok, err := InsertLocalViewPermission(m, tx, certPayload.Team.Team.ToPartyID(), viewee)
+
+	// For now, default to admin as to the role in the team that can load the owner (which is all admins
+	// and above).
+	viewerPermRole := core.TemporaryDefaultViewerRole
+
+	tok, err := InsertLocalViewPermission(m, tx, certPayload.Team.Team.ToPartyID(), viewerPermRole, viewee)
 	if err != nil {
 		return nil, err
 	}

--- a/server/shared/team_bearer_token.go
+++ b/server/shared/team_bearer_token.go
@@ -339,7 +339,7 @@ func CheckTeamVOBearerToken(
 		 JOIN team_members 
 		 USING (short_host_id, team_id, member_id, member_host_id, 
 			 src_role_type, src_viz_level, seqno)
-		 WHERE short_host_id=$1 AND token=$2`,
+		 WHERE short_host_id=$1 AND token=$2 AND T.state='active'`,
 		m.ShortHostID().ExportToDB(),
 		tok.ExportToDB(),
 	).Scan(&rawTeam, &active, &tm, &dstRoleType, &dstVizLevel, &g, &rawMember, &rawMemberHost,

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -33,3 +33,12 @@ var SQL = map[string]string{
 	"foks_beacon":        foksBeacon,
 	"foks_kv_store":      foksKVStore,
 }
+
+//go:embed patches/foks_users/p1.sql
+var foksUsersPatch1 string
+
+var Patches = map[string]map[int]string{
+	"foks_users": {
+		1: foksUsersPatch1,
+	},
+}

--- a/server/sql/foks_users.sql
+++ b/server/sql/foks_users.sql
@@ -566,6 +566,8 @@ CREATE TABLE local_view_permissions (
     token BYTEA NOT NULL, /* random 32-byte ID */
     ctime TIMESTAMP NOT NULL,
     mtime TIMESTAMP NOT NULL,
+    viewer_role_type SMALLINT NOT NULL, /* defaults to 2 (admin) prior to patch 1; viewers in the party at above this role can view*/
+    viewer_viz_level SMALLINT NOT NULL, /* defaults to 0 prior to patch 1 */
     PRIMARY KEY(short_host_id, target_eid, viewer_eid)
 );
 CREATE UNIQUE INDEX local_view_permissions_token_idx ON local_view_permissions(short_host_id, token);
@@ -900,3 +902,27 @@ CREATE TABLE yubi_mgmt_keys (
     mtime TIMESTAMP NOT NULL,
     PRIMARY KEY(short_host_id, uid, key_id)
 );
+
+CREATE TABLE team_member_load_floor (
+    short_host_id SMALLINT NOT NULL,
+    team_id BYTEA NOT NULL,
+
+    seqno INTEGER NOT NULL,
+
+    -- If alice is in the team, she can use the team to load other members if she is in the team 
+    -- at or above the role just below:
+    role_type SMALLINT NOT NULL,
+    viz_level SMALLINT NOT NULL,
+
+    ctime TIMESTAMP NOT NULL,
+
+    PRIMARY KEY (short_host_id, team_id, seqno),
+    FOREIGN KEY (short_host_id, team_id) REFERENCES teams(short_host_id, team_id)
+);
+
+CREATE TABLE schema_patches (
+    id INTEGER NOT NULL PRIMARY KEY,
+    ctime TIMESTAMP NOT NULL
+);
+
+INSERT INTO schema_patches (id, ctime) VALUES (1, NOW());

--- a/server/sql/patches/foks_users/p1.sql
+++ b/server/sql/patches/foks_users/p1.sql
@@ -1,0 +1,25 @@
+
+CREATE TABLE team_member_load_floor (
+    short_host_id SMALLINT NOT NULL,
+    team_id BYTEA NOT NULL,
+
+    seqno INTEGER NOT NULL,
+
+    -- If alice is in the team, she can use the team to load other members if she is at 
+    -- a target role at or above the member_load_floor.
+    role_type SMALLINT NOT NULL,
+    viz_level SMALLINT NOT NULL,
+
+    ctime TIMESTAMP NOT NULL,
+
+    PRIMARY KEY (short_host_id, team_id, seqno),
+    FOREIGN KEY (short_host_id, team_id) REFERENCES teams(short_host_id, team_id)
+);
+
+
+/*
+ * Also here is a multi-line comment
+ * to test our stripper.
+ */ 
+ALTER TABLE local_view_permissions ADD COLUMN viewer_role_type SMALLINT NOT NULL DEFAULT 2; -- 2 == "admin"
+ALTER TABLE local_view_permissions ADD COLUMN viewer_viz_level SMALLINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
- plumb through a temporary default role of Admin
- with special temporary role for the default viewRole
- plumb it through to team permission checks
- add a test to make sure we are catching permission failures
- no tests for non-owner user devices yet since we don't really have much infra yet for that
- DB patching system to patch the live system
- different default for open-viewership -- make it m/0
- working test to make sure team permission check of local_view_permission works too
