### PR TITLE
macOS: redirect stdout and stderr to logs

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -6,6 +6,8 @@ changelog:
     urgency: low
     stable: false
     changes:
+      - desc: capture stdout and stderr to log file on macos/launchd
+        closes: ["#75"]
       - desc: Allow m/0's to load adjacent team members (previously it was only admins and above). This improves the output of `team ls` for non-admins
         closes: ["#72"]
       - desc: Better error message for confusing case; team admin or above needed to make KV root


### PR DESCRIPTION
- this will capture strack traces on panic
- also will capture stray output to stderr or stdout
- close #75
