### PR TITLE
cli: log rotation

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -2,6 +2,13 @@ project: foks
 maintaner: Maxwell Krohn <max@ne43.com>
 
 changelog:
+  - version: 0.0.22
+    urgency: low
+    stable: false
+    date: none-yet
+    changes:
+      - desc: cli - log rotation for agent logs (not for error, just for output)
+        closes: []
   - version: 0.0.21
     urgency: low
     stable: false

--- a/client/agent/srv.go
+++ b/client/agent/srv.go
@@ -142,6 +142,11 @@ func (a *Agent) Stop() {
 }
 
 func (a *Agent) startBg(m libclient.MetaContext) error {
+
+	err := m.SetAsAgent()
+	if err != nil {
+		return err
+	}
 	cfg, err := m.G().Cfg().BgConfig()
 	if err != nil {
 		return err
@@ -149,6 +154,7 @@ func (a *Agent) startBg(m libclient.MetaContext) error {
 	bg := libclient.NewBgJobMgr(*cfg)
 	a.bg = bg
 	bg.Run(m)
+
 	return nil
 }
 

--- a/client/libclient/context.go
+++ b/client/libclient/context.go
@@ -191,3 +191,8 @@ func (g *GlobalContext) WarnwWithContext(
 ) {
 	core.WarnwWithContext(ctx, g.Log(), msg, keysAndValues...)
 }
+
+func (m MetaContext) SetAsAgent() error {
+	return m.g.SetAsAgent(m.Ctx())
+
+}

--- a/client/libclient/log_rotate.go
+++ b/client/libclient/log_rotate.go
@@ -1,0 +1,276 @@
+package libclient
+
+import (
+	"compress/gzip"
+	"io"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/foks-proj/go-foks/lib/core"
+)
+
+type LogRotate struct {
+	sync.Mutex
+
+	// called on shutdown to stop the background loop
+	stopper chan struct{}
+
+	// these two channels are used in testing. pokeCh awakens the background loop
+	// early so it can recheck the clock and then go back to sleep. And waiters wait
+	// for the next log rotation to happen.
+	pokeCh  chan<- struct{}
+	waiters []chan struct{}
+}
+
+func NewLogRotate() *LogRotate {
+	return &LogRotate{}
+}
+
+func (g *LogRotate) timeUntilLogRotate(m MetaContext) (time.Duration, error) {
+	// We want to rotate logs at 3 AM every day.
+	now := m.G().Now()
+	dayInc := 1
+	if now.Hour() < 3 {
+		dayInc = 0
+	}
+	nextRotate := time.Date(now.Year(), now.Month(), now.Day()+dayInc, 3, 0, 0, 0, now.Location())
+
+	diff := nextRotate.Sub(now)
+	if diff < time.Minute {
+		diff += 24 * time.Hour
+	}
+	return diff, nil
+}
+
+func (g *LogRotate) WaitForNextRotate(ch chan struct{}) {
+	g.Lock()
+	defer g.Unlock()
+	if ch == nil {
+		return
+	}
+	g.waiters = append(g.waiters, ch)
+}
+
+func (g *LogRotate) unlockWaiters(m MetaContext) {
+	g.Lock()
+	defer g.Unlock()
+	v := g.waiters
+	g.waiters = nil
+	for _, ch := range v {
+		close(ch)
+	}
+}
+
+func (g *LogRotate) doLogRotate(m MetaContext) (err error) {
+
+	defer func() {
+		if err != nil {
+			m.Errorw("logrotate", "stage", "doLogRotate", "err", err)
+		}
+	}()
+
+	nm, err := m.G().OutLogPath()
+	if err != nil {
+		return err
+	}
+	err = g.rename(m, nm)
+	if err != nil {
+		return err
+	}
+	err = g.ageOut(m, nm)
+	if err != nil {
+		return err
+	}
+
+	g.unlockWaiters(m)
+
+	return nil
+}
+
+func (g *LogRotate) gzipFile(m MetaContext, nm core.Path) (err error) {
+	dst := nm.AddSuffix(".gz")
+	m.Infow("logrotate", "stage", "gzipFile", "from", nm, "to", dst)
+
+	in, err := nm.Open()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if in == nil {
+			return
+		}
+		if cerr := in.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	out, err := dst.Create()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	gz := gzip.NewWriter(out)
+	_, err = io.Copy(gz, in)
+	if err != nil {
+		return err
+	}
+	err = in.Close()
+	if err != nil {
+		return err
+	}
+	in = nil
+
+	err = gz.Close()
+	if err != nil {
+		return err
+	}
+	gz = nil
+
+	m.Infow("logrotate", "stage", "gzipFile done")
+	if err := nm.Remove(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (g *LogRotate) rename(m MetaContext, nm core.Path) error {
+	now := m.G().Now()
+	// format time in YYYYMMDDHHMMSS format
+	timestamp := now.Format("20060102150405")
+
+	rotated := core.Path(nm.String() + "." + timestamp)
+
+	m.Infow("logrotate", "stage", "rename", "from", nm, "to", rotated)
+	err := nm.Rename(rotated)
+	if err != nil {
+		return err
+	}
+
+	err = g.gzipFile(m, rotated)
+	if err != nil {
+		m.Errorw("logrotate", "stage", "gzipFile", "err", err)
+	}
+
+	err = m.G().ConfigureLogging(m.Ctx())
+	if err != nil {
+		return err
+	}
+	m.Infow("logrotate", "stage", "done", "file", nm)
+	return nil
+}
+
+type RotatedLog struct {
+	Path      core.Path
+	Timestamp time.Time
+}
+
+func (g *LogRotate) FindRotatedLogs(m MetaContext, nm core.Path) ([]RotatedLog, error) {
+	parent := nm.Dir()
+	files, err := parent.ReadDir()
+	if err != nil {
+		return nil, err
+	}
+	rxx := regexp.MustCompile("^" + nm.Base().String() + `\.(\d{14})\.gz$`)
+	var ret []RotatedLog
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		matches := rxx.FindStringSubmatch(file.Name())
+		if matches == nil {
+			continue
+		}
+		timestamp := matches[1]
+		t, err := time.Parse("20060102150405", timestamp)
+		if err != nil {
+			m.Warnw("logrotate", "stage", "FindRotatedLogs", "err", err, "file", file.Name())
+			continue
+		}
+		ret = append(ret, RotatedLog{
+			Path:      parent.JoinStrings(file.Name()),
+			Timestamp: t,
+		})
+	}
+	return ret, nil
+}
+
+func (g *LogRotate) ageOut(m MetaContext, nm core.Path) error {
+
+	logs, err := g.FindRotatedLogs(m, nm)
+	if err != nil {
+		return err
+	}
+	now := m.G().Now()
+	for _, log := range logs {
+		if now.Sub(log.Timestamp) < 7*24*time.Hour {
+			m.Debugw("logrotate", "stage", "ageOut", "file", log.Path, "action", "keep")
+			continue
+		}
+		m.Debugw("logrotate", "stage", "ageOut", "file", log.Path, "action", "delete")
+		err := log.Path.Remove()
+		if err != nil {
+			m.Errorw("logrotate", "stage", "ageOut", "err", err, "file", log.Path)
+		}
+	}
+	return nil
+}
+
+func (g *LogRotate) Run(m MetaContext) error {
+	m = m.WithLogTag("logrotate")
+	ch := make(chan struct{})
+	pokeCh := make(chan struct{})
+	g.stopper = ch
+	g.pokeCh = pokeCh
+	go func() {
+		g.bgLoop(m, ch, pokeCh)
+	}()
+	return nil
+}
+
+func (g *LogRotate) Poke() {
+	if g.pokeCh != nil {
+		g.pokeCh <- struct{}{}
+	}
+}
+
+func (g *LogRotate) Stop() {
+	if g.stopper != nil {
+		tmp := g.stopper
+		g.stopper = nil
+		close(tmp)
+	}
+}
+
+func (g *LogRotate) bgLoop(m MetaContext, stopCh chan struct{}, pokeCh <-chan struct{}) {
+	m = m.Background()
+	m = m.WithLogTag("logrotate")
+
+	for {
+		wait, err := g.timeUntilLogRotate(m)
+		if err != nil {
+			m.Errorw("logrotate", "stage", "timeUntilLogRotate", "err", err)
+		}
+		select {
+		case <-stopCh:
+			m.Debugw("logrotate", "stage", "stop")
+			return
+		case <-pokeCh:
+			m.Debugw("logrotate", "stage", "poke")
+		case <-m.Ctx().Done():
+			m.Warnw("logrotate", "stage", "ctxDone", "err", m.Ctx().Err())
+			return
+		case <-m.G().After(wait):
+			m.Debugw("logrotate", "stage", "start")
+			err := g.doLogRotate(m)
+			if err != nil {
+				m.Errorw("logrotate", "stage", "doLogRotate", "err", err)
+			}
+		}
+	}
+}

--- a/integration-tests/cli/log_test.go
+++ b/integration-tests/cli/log_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/keybase/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogRotations(t *testing.T) {
+	agent := newTestAgent(t)
+	agent.runAgent(t)
+	defer agent.stop(t)
+
+	m := libclient.NewMetaContextBackground(agent.g)
+
+	line := 1
+	spew := func() {
+		m.Infow("test log", "cmd", line)
+		line++
+	}
+	cl := clockwork.NewFakeClock()
+	orig := m.G().Clock()
+	m.G().SetClock(cl)
+	defer m.G().SetClock(orig)
+
+	lr := m.G().LogRotate()
+
+	// After setting the new clock, we need to poke the log rotate loop
+	// to pick up the new clock.
+	lr.Poke()
+
+	for range 10 {
+		spew()
+	}
+
+	countLines := func(b []byte) int {
+		lines := 0
+		for _, c := range b {
+			if c == '\n' {
+				lines++
+			}
+		}
+		return lines
+	}
+
+	gunzip := func(p core.Path) []byte {
+		file, err := p.ReadFile()
+		require.NoError(t, err)
+		var b bytes.Buffer
+		_, err = b.Write(file)
+		require.NoError(t, err)
+		r, err := gzip.NewReader(&b)
+		require.NoError(t, err)
+		defer r.Close()
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		return data
+	}
+
+	countRotatedLogs := func(expected int) {
+		file, err := m.G().OutLogPath()
+		require.NoError(t, err)
+		logs, err := lr.FindRotatedLogs(m, file)
+		require.NoError(t, err)
+		require.Equal(t, expected, len(logs))
+		for _, log := range logs {
+			data := gunzip(log.Path)
+			lines := countLines(data)
+			require.Greater(t, lines, 1) // need at least two lines in each rotated log
+		}
+	}
+
+	readLog := func(low int, high int) {
+		_ = m.G().LogSync()
+		file, err := m.G().OutLogPath()
+		require.NoError(t, err)
+		data, err := file.ReadFile()
+		require.NoError(t, err)
+		lines := countLines(data)
+		require.GreaterOrEqual(t, lines, low)
+		require.LessOrEqual(t, lines, high)
+	}
+
+	readLog(10, 20)
+	countRotatedLogs(0)
+
+	ch := make(chan struct{})
+	lr.WaitForNextRotate(ch)
+
+	cl.Advance(25 * time.Hour) // Advance the clock by 24 hours to trigger log rotation
+
+	<-ch // Wait for the log rotation to complete
+	for range 3 {
+		spew()
+	}
+
+	// log rotation should add one line to the new log
+	readLog(4, 6)
+	countRotatedLogs(1)
+
+}

--- a/lib/core/path.go
+++ b/lib/core/path.go
@@ -148,3 +148,42 @@ func Getwd() (Path, error) {
 	}
 	return Path(cwd), nil
 }
+
+func (p Path) Rename(newPath Path) error {
+	if p.IsNil() {
+		return errors.New("cannot rename nil path")
+	}
+	if newPath.IsNil() {
+		return errors.New("cannot rename to nil path")
+	}
+	return os.Rename(p.String(), newPath.String())
+}
+
+func (p Path) ReadDir() ([]os.DirEntry, error) {
+	return os.ReadDir(p.String())
+}
+
+func (p Path) AddSuffix(suffix string) Path {
+	if p.IsNil() {
+		return p
+	}
+	return Path(p.String() + suffix)
+}
+
+func (p Path) Create() (*os.File, error) {
+	if p.IsNil() {
+		return nil, errors.New("cannot create file at nil path")
+	}
+	return os.Create(p.String())
+}
+
+func (p Path) Open() (*os.File, error) {
+	if p.IsNil() {
+		return nil, errors.New("cannot open file at nil path")
+	}
+	f, err := os.Open(p.String())
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}


### PR DESCRIPTION
- simple log rotation for the client, without any real tunable constants, but we might consider more in the future, like:
  - tunable time, tunable # of logs kept, and tunable gzip compression of old logs
- gzip happens now all the time on rotated logs
- partial close of #119, we still need to build logsend
