### PR TITLE
srv: various fixes for `standup`-generate hosts

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -9,6 +9,10 @@ changelog:
     changes:
       - desc: Better errors messages on windows for agent being dead
         closes: ["#94"]
+      - desc: FOKS_HOME variable is like HOME but doesn't mess with system HOME
+        closes: ["#93"]
+      - desc: Introduce standalone server mode
+        closes: ["#93"]
   - version: 0.0.20
     urgency: low
     stable: false

--- a/client/foks/cmd/ui/view.go
+++ b/client/foks/cmd/ui/view.go
@@ -5,10 +5,49 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/foks-proj/go-foks/lib/core"
+	"golang.org/x/term"
 )
+
+func getTermSize() (int, int) {
+	fd := int(os.Stdout.Fd())
+	if !term.IsTerminal(fd) {
+		return 0, 0
+	}
+
+	width, height, err := term.GetSize(fd)
+	if err != nil {
+		return 0, 0
+	}
+	return width, height
+}
+
+func wrapText(s string, padding int, secondLineIndent int) string {
+
+	width, _ := getTermSize()
+	if width == 0 {
+		return s
+	}
+
+	// the rewrap function we're going to call decreases the inner width by
+	// padding, but we also want a right margin, so are including it here.
+	width -= padding
+
+	txt, err := core.Rewrap(s, width, padding+secondLineIndent)
+	if err != nil {
+		return s
+	}
+
+	if len(txt) > secondLineIndent {
+		txt = txt[secondLineIndent:]
+	}
+
+	return txt
+}
 
 func drawTextInput(ti textinput.Model, prompt string, validator func(string) error) string {
 	var err error
@@ -22,9 +61,10 @@ func drawTextInput(ti textinput.Model, prompt string, validator func(string) err
 			emsg = styl.Render(textInputStyle.Render(err.Error())) + "\n\n"
 		}
 	}
+	prompt = wrapText(prompt, 4, 3)
 	var b strings.Builder
 	fmt.Fprintf(&b, "\n%s\n\n%s\n\n%s",
-		textInputStyle.Render(prompt),
+		prompt,
 		styl.Render(textInputStyle.Render(ti.View())),
 		emsg,
 	)

--- a/client/libclient/home.go
+++ b/client/libclient/home.go
@@ -90,6 +90,14 @@ func (b Base) getHome() string {
 			return ret
 		}
 	}
+
+	// Sometimes we want to run foks from a different home directory
+	// without affecting standard system services.
+	ret := b.getenv("FOKS_HOME")
+	if ret != "" {
+		return ret
+	}
+
 	return ""
 }
 

