### PR TITLE
standup: interactive mode; binary foks-tool release

### DIFF
--- a/client/agent/srv.go
+++ b/client/agent/srv.go
@@ -297,7 +297,7 @@ func (c *AgentConn) CheckArgHeader(ctx context.Context, h lcl.Header) error {
 func (c *AgentConn) MakeResHeader() lcl.Header {
 	return lcl.NewHeaderWithV1(
 		lcl.HeaderV1{
-			Semver: core.CurrentClientVersion,
+			Semver: core.CurrentSoftwareVersion,
 		},
 	)
 }

--- a/client/foks/cmd/cmd.go
+++ b/client/foks/cmd/cmd.go
@@ -35,7 +35,7 @@ services.
 Many applications can be built on top of this primitive but best suited are those
 that share encrypted, persistent information across groups of users with multiple
 devices. For instance, files and git hosting.`,
-		Version: core.CurrentClientVersion.String(),
+		Version: core.CurrentSoftwareVersion.String(),
 	}
 }
 
@@ -62,7 +62,7 @@ func versionCmd(m libclient.MetaContext) *cobra.Command {
 		Short: "Print the version number of foks",
 		Long:  "Print the version number of foks",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("foks version %s\n", core.CurrentClientVersion.String())
+			fmt.Printf("foks version %s\n", core.CurrentSoftwareVersion.String())
 			if verbose {
 				fmt.Printf(" - commit: %s\n", libclient.LinkerVersion)
 				fmt.Printf(" - protocol compatibility version: %d\n", core.CurrentCompatibilityVersion)

--- a/client/foks/cmd/nag.go
+++ b/client/foks/cmd/nag.go
@@ -35,7 +35,7 @@ func checkUnifiedNags(m libclient.MetaContext, withRateLimit bool) (*lcl.Unified
 	info, err := cli.GetUnifiedNags(m.Ctx(), lcl.GetUnifiedNagsArg{
 		WithRateLimit: withRateLimit,
 		Cv: proto.ClientVersionExt{
-			Vers:            core.CurrentClientVersion,
+			Vers:            core.CurrentSoftwareVersion,
 			LinkerVersion:   libclient.LinkerVersion,
 			LinkerPackaging: libclient.LinkerPackaging,
 		},

--- a/client/libclient/compat.go
+++ b/client/libclient/compat.go
@@ -14,7 +14,7 @@ import (
 func MakeProtoHeader() lcl.Header {
 	return lcl.NewHeaderWithV1(
 		lcl.HeaderV1{
-			Semver: core.CurrentClientVersion,
+			Semver: core.CurrentSoftwareVersion,
 		},
 	)
 }

--- a/client/libclient/nag.go
+++ b/client/libclient/nag.go
@@ -128,7 +128,7 @@ func (n *NagMinder) getServerClientVersionInfo(m MetaContext) error {
 	}
 
 	scv, err := reg.GetClientVersionInfo(m.Ctx(), proto.ClientVersionExt{
-		Vers:            core.CurrentClientVersion,
+		Vers:            core.CurrentSoftwareVersion,
 		LinkerVersion:   LinkerVersion,
 		LinkerPackaging: LinkerPackaging,
 	})
@@ -152,11 +152,11 @@ func (n *NagMinder) checkClientCriticallyOutdated(m MetaContext) (bool, error) {
 	if n.scv.Min == nil {
 		return false, nil
 	}
-	diff := n.scv.Min.Cmp(core.CurrentClientVersion)
+	diff := n.scv.Min.Cmp(core.CurrentSoftwareVersion)
 	if diff > 0 {
 		n.res = append(n.res, lcl.NewUnifiedNagWithClientversioncritical(
 			lcl.UpgradeNagInfo{
-				Agent:  core.CurrentClientVersion,
+				Agent:  core.CurrentSoftwareVersion,
 				Server: *n.scv,
 			},
 		),
@@ -168,7 +168,7 @@ func (n *NagMinder) checkClientCriticallyOutdated(m MetaContext) (bool, error) {
 
 func (n *NagMinder) checkAgentVersionClash(m MetaContext) (bool, error) {
 
-	diff := core.CurrentClientVersion.Cmp(n.CliVersion.Vers)
+	diff := core.CurrentSoftwareVersion.Cmp(n.CliVersion.Vers)
 	if diff == 0 {
 		return false, nil
 	}
@@ -186,7 +186,7 @@ func (n *NagMinder) checkAgentVersionClash(m MetaContext) (bool, error) {
 
 	n.res = append(n.res, lcl.NewUnifiedNagWithClientversionclash(
 		lcl.CliVersionPair{
-			Agent: core.CurrentClientVersion,
+			Agent: core.CurrentSoftwareVersion,
 			Cli:   n.CliVersion.Vers,
 		},
 	),
@@ -252,7 +252,7 @@ func (n *NagMinder) checkUpgradeAvailable(m MetaContext) (bool, error) {
 		return false, nil
 	}
 
-	diff := n.scv.Newest.Cmp(core.CurrentClientVersion)
+	diff := n.scv.Newest.Cmp(core.CurrentSoftwareVersion)
 
 	// Ignore the case of the client being newer than what the server
 	// says is possible. Maybe the client is trying a test build.
@@ -290,7 +290,7 @@ func (n *NagMinder) checkUpgradeAvailable(m MetaContext) (bool, error) {
 	n.res = append(n.res,
 		lcl.NewUnifiedNagWithClientversionupgradeavailable(
 			lcl.UpgradeNagInfo{
-				Agent:  core.CurrentClientVersion,
+				Agent:  core.CurrentSoftwareVersion,
 				Server: *n.scv,
 			},
 		),

--- a/dockerfiles/foks-tool.dev
+++ b/dockerfiles/foks-tool.dev
@@ -7,11 +7,16 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 
+ARG LDFLAGS=""
+
 COPY lib lib
 COPY proto proto
 COPY server server
 COPY conf/srv conf/srv
-RUN CGO_ENABLED=0 GOOS=linux GOFLAGS="-tags=noresinit" go build -C server/foks-tool -o ../../foks-tool .
+
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS="-tags=noresinit" \
+    go build -C server/foks-tool \
+       -o ../../foks-tool -ldflags \'$LDFLAGS\' .
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/integration-tests/cli/nag_test.go
+++ b/integration-tests/cli/nag_test.go
@@ -134,7 +134,7 @@ func TestVersionNags(t *testing.T) {
 
 	assertNagType(lcl.NagType_ClientVersionCritical, nil)
 
-	cfg.Data.Client.ClientVersion_.MinVersion_ = wrapVers(core.CurrentClientVersion)
+	cfg.Data.Client.ClientVersion_.MinVersion_ = wrapVers(core.CurrentSoftwareVersion)
 
 	assertNagType(lcl.NagType_TooFewDevices, nil)
 

--- a/lib/core/version.go
+++ b/lib/core/version.go
@@ -15,7 +15,7 @@ import (
 // in terms of FOKS clients talking to FOKS servers.
 const CurrentCompatibilityVersion proto.CompatibilityVersion = 1
 
-var CurrentClientVersion = proto.SemVer{
+var CurrentSoftwareVersion = proto.SemVer{
 	Major: 0,
 	Minor: 0,
 	Patch: 20,

--- a/make/server.mk
+++ b/make/server.mk
@@ -85,6 +85,8 @@ foks-server-docker-push: ghcr-login foks-server-docker-image-latest foks-tool-do
 	docker tag foks-tool:latest ghcr.io/foks-proj/foks-tool:latest
 	docker push ghcr.io/foks-proj/foks-tool:latest
 
+.PHONY: foks-tool-linux
+foks-tool-linux: build/foks-tool.linux-arm64 build/foks-tool.linux-amd64
 
 .PHONY: foks-tool-docker-image-latest
 foks-tool-docker-image-latest:
@@ -92,3 +94,9 @@ foks-tool-docker-image-latest:
 		-f dockerfiles/foks-tool.dev \
 		-t foks-tool:latest \
 		--platform=linux/arm64,linux/amd64 .
+
+build/foks-tool.linux-arm64:
+	bash -x scripts/cross-compile-foks-tool.bash -p arm64 -s
+build/foks-tool.linux-amd64:
+	bash -x scripts/cross-compile-foks-tool.bash -p amd64 -s
+

--- a/scripts/cross-compile-foks-tool.bash
+++ b/scripts/cross-compile-foks-tool.bash
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# set -euo pipefail
+set -x 
+
+usage() {
+    echo "Usage: $0 -p {arm64|amd64} [-s]"
+    exit 1
+}
+
+strip=0
+plat=""
+
+# take two arguments: -p which can be arm64 or amd64, and also
+# -s, which is a boolean flag that means to strip the binary
+while getopts ":p:s" opt; do
+    case $opt in
+        p)
+            plat=$OPTARG
+            ;;
+        s)
+            strip=1
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            usage
+            ;;
+    esac
+done
+
+
+shift $((OPTIND -1))
+
+if [ $# -ne 0 ]; then
+   usage
+fi
+
+if [ "$plat" != "arm64" ] && [ "$plat" != "amd64" ]; then
+    usage
+fi
+
+version=$(git describe --tags --always)
+trimpath=""
+
+ldflags="-X main.LinkerVersion=${version}"
+if [ $strip -eq 1 ]; then
+    ldflags="${ldflags} -w"
+    trimpath="-trimpath"
+fi
+
+GOOS=linux GOARCH=${plat} GOFLAGS="-tags=noresinit" \
+    go build \
+        -C server/foks-tool \
+        -o ../../build/foks-tool.linux.${plat} \
+        -ldflags "${ldflags}" \
+        $trimpath \
+        .
+
+gzip -f build/foks-tool.linux.${plat}

--- a/server/foks-tool/main.go
+++ b/server/foks-tool/main.go
@@ -15,6 +15,10 @@ func AddCmd(cmd shared.CLIApp) {
 	cmds = append(cmds, cmd)
 }
 
+var (
+	LinkerVersion = "unknown"
+)
+
 func newRootCmd() *shared.RootCommand {
 	var ret shared.RootCommand
 	ret.Cmd = &cobra.Command{

--- a/server/foks-tool/version.go
+++ b/server/foks-tool/version.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/server/shared"
+	"github.com/spf13/cobra"
+)
+
+type VersionCmd struct {
+	CLIAppBase
+}
+
+func (v *VersionCmd) CobraConfig() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the version of the FOKS tool",
+	}
+}
+
+func (v *VersionCmd) CheckArgs(args []string) error {
+	if len(args) != 0 {
+		return core.BadArgsError("no args allowed")
+	}
+	return nil
+}
+
+func (v *VersionCmd) Run(m shared.MetaContext) error {
+	var lv string
+	if LinkerVersion != "unknown" {
+		lv = fmt.Sprintf(" (linked as: %s)", LinkerVersion)
+	}
+	fmt.Printf("%s%s\n",
+		core.CurrentSoftwareVersion.String(),
+		lv,
+	)
+	return nil
+}
+
+func (v *VersionCmd) SetGlobalContext(g *shared.GlobalContext) {}
+func (v *VersionCmd) TweakOpts(opts *shared.GlobalCLIConfigOpts) {
+	opts.SkipNetwork = true
+	opts.SkipConfig = true
+	opts.NoStartupMsg = true
+}
+
+var _ shared.CLIApp = (*VersionCmd)(nil)
+
+func init() {
+	AddCmd(&VersionCmd{})
+}


### PR DESCRIPTION
- for the curl script, interactive mode will deal with the weirdness around passing params through to the script
- for now, since docker is too annoying, we'll release static linux binaries along with releases
- server-install.sh script is tested
- run with: `/usr/bin/env bash <(curl -fsSL https://pkgs.foks.pub/server-install.sh)`
- close #89
