### PR TITLE
plumb Member Load Floor through team create and load

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -6,6 +6,8 @@ changelog:
     urgency: low
     stable: false
     changes:
+      - desc: Allow m/0's to load adjacent team members (previously it was only admins and above). This improves the output of `team ls` for non-admins
+        closes: ["#72"]
       - desc: Better error message for confusing case; team admin or above needed to make KV root
         closes: ["#67"]
       - desc: Actually try to rewrite the git-bash-mangled paths, rather than just warn; easy to backout if it's a flop

--- a/client/libclient/team_minder_edit.go
+++ b/client/libclient/team_minder_edit.go
@@ -668,12 +668,15 @@ func (t *TeamEditor) boxOneRemoteMemberViewToken(
 	if err != nil {
 		return err
 	}
+	mlf := t.tw.MemberLoadFloor()
+
 	rmvtk := proto.TeamRemoteMemberViewToken{
 		Team: t.id,
 		Inner: proto.TeamRemoteMemberViewTokenInner{
 			SecretBox: *sbox,
 			PtkGen:    ptk.Metadata().Gen,
 			Member:    rtp.Rmvtbp.Party,
+			PtkRole:   mlf,
 		},
 		Jrt: *jrt,
 	}
@@ -685,7 +688,13 @@ func (t *TeamEditor) boxAllRemoteMemberViewTokens(m MetaContext) error {
 	if len(t.rtps) == 0 {
 		return nil
 	}
-	ptk := t.tw.KeyRing().CurrentPrivateKeyAtRole(RemoteViewTokenEncryptionRole)
+	mlf := t.tw.MemberLoadFloor()
+	mlfRk, err := core.ImportRole(mlf)
+	if err != nil {
+		return err
+	}
+
+	ptk := t.tw.KeyRing().CurrentPrivateKeyAtRole(*mlfRk)
 	if ptk == nil {
 		return core.KeyNotFoundError{Which: "PTK"}
 	}

--- a/client/libclient/user_loader.go
+++ b/client/libclient/user_loader.go
@@ -516,7 +516,7 @@ func (u *UserLoader) loadUserFromServer(m MetaContext) error {
 	res, err := u.rpcLoader.LoadUserChain(m.Ctx(), arg)
 	if err != nil {
 		race := true
-		if core.IsAuthError(err) {
+		if core.IsAuthError(err) || core.IsPermissionError(err) {
 			race = false
 		}
 		return core.ChainLoaderError{

--- a/integration-tests/lib/open_view_test.go
+++ b/integration-tests/lib/open_view_test.go
@@ -15,13 +15,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func toFQParsedPartyAndRole(u *TestUser) lcl.FQPartyParsedAndRole {
+	return lcl.FQPartyParsedAndRole{
+		Fqp: proto.FQPartyParsed{
+			Party: proto.NewParsedPartyWithTrue(
+				proto.PartyName{
+					IsTeam: false,
+					Name:   u.name,
+				},
+			),
+		},
+	}
+}
+
 func TestOpenUserViewAndTeamAdd(t *testing.T) {
 	tew := testEnvBeta(t)
 
 	// #4 we'll reserve for making an "open vhost"
 	vHostID := tew.VHostMakeI(t, 4)
 	require.NotNil(t, vHostID)
-	tew.NewTestUserAtVHost(t, vHostID)
 	alice := tew.NewTestUserAtVHost(t, vHostID)
 	bob := tew.NewTestUserAtVHost(t, vHostID)
 	carole := tew.NewTestUserAtVHost(t, vHostID)
@@ -43,6 +55,12 @@ func TestOpenUserViewAndTeamAdd(t *testing.T) {
 
 	err = shared.VHostSetUserViewership(m, proto.ViewershipMode_OpenToAll)
 	require.NoError(t, err)
+
+	// don't forget to change it back so other tests don't fail
+	defer func() {
+		err = shared.VHostSetUserViewership(m, proto.ViewershipMode_Closed)
+		require.NoError(t, err)
+	}()
 	_, err = acli.LoadUserChain(m.Ctx(), arg)
 	require.NoError(t, err)
 
@@ -107,19 +125,6 @@ func TestOpenUserViewAndTeamAdd(t *testing.T) {
 
 	fqtp := tm.ToFQTeamParsed(t)
 
-	toFQParsedPartyAndRole := func(u *TestUser) lcl.FQPartyParsedAndRole {
-		return lcl.FQPartyParsedAndRole{
-			Fqp: proto.FQPartyParsed{
-				Party: proto.NewParsedPartyWithTrue(
-					proto.PartyName{
-						IsTeam: false,
-						Name:   u.name,
-					},
-				),
-			},
-		}
-	}
-
 	err = tMinder.Add(mc, lcl.TeamAddArg{
 		Team: *fqtp,
 		Members: []lcl.FQPartyParsedAndRole{
@@ -145,4 +150,101 @@ func TestOpenUserViewAndTeamAdd(t *testing.T) {
 	require.Equal(t, membs.Teams[0].Team.Name, tm.nm)
 	require.Equal(t, membs.Teams[0].SrcRole, proto.OwnerRole)
 	require.Equal(t, membs.Teams[0].DstRole, proto.DefaultRole)
+}
+
+func TestOpenViewTeamList(t *testing.T) {
+	tew := testEnvBeta(t)
+
+	// #4 we'll reserve for making an "open vhost"
+	vHostID := tew.VHostMakeI(t, 4)
+	require.NotNil(t, vHostID)
+	alice := tew.NewTestUserAtVHost(t, vHostID)
+	bob := tew.NewTestUserAtVHost(t, vHostID)
+	carole := tew.NewTestUserAtVHost(t, vHostID)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	m := tew.MetaContext()
+	m = m.WithHostID(&vHostID.HostID)
+	err := shared.VHostSetUserViewership(m, proto.ViewershipMode_OpenToAll)
+	require.NoError(t, err)
+
+	// don't forget to change it back so other tests don't fail
+	defer func() {
+		err := shared.VHostSetUserViewership(m, proto.ViewershipMode_Closed)
+		require.NoError(t, err)
+	}()
+
+	tm := tew.makeTeamForOwner(t, alice)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	mca := tew.NewClientMetaContext(t, alice)
+	tMinder, err := mca.TeamMinder()
+	require.NoError(t, err)
+
+	fqtp := tm.ToFQTeamParsed(t)
+
+	doAdd := func(user *TestUser, role proto.Role) {
+		err := tMinder.Add(mca, lcl.TeamAddArg{
+			Team: *fqtp,
+			Members: []lcl.FQPartyParsedAndRole{
+				toFQParsedPartyAndRole(user),
+			},
+			DstRole: &role,
+		})
+		require.NoError(t, err)
+		tew.DirectMerklePokeInTest(t)
+	}
+	doAdd(bob, proto.DefaultRole)
+	caroleRole := proto.NewRoleWithMember(-4)
+	doAdd(carole, caroleRole)
+
+	testLoadFor := func(user *TestUser) {
+		mc := tew.NewClientMetaContext(t, user)
+		twr, err := libclient.LoadTeam(mc, libclient.LoadTeamArg{
+			Team:        tm.FQTeam(t),
+			As:          user.FQUser().FQParty(),
+			SrcRole:     proto.OwnerRole,
+			Keys:        user.KeySeq(t, proto.OwnerRole),
+			LoadMembers: true,
+		},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, twr)
+
+		expected := map[proto.NameUtf8]struct {
+			role proto.Role
+			uid  proto.UID
+		}{
+			alice.name: {
+				role: proto.OwnerRole,
+				uid:  alice.uid,
+			},
+			bob.name: {
+				role: proto.DefaultRole,
+				uid:  bob.uid,
+			},
+			carole.name: {
+				role: caroleRole,
+				uid:  carole.uid,
+			},
+		}
+		x, err := twr.ExportToRoster()
+		require.NoError(t, err)
+		require.Equal(t, len(expected), len(x.Members))
+		for _, m := range x.Members {
+			require.Greater(t, len(m.Mem.Name), 0, "member name should not be empty")
+			e, ok := expected[m.Mem.Name]
+			require.True(t, ok, "unexpected member %s", m.Mem.Name)
+			require.Equal(t, e.role, m.DstRole)
+			require.True(t, m.Mem.Fqp.Party.IsUser())
+			uid, err := m.Mem.Fqp.Party.UID()
+			require.NoError(t, err)
+			require.Equal(t, e.uid, uid, "member %s has unexpected uid", m.Mem.Name)
+		}
+	}
+
+	testLoadFor(bob)
+	testLoadFor(alice)
+	testLoadFor(carole)
+
 }

--- a/integration-tests/lib/reg_test.go
+++ b/integration-tests/lib/reg_test.go
@@ -496,10 +496,21 @@ func NewTestUserWithUsername(un proto.NameUtf8) *TestUser {
 	}
 }
 
-func NewTestUser(t *testing.T) *TestUser {
-	un, err := RandomUsername(9)
+func NewTestUserWithPrefix(t *testing.T, prefix string) *TestUser {
+	baselen := 9
+	if len(prefix) > 0 {
+		baselen = 7
+	}
+	un, err := RandomUsername(baselen)
 	require.NoError(t, err)
+	if len(prefix) > 0 {
+		un = prefix + "_" + un
+	}
 	return NewTestUserWithUsername(proto.NameUtf8(un))
+}
+
+func NewTestUser(t *testing.T) *TestUser {
+	return NewTestUserWithPrefix(t, "")
 }
 
 func deviceKeyConstructor(role proto.Role, host proto.HostID) (core.PrivateSuiter, error) {
@@ -542,6 +553,7 @@ type TestUserOpts struct {
 	KeyConstructor func(role proto.Role, host proto.HostID) (core.PrivateSuiter, error)
 	InviteCode     *rem.InviteCode
 	HostID         *core.HostIDAndName
+	UsernamePrefix string
 }
 
 func (u *TestUser) SignupWithOpts(
@@ -757,7 +769,11 @@ func GenerateNewTestUser(t *testing.T) *TestUser {
 
 func GenerateNewTestUserWithRegCli(t *testing.T, te *common.TestEnv, cli *rem.RegClient, opts *TestUserOpts) *TestUser {
 	m := te.MetaContext()
-	testUser := NewTestUser(t)
+	var prfx string
+	if opts != nil && opts.UsernamePrefix != "" {
+		prfx = opts.UsernamePrefix
+	}
+	testUser := NewTestUserWithPrefix(t, prfx)
 	testUser.SignupWithRegCli(t, m, te, cli, opts)
 	return testUser
 }

--- a/integration-tests/lib/team_common_test.go
+++ b/integration-tests/lib/team_common_test.go
@@ -1171,15 +1171,23 @@ func runRemoteJoinSequence(
 		Tm:    proto.Now(),
 		Party: joinerParty,
 	}
-	skey := ptk.SecretBoxKey()
+
+	mlfRole := proto.DefaultMemberLoadFloor
+	mlfRoleKey, err := core.ImportRole(mlfRole)
+	require.NoError(t, err)
+
+	ptkM0 := tm.ptks[*mlfRoleKey]
+	require.NotNil(t, ptkM0)
+	skey := ptkM0.SecretBoxKey()
 	sbox, err := core.SealIntoSecretBox(&vtbp, &skey)
 	require.NoError(t, err)
 	trmvt := proto.TeamRemoteMemberViewToken{
 		Team: tm.FQTeam(t).Team,
 		Inner: proto.TeamRemoteMemberViewTokenInner{
 			Member:    joinerParty,
-			PtkGen:    ptk.Metadata().Gen,
+			PtkGen:    ptkM0.Metadata().Gen,
 			SecretBox: *sbox,
+			PtkRole:   mlfRole,
 		},
 		Jrt: jrtok,
 	}

--- a/integration-tests/lib/team_perms_test.go
+++ b/integration-tests/lib/team_perms_test.go
@@ -236,10 +236,10 @@ func TestTeamLoaderPermissions(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, core.NotFoundError("team vo bearer token"), err)
 
-	// Add boto to tm0 as a member/0. We're going to test that
+	// Add boto to tm0 as a member/-3. We're going to test that
 	// he can't load tm1 with tm0's view-only token, since his role
 	// in tm0 is not high enough.
-	mr := boto.toMemberRole(t, proto.DefaultRole, tm0.hepks)
+	mr := boto.toMemberRole(t, proto.NewRoleWithMember(-3), tm0.hepks)
 	tm0.makeChanges(
 		t,
 		m,

--- a/lib/core/codec_test.go
+++ b/lib/core/codec_test.go
@@ -1,0 +1,64 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/keybase/go-codec/codec"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that if you have am object Foo, and add a field to it, that new new encoders can
+// still decode the old object. And vice versa.
+func TestCodecForwardsCompatible(t *testing.T) {
+
+	type Obj1 struct {
+		_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+		F1      *int
+		F2      *string
+	}
+
+	type Obj2 struct {
+		_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+		F1      *int
+		F2      *string
+		F3      *int
+	}
+
+	i := 10
+	s := "yo"
+
+	o1 := Obj1{
+		F1: &i, F2: &s,
+	}
+
+	mh := Codec()
+	var buf []byte
+	enc := codec.NewEncoderBytes(&buf, mh)
+	err := enc.Encode(&o1)
+	require.NoError(t, err)
+
+	var o2 Obj2
+	dec := codec.NewDecoderBytes(buf, mh)
+	err = dec.Decode(&o2)
+	require.NoError(t, err)
+
+	require.Nil(t, o2.F3)
+	require.Equal(t, i, *o2.F1)
+	require.Equal(t, s, *o2.F2)
+
+	var buf2 []byte
+	i3 := 40
+	o2.F3 = &i3
+
+	enc = codec.NewEncoderBytes(&buf2, mh)
+	err = enc.Encode(&o2)
+	require.NoError(t, err)
+
+	var o3 Obj1
+	dec = codec.NewDecoderBytes(buf2, mh)
+	err = dec.Decode(&o3)
+	require.NoError(t, err)
+	require.Equal(t, i, *o3.F1)
+	require.Equal(t, s, *o3.F2)
+
+}

--- a/lib/core/role.go
+++ b/lib/core/role.go
@@ -195,5 +195,3 @@ func (k LocalUserIndex) Export() proto.LocalUserIndex {
 		},
 	}
 }
-
-var TemporaryDefaultViewerRole = proto.AdminRole

--- a/play/main.go
+++ b/play/main.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 
 	"github.com/go-piv/piv-go/v2/piv"
+	"github.com/keybase/go-codec/codec"
 )
 
 var pinOld = piv.DefaultPIN
@@ -197,8 +198,50 @@ func ff(doErr bool) (err error) {
 	return nil
 }
 
-func main() {
+func Main4() {
 	fmt.Printf("%v\n", ff(true))
 	fmt.Printf("%v\n", ff(false))
+}
+
+type Obj1 struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	F1      *int
+	F2      *string
+}
+
+type Obj2 struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	F1      *int
+	F2      *string
+	F3      *int
+}
+
+func main() {
+
+	i := 10
+	s := "yo"
+
+	o1 := &Obj1{
+		F1: &i,
+		F2: &s,
+	}
+	var mh codec.MsgpackHandle
+	mh.WriteExt = true
+	var buf []byte
+
+	enc := codec.NewEncoderBytes(&buf, &mh)
+	err := enc.Encode(o1)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", buf)
+
+	var o2 Obj2
+	dec := codec.NewDecoderBytes(buf, &mh)
+	err = dec.Decode(&o2)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("%+v\n", o2)
 
 }

--- a/proto-src/lcl/db.snowp
+++ b/proto-src/lcl/db.snowp
@@ -115,5 +115,6 @@ struct TeamChainState {
     hepks @11 : lib.HEPKSet;
     tir @12 : lib.RationalRange; // TeamIndexRange
     historicalSenders @13 : List(lib.SenderPair); // Senders we have used for unboxing in the past
+    memberLoadFloor @14 : Option(lib.Role); // Defaults to m/0 if not set.
 }
 

--- a/proto-src/lib/chains.snowp
+++ b/proto-src/lib/chains.snowp
@@ -189,6 +189,7 @@ enum ChangeType {
     Eldest @2;
     Teamname @3;
     TeamIndexRange @4;
+    MemberLoadFloor @5;
 }
 
 enum DeviceType {
@@ -224,6 +225,17 @@ variant ChangeMetadata switch (t : ChangeType) {
     case DeviceName, Username, Teamname @0 : Commitment;
     case Eldest @1 : EldestMetadata;
     case TeamIndexRange @2 : RationalRange;
+
+    // The minimal target role that a member has to be in the team
+    // before they can view other teams (as a function of being in the team).
+    // This field was introduced in v0.0.20. Prior to that, we assumed
+    // it was hard-coded in at AdminRole, but only a few teams were created
+    // with this behavior. Going forward, with v0.0.20 and onward,
+    // we assume a default value of m/0 role if this field is left out
+    // (for pre-v0.0.20 chains). Going forward, with v0.0.20 and onward,
+    // this field is required in eldest team links. In the future,
+    // but not now, we might allow this field to be updated.
+    case MemberLoadFloor @3 : Role;
 }
 
 variant LinkOuter switch (v : LinkVersion) @0xed4cc0f7081732b6 {

--- a/proto-src/lib/team.snowp
+++ b/proto-src/lib/team.snowp
@@ -55,6 +55,11 @@ struct TeamRemoteMemberViewTokenInner {
     member @0 : FQParty;
     ptkGen @1 : Generation; // The generation of the PTK it's encrypted for
     secretBox @2 : SecretBox; // The secret box of ViewTokenBoxPayload
+
+    // The PTK role it's encrypted for. Prior to v0.0.20, this value was
+    // missing, but was understood to be ADMIN. So a NONE value here
+    // is assumed to be ADMIN.
+    ptkRole @3 : Role; 
 }
 
 typedef TeamCertHash = StdHash;

--- a/proto-src/lib/user.snowp
+++ b/proto-src/lib/user.snowp
@@ -29,6 +29,7 @@ struct UserContext {
 struct RegServerConfig {
     sso @0 : Option(SSOConfig);
     typ @1 : HostType; 
+    view @2 : HostViewership;
 }
 
 typedef Email = Text;

--- a/proto-src/rem/team.snowp
+++ b/proto-src/rem/team.snowp
@@ -172,6 +172,8 @@ protocol TeamLoader errors lib.Status @0xf9128579 {
         tok @1 : TeamVOBearerToken,
         members @2 : List(lib.FQParty)
     ) -> TeamRemoteViewTokenSet;
+
+    getServerConfig @7 () : GetServerConfigTeamLoaderArg -> lib.RegServerConfig;
 }
 
 protocol TeamMember errors lib.Status @0xbda3b9d3 {

--- a/proto/lcl/db.go
+++ b/proto/lcl/db.go
@@ -1040,6 +1040,7 @@ type TeamChainState struct {
 	Hepks             lib.HEPKSet
 	Tir               lib.RationalRange
 	HistoricalSenders []lib.SenderPair
+	MemberLoadFloor   *lib.Role
 }
 type TeamChainStateInternal__ struct {
 	_struct           struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -1057,6 +1058,7 @@ type TeamChainStateInternal__ struct {
 	Hepks             *lib.HEPKSetInternal__
 	Tir               *lib.RationalRangeInternal__
 	HistoricalSenders *[](*lib.SenderPairInternal__)
+	MemberLoadFloor   *lib.RoleInternal__
 }
 
 func (t TeamChainStateInternal__) Import() TeamChainState {
@@ -1223,6 +1225,18 @@ func (t TeamChainStateInternal__) Import() TeamChainState {
 			}
 			return ret
 		})(t.HistoricalSenders),
+		MemberLoadFloor: (func(x *lib.RoleInternal__) *lib.Role {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *lib.RoleInternal__) (ret lib.Role) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(t.MemberLoadFloor),
 	}
 }
 func (t TeamChainState) Export() *TeamChainStateInternal__ {
@@ -1300,6 +1314,12 @@ func (t TeamChainState) Export() *TeamChainStateInternal__ {
 			}
 			return &ret
 		})(t.HistoricalSenders),
+		MemberLoadFloor: (func(x *lib.Role) *lib.RoleInternal__ {
+			if x == nil {
+				return nil
+			}
+			return (*x).Export()
+		})(t.MemberLoadFloor),
 	}
 }
 func (t *TeamChainState) Encode(enc rpc.Encoder) error {

--- a/proto/lib/chains.go
+++ b/proto/lib/chains.go
@@ -1798,19 +1798,21 @@ func (l *LinkOuterV1) Bytes() []byte { return nil }
 type ChangeType int
 
 const (
-	ChangeType_DeviceName     ChangeType = 0
-	ChangeType_Username       ChangeType = 1
-	ChangeType_Eldest         ChangeType = 2
-	ChangeType_Teamname       ChangeType = 3
-	ChangeType_TeamIndexRange ChangeType = 4
+	ChangeType_DeviceName      ChangeType = 0
+	ChangeType_Username        ChangeType = 1
+	ChangeType_Eldest          ChangeType = 2
+	ChangeType_Teamname        ChangeType = 3
+	ChangeType_TeamIndexRange  ChangeType = 4
+	ChangeType_MemberLoadFloor ChangeType = 5
 )
 
 var ChangeTypeMap = map[string]ChangeType{
-	"DeviceName":     0,
-	"Username":       1,
-	"Eldest":         2,
-	"Teamname":       3,
-	"TeamIndexRange": 4,
+	"DeviceName":      0,
+	"Username":        1,
+	"Eldest":          2,
+	"Teamname":        3,
+	"TeamIndexRange":  4,
+	"MemberLoadFloor": 5,
 }
 var ChangeTypeRevMap = map[ChangeType]string{
 	0: "DeviceName",
@@ -1818,6 +1820,7 @@ var ChangeTypeRevMap = map[ChangeType]string{
 	2: "Eldest",
 	3: "Teamname",
 	4: "TeamIndexRange",
+	5: "MemberLoadFloor",
 }
 
 type ChangeTypeInternal__ ChangeType
@@ -2072,6 +2075,7 @@ type ChangeMetadata struct {
 	F_0__ *Commitment     `json:"f0,omitempty"`
 	F_1__ *EldestMetadata `json:"f1,omitempty"`
 	F_2__ *RationalRange  `json:"f2,omitempty"`
+	F_3__ *Role           `json:"f3,omitempty"`
 }
 type ChangeMetadataInternal__ struct {
 	_struct  struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -2083,6 +2087,7 @@ type ChangeMetadataInternalSwitch__ struct {
 	F_0__   *CommitmentInternal__     `codec:"0"`
 	F_1__   *EldestMetadataInternal__ `codec:"1"`
 	F_2__   *RationalRangeInternal__  `codec:"2"`
+	F_3__   *RoleInternal__           `codec:"3"`
 }
 
 func (c ChangeMetadata) GetT() (ret ChangeType, err error) {
@@ -2098,6 +2103,10 @@ func (c ChangeMetadata) GetT() (ret ChangeType, err error) {
 	case ChangeType_TeamIndexRange:
 		if c.F_2__ == nil {
 			return ret, errors.New("unexpected nil case for F_2__")
+		}
+	case ChangeType_MemberLoadFloor:
+		if c.F_3__ == nil {
+			return ret, errors.New("unexpected nil case for F_3__")
 		}
 	}
 	return c.T, nil
@@ -2147,6 +2156,15 @@ func (c ChangeMetadata) Teamindexrange() RationalRange {
 	}
 	return *c.F_2__
 }
+func (c ChangeMetadata) Memberloadfloor() Role {
+	if c.F_3__ == nil {
+		panic("unexpected nil case; should have been checked")
+	}
+	if c.T != ChangeType_MemberLoadFloor {
+		panic(fmt.Sprintf("unexpected switch value (%v) when Memberloadfloor is called", c.T))
+	}
+	return *c.F_3__
+}
 func NewChangeMetadataWithDevicename(v Commitment) ChangeMetadata {
 	return ChangeMetadata{
 		T:     ChangeType_DeviceName,
@@ -2175,6 +2193,12 @@ func NewChangeMetadataWithTeamindexrange(v RationalRange) ChangeMetadata {
 	return ChangeMetadata{
 		T:     ChangeType_TeamIndexRange,
 		F_2__: &v,
+	}
+}
+func NewChangeMetadataWithMemberloadfloor(v Role) ChangeMetadata {
+	return ChangeMetadata{
+		T:     ChangeType_MemberLoadFloor,
+		F_3__: &v,
 	}
 }
 func (c ChangeMetadataInternal__) Import() ChangeMetadata {
@@ -2216,6 +2240,18 @@ func (c ChangeMetadataInternal__) Import() ChangeMetadata {
 			})(x)
 			return &tmp
 		})(c.Switch__.F_2__),
+		F_3__: (func(x *RoleInternal__) *Role {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *RoleInternal__) (ret Role) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(c.Switch__.F_3__),
 	}
 }
 func (c ChangeMetadata) Export() *ChangeMetadataInternal__ {
@@ -2240,6 +2276,12 @@ func (c ChangeMetadata) Export() *ChangeMetadataInternal__ {
 				}
 				return (*x).Export()
 			})(c.F_2__),
+			F_3__: (func(x *Role) *RoleInternal__ {
+				if x == nil {
+					return nil
+				}
+				return (*x).Export()
+			})(c.F_3__),
 		},
 	}
 }

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -1821,6 +1821,14 @@ var OwnerRole = NewRoleDefault(RoleType_OWNER)
 var AdminRole = NewRoleDefault(RoleType_ADMIN)
 var DefaultRole = NewRoleWithMember(VizLevel(0))
 var MinKVRole = NewRoleWithMember(VizLevelKvMin)
+var DefaultMemberLoadFloor = DefaultRole
+
+func (r *Role) WithDefaultMemberLoadFloor() Role {
+	if r == nil {
+		return DefaultMemberLoadFloor
+	}
+	return *r
+}
 
 func (d DeviceLabel) Eq(d2 DeviceLabel) bool {
 	return d.Name == d2.Name && d.Serial == d2.Serial
@@ -4770,4 +4778,17 @@ func (s SemVer) Cmp(s2 SemVer) int {
 
 func (s SemVer) String() string {
 	return fmt.Sprintf("%d.%d.%d", s.Major, s.Minor, s.Patch)
+}
+
+func (i TeamRemoteMemberViewTokenInner) GetPTKRole() (*Role, error) {
+	ret := i.PtkRole
+	typ, err := ret.GetT()
+	if err != nil {
+		return nil, err
+	}
+	if typ == RoleType_NONE {
+		ret := AdminRole
+		return &ret, nil
+	}
+	return &ret, nil
 }

--- a/proto/lib/team.go
+++ b/proto/lib/team.go
@@ -490,12 +490,14 @@ type TeamRemoteMemberViewTokenInner struct {
 	Member    FQParty
 	PtkGen    Generation
 	SecretBox SecretBox
+	PtkRole   Role
 }
 type TeamRemoteMemberViewTokenInnerInternal__ struct {
 	_struct   struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
 	Member    *FQPartyInternal__
 	PtkGen    *GenerationInternal__
 	SecretBox *SecretBoxInternal__
+	PtkRole   *RoleInternal__
 }
 
 func (t TeamRemoteMemberViewTokenInnerInternal__) Import() TeamRemoteMemberViewTokenInner {
@@ -518,6 +520,12 @@ func (t TeamRemoteMemberViewTokenInnerInternal__) Import() TeamRemoteMemberViewT
 			}
 			return x.Import()
 		})(t.SecretBox),
+		PtkRole: (func(x *RoleInternal__) (ret Role) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(t.PtkRole),
 	}
 }
 func (t TeamRemoteMemberViewTokenInner) Export() *TeamRemoteMemberViewTokenInnerInternal__ {
@@ -525,6 +533,7 @@ func (t TeamRemoteMemberViewTokenInner) Export() *TeamRemoteMemberViewTokenInner
 		Member:    t.Member.Export(),
 		PtkGen:    t.PtkGen.Export(),
 		SecretBox: t.SecretBox.Export(),
+		PtkRole:   t.PtkRole.Export(),
 	}
 }
 func (t *TeamRemoteMemberViewTokenInner) Encode(enc rpc.Encoder) error {

--- a/proto/lib/user.go
+++ b/proto/lib/user.go
@@ -269,13 +269,15 @@ func (u *UserContext) Decode(dec rpc.Decoder) error {
 func (u *UserContext) Bytes() []byte { return nil }
 
 type RegServerConfig struct {
-	Sso *SSOConfig
-	Typ HostType
+	Sso  *SSOConfig
+	Typ  HostType
+	View HostViewership
 }
 type RegServerConfigInternal__ struct {
 	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
 	Sso     *SSOConfigInternal__
 	Typ     *HostTypeInternal__
+	View    *HostViewershipInternal__
 }
 
 func (r RegServerConfigInternal__) Import() RegServerConfig {
@@ -298,6 +300,12 @@ func (r RegServerConfigInternal__) Import() RegServerConfig {
 			}
 			return x.Import()
 		})(r.Typ),
+		View: (func(x *HostViewershipInternal__) (ret HostViewership) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.View),
 	}
 }
 func (r RegServerConfig) Export() *RegServerConfigInternal__ {
@@ -308,7 +316,8 @@ func (r RegServerConfig) Export() *RegServerConfigInternal__ {
 			}
 			return (*x).Export()
 		})(r.Sso),
-		Typ: r.Typ.Export(),
+		Typ:  r.Typ.Export(),
+		View: r.View.Export(),
 	}
 }
 func (r *RegServerConfig) Encode(enc rpc.Encoder) error {

--- a/server/engine/reg.go
+++ b/server/engine/reg.go
@@ -1146,18 +1146,12 @@ func (c *RegClientConn) ResolveUsername(
 
 func (c *RegClientConn) GetServerConfig(ctx context.Context) (proto.RegServerConfig, error) {
 	m := shared.NewMetaContextConn(ctx, c)
-	var ret proto.RegServerConfig
-	ssoCfg, err := shared.LoadSSOConfig(m, nil)
+	ret, err := shared.GetServerConfig(m)
+	var zed proto.RegServerConfig
 	if err != nil {
-		return ret, err
+		return zed, err
 	}
-	ret.Sso = ssoCfg
-	cfg, err := m.G().HostIDMap().Config(m, m.ShortHostID())
-	if err != nil {
-		return ret, err
-	}
-	ret.Typ = cfg.Typ
-	return ret, nil
+	return *ret, nil
 }
 
 func (c *RegClientConn) InitOAuth2Session(ctx context.Context, arg rem.InitOAuth2SessionArg) (proto.URLString, error) {

--- a/server/engine/team_loader.go
+++ b/server/engine/team_loader.go
@@ -235,5 +235,20 @@ func (u *UserClientConn) LoadTeamRemoteViewTokens(
 	return shared.LoadTeamRemoteViewTokens(m, arg)
 }
 
+func (u *UserClientConn) GetServerConfig(
+	ctx context.Context,
+) (
+	proto.RegServerConfig,
+	error,
+) {
+	m := shared.NewMetaContextConn(ctx, u)
+	var zed proto.RegServerConfig
+	ret, err := shared.GetServerConfig(m)
+	if err != nil {
+		return zed, err
+	}
+	return *ret, nil
+}
+
 var _ rem.TeamLoaderInterface = (*UserClientConn)(nil)
 var _ rem.TeamLoaderInterface = (*RegClientConn)(nil)

--- a/server/shared/hostconfig.go
+++ b/server/shared/hostconfig.go
@@ -1,0 +1,26 @@
+package shared
+
+import (
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+func GetServerConfig(
+	m MetaContext,
+) (
+	*proto.RegServerConfig,
+	error,
+) {
+	ssoCfg, err := LoadSSOConfig(m, nil)
+	if err != nil {
+		return nil, err
+	}
+	var ret proto.RegServerConfig
+	ret.Sso = ssoCfg
+	cfg, err := m.G().HostIDMap().Config(m, m.ShortHostID())
+	if err != nil {
+		return nil, err
+	}
+	ret.Typ = cfg.Typ
+	ret.View = cfg.Viewership
+	return &ret, nil
+}

--- a/server/shared/perms.go
+++ b/server/shared/perms.go
@@ -78,14 +78,9 @@ func GrantLocalViewPermission(
 		return zed, err
 	}
 
-	rolep := arg.ViewerRole
-	if rolep == nil {
-		// Default role was assumed to be admin, prior to version v0.0.20.
-		tmp := core.TemporaryDefaultViewerRole
-		rolep = &tmp
-	}
+	role := arg.ViewerRole.WithDefaultMemberLoadFloor()
 
-	ret, err := InsertLocalViewPermission(m, db, arg.Viewer, *rolep, arg.Viewee)
+	ret, err := InsertLocalViewPermission(m, db, arg.Viewer, role, arg.Viewee)
 	if err != nil {
 		return zed, err
 	}


### PR DESCRIPTION
- new default is that if alice is in a team as m/0 or above, she can load the user of anyone else on the team
  - this allows for a better output to `team ls`
- changes to client, server and protocol
- tests all working
- some new tests to test new behavior
- test backwards and forward compatibility of msgpack encoder (since we are adding new fields to persistent plaintexts)
- change logic around loader, not just admin can load members, can be any member above the mlf (member load floor)
- currently, remote members of teams cannot load members of the team they are on (might be the wrong behavior, but not changing here)
  - we can switch this now that #72 is done, now that we've relaxed the fact that members can load other members locally
- close #72
- change merkle race accounting: it's not a race if we fail a load on merkle permission check