--- a/conf/srv/foks-docker-compose.jsonnet
+++ b/conf/srv/foks-docker-compose.jsonnet
@@ -73,7 +73,8 @@ pre.final({
         merkle_builder : make_listen(base, 2, "merkle_builder", false),
         merkle_signer : make_listen(base, 3, "merkle_signer", false),
         queue : make_listen(base, 4, "queue", false),
-        quota : make_listen(base, 5, "quota", false)
+        quota : make_listen(base, 5, "quota", false),
+        autocert : make_listen(base, 6, "autocert", false),
     },
 
     apps : {

--- a/dockerfiles/foks-server.dev
+++ b/dockerfiles/foks-server.dev
@@ -11,7 +11,8 @@ COPY lib lib
 COPY proto proto
 COPY server server
 COPY conf/srv conf/srv
-RUN CGO_ENABLED=0 GOOS=linux GOFLAGS="-tags=noresinit" go build -C server/foks-server -o ../../foks-server .
+RUN CGO_ENABLED=0 GOOS=linux GOFLAGS="-tags=noresinit" \
+    go build -C server/foks-server -o ../../foks-server -trimpath .
 
 FROM scratch
 

--- a/dockerfiles/foks-tool.dev
+++ b/dockerfiles/foks-tool.dev
@@ -7,8 +7,6 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 
-ARG LDFLAGS=""
-
 COPY lib lib
 COPY proto proto
 COPY server server
@@ -16,7 +14,7 @@ COPY conf/srv conf/srv
 
 RUN CGO_ENABLED=0 GOOS=linux GOFLAGS="-tags=noresinit" \
     go build -C server/foks-tool \
-       -o ../../foks-tool -ldflags \'$LDFLAGS\' .
+       -o ../../foks-tool -trimpath .
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/make/server.mk
+++ b/make/server.mk
@@ -86,7 +86,7 @@ foks-server-docker-push: ghcr-login foks-server-docker-image-latest foks-tool-do
 	docker push ghcr.io/foks-proj/foks-tool:latest
 
 .PHONY: foks-tool-linux
-foks-tool-linux: build/foks-tool.linux-arm64 build/foks-tool.linux-amd64
+foks-tool-linux: build/foks-tool.linux.arm64.gz build/foks-tool.linux.amd64.gz
 
 .PHONY: foks-tool-docker-image-latest
 foks-tool-docker-image-latest:
@@ -95,8 +95,17 @@ foks-tool-docker-image-latest:
 		-t foks-tool:latest \
 		--platform=linux/arm64,linux/amd64 .
 
-build/foks-tool.linux-arm64:
+.PHONY: build/foks-tool.linux.arm64.gz
+build/foks-tool.linux.arm64.gz:
 	bash -x scripts/cross-compile-foks-tool.bash -p arm64 -s
-build/foks-tool.linux-amd64:
+
+.PHONY: build/foks-tool.linux.amd64.gz
+build/foks-tool.linux.amd64.gz:
 	bash -x scripts/cross-compile-foks-tool.bash -p amd64 -s
 
+.PHONY: foks-tool-release
+foks-tool-gh-push: foks-tool-linux
+	gh release upload \
+		--clobber $$(git describe --tags --abbrev=0) \
+		build/foks-tool.linux.arm64.gz \
+		build/foks-tool.linux.amd64.gz

--- a/proto-src/lib/config.snowp
+++ b/proto-src/lib/config.snowp
@@ -14,6 +14,7 @@ enum HostType {
     BigTop @1;
     VHostManagement @2;
     VHost @3;
+    Standalone @4;
 }
 
 struct HostViewership {

--- a/proto/lib/config.go
+++ b/proto/lib/config.go
@@ -42,6 +42,7 @@ const (
 	HostType_BigTop          HostType = 1
 	HostType_VHostManagement HostType = 2
 	HostType_VHost           HostType = 3
+	HostType_Standalone      HostType = 4
 )
 
 var HostTypeMap = map[string]HostType{
@@ -49,12 +50,14 @@ var HostTypeMap = map[string]HostType{
 	"BigTop":          1,
 	"VHostManagement": 2,
 	"VHost":           3,
+	"Standalone":      4,
 }
 var HostTypeRevMap = map[HostType]string{
 	0: "None",
 	1: "BigTop",
 	2: "VHostManagement",
 	3: "VHost",
+	4: "Standalone",
 }
 
 type HostTypeInternal__ HostType

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -4191,6 +4191,18 @@ func (v ViewershipMode) String() string {
 	}
 }
 
+func (v *ViewershipMode) ImportFromCLI(s string) error {
+	switch s {
+	case "closed":
+		*v = ViewershipMode_Closed
+	case "open":
+		*v = ViewershipMode_OpenToAll
+	default:
+		return DataError("bad viewership mode")
+	}
+	return nil
+}
+
 func (v *ViewershipMode) ImportFromDB(s string) error {
 	switch s {
 	case "closed":
@@ -4583,10 +4595,12 @@ func (t HostType) String() string {
 		return "none"
 	case HostType_BigTop:
 		return "big_top"
-	case HostType_VHostManagement:
-		return "vhost_management"
 	case HostType_VHost:
 		return "vhost"
+	case HostType_VHostManagement:
+		return "vhost_management"
+	case HostType_Standalone:
+		return "standalone"
 	default:
 		return "error"
 	}
@@ -4600,6 +4614,8 @@ func (t *HostType) ImportFromString(s string) error {
 		*t = HostType_BigTop
 	case "vhost_management":
 		*t = HostType_VHostManagement
+	case "standalone":
+		*t = HostType_Standalone
 	case "vhost":
 		*t = HostType_VHost
 	default:
@@ -4622,7 +4638,7 @@ func (t Time) UnixSeconds() int64 {
 
 func (h HostType) SupportKVStore() bool {
 	switch h {
-	case HostType_BigTop, HostType_VHost:
+	case HostType_BigTop, HostType_VHost, HostType_Standalone:
 		return true
 	default:
 		return false

--- a/proto/lib/server.go
+++ b/proto/lib/server.go
@@ -126,7 +126,7 @@ var FrontFacingServers []ServerType = []ServerType{
 var CoreServers []ServerType = []ServerType{
 	ServerType_Reg, ServerType_User, ServerType_MerkleBuilder, ServerType_InternalCA, ServerType_MerkleQuery,
 	ServerType_Queue, ServerType_MerkleBatcher, ServerType_MerkleSigner, ServerType_Probe,
-	ServerType_KVStore,
+	ServerType_KVStore, ServerType_Autocert,
 }
 
 func (t ServerType) IsFrontFacing() bool {

--- a/server/foks-tool/viewership.go
+++ b/server/foks-tool/viewership.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package main
+
+import (
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/server/shared"
+	"github.com/spf13/cobra"
+)
+
+type ViewCmd struct {
+	CLIAppBase
+	SetTo string
+	Set   *proto.ViewershipMode
+	Hosts []int
+}
+
+func (o *ViewCmd) CobraConfig() *cobra.Command {
+	ret := &cobra.Command{
+		Use:     "viewiership",
+		Aliases: []string{"view"},
+		Short:   "Check or change viewership settings for a FOKS host (or vhost)",
+		Long: `Check or change viewership settings for a FOKS host (or vhost).
+With --set, will try to set the value to the given bool. Withou --set, will print the current value.
+If there is only one virtual host on this machine, no need to specify --host-id on --set,
+but otherwise, you must.`,
+	}
+	ret.Flags().StringVar(&o.SetTo, "set", "", "Set the viewership setting to the given value; must be 'open' or 'closed'")
+	ret.Flags().IntSliceVar(&o.Hosts, "host-id", nil, "Host IDs to apply changes to; required if there are multiple hosts on this machine")
+	return ret
+}
+
+func (i *ViewCmd) CheckArgs(args []string) error {
+	if len(args) != 0 {
+		return core.BadArgsError("no args allowed")
+	}
+	if i.SetTo != "" {
+		var tmp proto.ViewershipMode
+		err := tmp.ImportFromCLI(i.SetTo)
+		if err != nil {
+			return core.BadArgsError("invalid value for --set; must be 'open' or 'closed'")
+		}
+		i.Set = &tmp
+	}
+	return nil
+}
+
+func (o *ViewCmd) Run(m shared.MetaContext) error {
+	hosts := core.Map(o.Hosts, func(i int) core.ShortHostID {
+		return core.ShortHostID(i)
+	})
+	if o.Set == nil {
+		_, err := shared.GetViewership(m, hosts)
+		return err
+	}
+	return shared.SetViewership(m, *o.Set, hosts)
+}
+
+func (k *ViewCmd) SetGlobalContext(g *shared.GlobalContext) {}
+
+var _ shared.CLIApp = (*ViewCmd)(nil)
+
+func init() {
+	AddCmd(&ViewCmd{})
+}

--- a/server/shared/viewership.go
+++ b/server/shared/viewership.go
@@ -1,0 +1,84 @@
+package shared
+
+import (
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+type HostViewership struct {
+	HostID      core.ShortHostID
+	UserViewing proto.ViewershipMode
+}
+
+func GetViewership(m MetaContext, hosts []core.ShortHostID) ([]HostViewership, error) {
+	iHosts := core.Map(hosts, func(h core.ShortHostID) int {
+		return int(h)
+	})
+
+	q := `SELECT short_host_id, user_viewing FROM host_config`
+	args := []any{}
+	if len(iHosts) > 0 {
+		q += ` WHERE host_id = ANY($1)`
+		args = append(args, iHosts)
+	}
+	db, err := m.Db(DbTypeServerConfig)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Release()
+	rows, err := db.Query(m.Ctx(), q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ret []HostViewership
+	for rows.Next() {
+		var uvs string
+		var host int
+		if err := rows.Scan(&host, &uvs); err != nil {
+			return nil, err
+		}
+		item := HostViewership{
+			HostID: core.ShortHostID(host),
+		}
+		err := item.UserViewing.ImportFromDB(uvs)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func SetViewership(m MetaContext, mode proto.ViewershipMode, hosts []core.ShortHostID) error {
+	if len(hosts) == 0 {
+		hv, err := GetViewership(m, nil)
+		if err != nil {
+			return err
+		}
+		if len(hv) == 0 {
+			return core.HostIDNotFoundError{}
+		}
+		if len(hv) > 1 {
+			return core.BadArgsError("need to specify hostID since there are multiple hosts")
+		}
+		hosts = []core.ShortHostID{hv[0].HostID}
+	}
+	db, err := m.Db(DbTypeServerConfig)
+	if err != nil {
+		return err
+	}
+	defer db.Release()
+	q := `UPDATE host_config SET user_viewing = $1 WHERE short_host_id = ANY($2)`
+	args := []any{
+		mode.String(),
+		core.Map(hosts, func(h core.ShortHostID) int { return int(h) })}
+	_, err = db.Exec(m.Ctx(), q, args...)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -40,9 +40,15 @@ var usersPatch1 string
 //go:embed patches/foks_users/p2.sql
 var usersPatch2 string
 
+//go:embed patches/foks_server_config/p1.sql
+var serverConfigPatch1 string
+
 var Patches = map[string]map[int]string{
 	"foks_users": {
 		1: usersPatch1,
 		2: usersPatch2,
+	},
+	"foks_server_config": {
+		1: serverConfigPatch1,
 	},
 }

--- a/server/sql/foks_server_config.sql
+++ b/server/sql/foks_server_config.sql
@@ -108,7 +108,7 @@ CREATE TABLE server_aliases (
     FOREIGN KEY(root_short_host_id) REFERENCES hosts(short_host_id)
 );
 
-CREATE TYPE host_type AS ENUM('big_top', 'vhost_management', 'vhost');
+CREATE TYPE host_type AS ENUM('big_top', 'vhost_management', 'vhost', 'standalone');
 
 CREATE TYPE viewership_mode AS ENUM('closed', 'open_to_admin', 'open_to_all');
 
@@ -242,3 +242,10 @@ CREATE TABLE x509_assets (
 );
 
 CREATE INDEX x509_assets_ctime_idx ON x509_assets(short_host_id, typ, ctime) WHERE active=true;
+
+CREATE TABLE schema_patches (
+    id INTEGER NOT NULL PRIMARY KEY,
+    ctime TIMESTAMP NOT NULL
+);
+
+INSERT INTO schema_patches (id, ctime) VALUES (1, NOW());

--- a/server/sql/patches/foks_server_config/p1.sql
+++ b/server/sql/patches/foks_server_config/p1.sql
@@ -1,0 +1,2 @@
+
+ALTER TYPE host_type ADD VALUE 'standalone';


### PR DESCRIPTION
- get/set of viewership mode via CLI
- styling tweaks to standup and signup (for recoring videos)
- FOKS_HOME feature, can specify foks home dir via environment variable without messing with $HOME, which impacts system functioning
- add a standalone basic server type
  - DB patch included for foks_server_config database
- rewrap text where necessary
- fix lint errors in standup
- macros for pushing tools and server to github and container registry
- support kv store on standalone host
- close #93
