### PR TITLE
srv: rename OpenToAll -> Open

### DIFF
--- a/client/libclient/team_loader.go
+++ b/client/libclient/team_loader.go
@@ -1369,7 +1369,7 @@ func (l *TeamLoader) setCanLoadMembersFlag(m MetaContext) error {
 		return err
 	}
 
-	if cfg.View.User == proto.ViewershipMode_OpenToAll {
+	if cfg.View.User == proto.ViewershipMode_Open {
 		l.canLoadMembers = true
 		l.openView = true
 		return nil

--- a/client/libclient/team_minder_add.go
+++ b/client/libclient/team_minder_add.go
@@ -44,7 +44,7 @@ func (t *TeamMinder) requireOpenViewership(m MetaContext) error {
 	if err != nil {
 		return err
 	}
-	if cfg.Viewership.User != proto.ViewershipMode_OpenToAll {
+	if cfg.Viewership.User != proto.ViewershipMode_Open {
 		return core.PermissionError("host does not allow open viewership; must use 3-way invitation flow")
 	}
 	return nil

--- a/integration-tests/cli/team_test.go
+++ b/integration-tests/cli/team_test.go
@@ -419,7 +419,7 @@ func createTeamOpenViewership(
 	require.NoError(t, err)
 	m = m.WithHostID(chid)
 
-	err = shared.VHostSetUserViewership(m, proto.ViewershipMode_OpenToAll)
+	err = shared.VHostSetUserViewership(m, proto.ViewershipMode_Open)
 	require.NoError(t, err)
 
 	y := newTestAgent(t)

--- a/integration-tests/cli/web_vanity_test.go
+++ b/integration-tests/cli/web_vanity_test.go
@@ -331,14 +331,14 @@ func (a *adminWebClient) openUserViewership(t *testing.T) {
 	slices.Sort(vals)
 	require.Equal(t, []string{
 		proto.ViewershipMode_Closed.String(),
-		proto.ViewershipMode_OpenToAll.String(),
+		proto.ViewershipMode_Open.String(),
 	}, vals)
 	targ, found := form.Attr("hx-patch")
 	require.True(t, found, "hx-patch")
 	varName, found := sel.Attr("name")
 	require.True(t, found, "name")
 	data := url.Values{}
-	data.Add(varName, proto.ViewershipMode_OpenToAll.String())
+	data.Add(varName, proto.ViewershipMode_Open.String())
 	resp := a.httpOp(t, "PATCH", proto.URLString(targ), data, nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 }

--- a/integration-tests/lib/open_view_test.go
+++ b/integration-tests/lib/open_view_test.go
@@ -53,7 +53,7 @@ func TestOpenUserViewAndTeamAdd(t *testing.T) {
 
 	m = m.WithHostID(&vHostID.HostID)
 
-	err = shared.VHostSetUserViewership(m, proto.ViewershipMode_OpenToAll)
+	err = shared.VHostSetUserViewership(m, proto.ViewershipMode_Open)
 	require.NoError(t, err)
 
 	// don't forget to change it back so other tests don't fail
@@ -165,7 +165,7 @@ func TestOpenViewTeamList(t *testing.T) {
 
 	m := tew.MetaContext()
 	m = m.WithHostID(&vHostID.HostID)
-	err := shared.VHostSetUserViewership(m, proto.ViewershipMode_OpenToAll)
+	err := shared.VHostSetUserViewership(m, proto.ViewershipMode_Open)
 	require.NoError(t, err)
 
 	// don't forget to change it back so other tests don't fail

--- a/proto-src/lib/config.snowp
+++ b/proto-src/lib/config.snowp
@@ -6,7 +6,7 @@
 enum ViewershipMode {
     Closed @0;
     OpenToAdmin @1;
-    OpenToAll @2;
+    Open @2;
 }
 
 enum HostType {

--- a/proto/lib/config.go
+++ b/proto/lib/config.go
@@ -12,18 +12,18 @@ type ViewershipMode int
 const (
 	ViewershipMode_Closed      ViewershipMode = 0
 	ViewershipMode_OpenToAdmin ViewershipMode = 1
-	ViewershipMode_OpenToAll   ViewershipMode = 2
+	ViewershipMode_Open        ViewershipMode = 2
 )
 
 var ViewershipModeMap = map[string]ViewershipMode{
 	"Closed":      0,
 	"OpenToAdmin": 1,
-	"OpenToAll":   2,
+	"Open":        2,
 }
 var ViewershipModeRevMap = map[ViewershipMode]string{
 	0: "Closed",
 	1: "OpenToAdmin",
-	2: "OpenToAll",
+	2: "Open",
 }
 
 type ViewershipModeInternal__ ViewershipMode

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -4184,23 +4184,11 @@ func (v ViewershipMode) String() string {
 		return "closed"
 	case ViewershipMode_OpenToAdmin:
 		return "open_to_admin"
-	case ViewershipMode_OpenToAll:
-		return "open_to_all"
+	case ViewershipMode_Open:
+		return "open"
 	default:
 		return "error"
 	}
-}
-
-func (v *ViewershipMode) ImportFromCLI(s string) error {
-	switch s {
-	case "closed":
-		*v = ViewershipMode_Closed
-	case "open":
-		*v = ViewershipMode_OpenToAll
-	default:
-		return DataError("bad viewership mode")
-	}
-	return nil
 }
 
 func (v *ViewershipMode) ImportFromDB(s string) error {
@@ -4209,8 +4197,8 @@ func (v *ViewershipMode) ImportFromDB(s string) error {
 		*v = ViewershipMode_Closed
 	case "open_to_admin":
 		*v = ViewershipMode_OpenToAdmin
-	case "open_to_all":
-		*v = ViewershipMode_OpenToAll
+	case "open":
+		*v = ViewershipMode_Open
 	default:
 		return DataError("bad viewership mode")
 	}

--- a/server/foks-tool/standup.go
+++ b/server/foks-tool/standup.go
@@ -132,8 +132,9 @@ func (s *StandupCmd) setViewership() error {
 		s.viewershipStr = "open"
 	}
 	var tmp proto.ViewershipMode
-	err := tmp.ImportFromCLI(s.viewershipStr)
-	if err != nil {
+	err := tmp.ImportFromDB(s.viewershipStr)
+	if err != nil ||
+		(tmp != proto.ViewershipMode_Open && tmp != proto.ViewershipMode_Closed) {
 		return core.BadArgsError("invalid value for --viewership; must be 'open' or 'closed'")
 	}
 	s.viewership = &tmp
@@ -274,7 +275,7 @@ func (s *StandupCmd) getViewshipMode(m shared.MetaContext) error {
 	switch i {
 	case 0:
 		s.viewershipStr = "open"
-		tmp := proto.ViewershipMode_OpenToAll
+		tmp := proto.ViewershipMode_Open
 		s.viewership = &tmp
 	case 1:
 		s.viewershipStr = "closed"

--- a/server/foks-tool/standup.go
+++ b/server/foks-tool/standup.go
@@ -126,16 +126,24 @@ docker-compose up`,
 	return ret
 }
 
+func parseViewershipMode(s string) (proto.ViewershipMode, error) {
+	var tmp proto.ViewershipMode
+	err := tmp.ImportFromDB(s)
+	if err == nil && (tmp == proto.ViewershipMode_Open || tmp == proto.ViewershipMode_Closed) {
+		return tmp, nil
+	}
+	var zed proto.ViewershipMode
+	return zed, core.BadArgsError("invalid value for viewership; must be 'open' or 'closed'")
+}
+
 func (s *StandupCmd) setViewership() error {
 
 	if s.viewershipStr == "" {
 		s.viewershipStr = "open"
 	}
-	var tmp proto.ViewershipMode
-	err := tmp.ImportFromDB(s.viewershipStr)
-	if err != nil ||
-		(tmp != proto.ViewershipMode_Open && tmp != proto.ViewershipMode_Closed) {
-		return core.BadArgsError("invalid value for --viewership; must be 'open' or 'closed'")
+	tmp, err := parseViewershipMode(s.viewershipStr)
+	if err != nil {
+		return err
 	}
 	s.viewership = &tmp
 	return nil

--- a/server/foks-tool/viewership.go
+++ b/server/foks-tool/viewership.go
@@ -37,11 +37,9 @@ func (i *ViewCmd) CheckArgs(args []string) error {
 		return core.BadArgsError("no args allowed")
 	}
 	if i.SetTo != "" {
-		var tmp proto.ViewershipMode
-		err := tmp.ImportFromDB(i.SetTo)
-		if err != nil ||
-			(tmp != proto.ViewershipMode_Open && tmp != proto.ViewershipMode_Closed) {
-			return core.BadArgsError("invalid value for --set; must be 'open' or 'closed'")
+		tmp, err := parseViewershipMode(i.SetTo)
+		if err != nil {
+			return err
 		}
 		i.Set = &tmp
 	}

--- a/server/foks-tool/viewership.go
+++ b/server/foks-tool/viewership.go
@@ -38,8 +38,9 @@ func (i *ViewCmd) CheckArgs(args []string) error {
 	}
 	if i.SetTo != "" {
 		var tmp proto.ViewershipMode
-		err := tmp.ImportFromCLI(i.SetTo)
-		if err != nil {
+		err := tmp.ImportFromDB(i.SetTo)
+		if err != nil ||
+			(tmp != proto.ViewershipMode_Open && tmp != proto.ViewershipMode_Closed) {
 			return core.BadArgsError("invalid value for --set; must be 'open' or 'closed'")
 		}
 		i.Set = &tmp

--- a/server/shared/perms.go
+++ b/server/shared/perms.go
@@ -184,7 +184,7 @@ func BulkInsertLocalViewPermissions(
 	if err != nil {
 		return err
 	}
-	if cfg.Viewership.User != proto.ViewershipMode_OpenToAll {
+	if cfg.Viewership.User != proto.ViewershipMode_Open {
 		return core.PermissionError("no open viewership mode")
 	}
 

--- a/server/shared/resolve_username.go
+++ b/server/shared/resolve_username.go
@@ -36,7 +36,7 @@ func ResolveUsername(
 
 	switch typ {
 	case rem.LoadUserChainAuthType_OpenVHost:
-		if hc.Viewership.User != proto.ViewershipMode_OpenToAll {
+		if hc.Viewership.User != proto.ViewershipMode_Open {
 			return zed, pde
 		}
 		authed = true

--- a/server/shared/user_loader.go
+++ b/server/shared/user_loader.go
@@ -334,7 +334,7 @@ func (u *UserLoader) checkPerms(m MetaContext) error {
 			return err
 		}
 		switch cfg.Viewership.User {
-		case proto.ViewershipMode_OpenToAll:
+		case proto.ViewershipMode_Open:
 			return nil
 		default:
 			return core.PermissionError("no open viewership mode")

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -43,6 +43,9 @@ var usersPatch2 string
 //go:embed patches/foks_server_config/p1.sql
 var serverConfigPatch1 string
 
+//go:embed patches/foks_server_config/p2.sql
+var serverConfigPatch2 string
+
 var Patches = map[string]map[int]string{
 	"foks_users": {
 		1: usersPatch1,
@@ -50,5 +53,6 @@ var Patches = map[string]map[int]string{
 	},
 	"foks_server_config": {
 		1: serverConfigPatch1,
+		2: serverConfigPatch2,
 	},
 }

--- a/server/sql/foks_server_config.sql
+++ b/server/sql/foks_server_config.sql
@@ -110,7 +110,7 @@ CREATE TABLE server_aliases (
 
 CREATE TYPE host_type AS ENUM('big_top', 'vhost_management', 'vhost', 'standalone');
 
-CREATE TYPE viewership_mode AS ENUM('closed', 'open_to_admin', 'open_to_all');
+CREATE TYPE viewership_mode AS ENUM('closed', 'open_to_admin', 'open');
 
 /*
  * one row in host-config for every host, whether virtual or not.

--- a/server/sql/patches/foks_server_config/p2.sql
+++ b/server/sql/patches/foks_server_config/p2.sql
@@ -1,0 +1,2 @@
+
+ALTER TYPE viewership_mode RENAME VALUE 'open_to_all' TO 'open';

--- a/server/web/lib/vhosts.go
+++ b/server/web/lib/vhosts.go
@@ -20,7 +20,7 @@ type ViewershipMode struct {
 }
 
 var ValidUserViewershipModes = []ViewershipMode{
-	{proto.ViewershipMode_OpenToAll, "open"},
+	{proto.ViewershipMode_Open, "open"},
 	{proto.ViewershipMode_Closed, "closed"},
 }
 


### PR DESCRIPTION
- eventually we're going to have OpenToWorld, which means even remote users can load users on this host
- OpenToAll seems confusing and similar to OpenToWorld, so proactively change it to Open now
- close #98
