### PR TITLE
logsend feature

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -9,6 +9,8 @@ changelog:
     changes:
       - desc: cli - log rotation for agent logs (not for error, just for output)
         closes: []
+      - desc: logsend feature for debugging problems
+        closes: ["#119"]
   - version: 0.0.21
     urgency: low
     stable: false

--- a/client/agent/general.go
+++ b/client/agent/general.go
@@ -157,6 +157,8 @@ func (c *AgentConn) PutServer(ctx context.Context, arg lcl.PutServerArg) (proto.
 	if err != nil {
 		return ret, err
 	}
+	// In case we need to debug a failed login, we hold onto the last registered server.
+	m.G().SetLastServer(prb)
 	sess.homeServer = prb
 	sess.ssoCfg = cfg.Sso
 	sess.regServerType = arg.Typ

--- a/client/agent/logsend.go
+++ b/client/agent/logsend.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+func (a *AgentConn) LogSend(
+	ctx context.Context,
+	arg lcl.LogSendSet,
+) (lcl.LogSendRes, error) {
+	var zed lcl.LogSendRes
+	logs := core.Map(arg.Files, func(p proto.LocalFSPath) core.Path {
+		return core.ImportPath(p)
+	})
+	m := a.MetaContext(ctx)
+	res, err := libclient.LogSend(m, logs)
+	if err != nil {
+		return zed, err
+	}
+	return *res, nil
+}
+
+func (a *AgentConn) LogSendList(
+	ctx context.Context,
+	n uint64,
+) (
+	lcl.LogSendSet,
+	error,
+) {
+	var zed lcl.LogSendSet
+	m := a.MetaContext(ctx)
+	logs, err := libclient.ListLatestLogs(m, int(n))
+	if err != nil {
+		return zed, err
+	}
+	return lcl.LogSendSet{
+		Files: core.Map(logs, func(p core.Path) proto.LocalFSPath { return p.Export() }),
+	}, nil
+}
+
+var _ lcl.LogSendInterface = (*AgentConn)(nil)

--- a/client/agent/srv.go
+++ b/client/agent/srv.go
@@ -255,6 +255,7 @@ func (c *AgentConn) Serve(m libclient.MetaContext) {
 		lcl.AdminProtocol(c),
 		lcl.UtilProtocol(c),
 		lcl.KeyProtocol(c),
+		lcl.LogSendProtocol(c),
 	}
 	otherProtocols := OtherProtocols(c)
 	protocols = append(protocols, otherProtocols...)

--- a/client/foks/cmd/logsend.go
+++ b/client/foks/cmd/logsend.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/client/libterm"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	"github.com/spf13/cobra"
+)
+
+func logsendCmd(m libclient.MetaContext) *cobra.Command {
+	var nLogs int
+	ret := &cobra.Command{
+		Use:   "logsend",
+		Short: "Send logs to FOKS developers",
+		Long: libterm.MustRewrapSense(`Send FOKS logs to the developer team to
+help debug. FOKS logs do not comatin any sensitive data, but we ask users to check them
+before sending, just to be sure.`, 0),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogSend(m, args, nLogs)
+		},
+	}
+	ret.Flags().IntVarP(&nLogs, "num-logs", "n", 3, "max number of logs to send")
+	return ret
+}
+
+func runLogSend(m libclient.MetaContext, args []string, nLogs int) error {
+	cli, clean, err := quickStart[lcl.LogSendClient](m, nil)
+	if err != nil {
+		return err
+	}
+	defer clean()
+	if len(args) != 0 {
+		return ArgsError("no args allowed")
+	}
+	if nLogs < 1 {
+		return ArgsError("num-logs must be at least 1")
+	}
+	if nLogs > 30 {
+		return ArgsError("num-logs must be at most 30")
+	}
+	sl, err := cli.LogSendList(m.Ctx(), uint64(nLogs))
+	if err != nil {
+		return err
+	}
+	if len(sl.Files) == 0 {
+		return core.NotFoundError("no logs found")
+	}
+	lsui := m.G().UIs().LogSend
+	err = lsui.ApproveLogs(m, sl)
+	if err != nil {
+		return err
+	}
+	_ = lsui.ShowStartSend(m)
+	res, err := cli.LogSend(m.Ctx(), sl)
+	_ = lsui.ShowCompleteSend(m, err)
+	if err != nil {
+		return err
+	}
+	err = lsui.ShowLogSendRes(m, res)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	AddCmd(logsendCmd)
+}

--- a/client/foks/cmd/simple_ui/logsend.go
+++ b/client/foks/cmd/simple_ui/logsend.go
@@ -1,0 +1,77 @@
+package simple_ui
+
+import (
+	"fmt"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/client/libterm"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	"github.com/manifoldco/promptui"
+)
+
+type LogSendUI struct {
+	spinner *Spinner
+}
+
+func (s *LogSendUI) Outputf(f string, args ...interface{}) {
+	fmt.Printf(f, args...)
+}
+
+func (l *LogSendUI) ApproveLogs(m libclient.MetaContext, logs lcl.LogSendSet) error {
+	l.Outputf("🔍 Sending the following logs for analysis:\n\n")
+	for _, log := range logs.Files {
+		l.Outputf("    - %s\n", log)
+	}
+	l.Outputf("\n")
+	l.Outputf(
+		libterm.MustRewrapSense(
+			`Feel free to examine your logs to be certain that you are comfortable
+sharing their contents with the FOKS developers. We are careful to exclude sensitive data
+from logs, but please check our work. If you notice any sensitive data in these logs, do not send and please file a GitHub issue.
+Thank you for helping us to improve this software.`, 0),
+	)
+	l.Outputf("\n")
+
+	prompt := promptui.Select{
+		Label: "Go ahead and share logs with the developers?",
+		Items: []string{
+			"❌ No, forget it",
+			"✅ Yes, send them",
+		},
+	}
+	idx, _, err := prompt.Run()
+	if err != nil {
+		return err
+	}
+	if idx == 0 {
+		return core.CanceledInputError{}
+	}
+	return nil
+}
+
+func (l *LogSendUI) ShowLogSendRes(m libclient.MetaContext, res lcl.LogSendRes) error {
+	l.Outputf("✅ Logs sent successfully; please relay these details to the developer you are working with!\n")
+	l.Outputf(" - Id: %s\n", res.Id.String())
+	l.Outputf(" - Server: %s\n", res.Host.String())
+	return nil
+}
+
+func (l *LogSendUI) ShowStartSend(m libclient.MetaContext) error {
+	l.spinner = NewSpinner("Sending logs...")
+	l.spinner.Start()
+	return nil
+}
+
+func (l *LogSendUI) ShowCompleteSend(m libclient.MetaContext, err error) error {
+	var msg string
+	if err != nil {
+		msg = fmt.Sprintf(" ❌ Log send failed: %v", err)
+	} else {
+		msg = " 🎉 success"
+	}
+	l.spinner.Stop(msg)
+	return nil
+}
+
+var _ libclient.LogSendUIer = &LogSendUI{}

--- a/client/foks/cmd/simple_ui/setup.go
+++ b/client/foks/cmd/simple_ui/setup.go
@@ -13,5 +13,6 @@ func Setup() libclient.UIs {
 		Backup:     &BackupUI{},
 		SSOLogin:   &SSOLoginUI{},
 		PIN:        &PINUI{},
+		LogSend:    &LogSendUI{},
 	}
 }

--- a/client/foks/cmd/simple_ui/spinner.go
+++ b/client/foks/cmd/simple_ui/spinner.go
@@ -1,0 +1,57 @@
+package simple_ui
+
+import (
+	"fmt"
+	"time"
+)
+
+type Spinner struct {
+	Msg string
+	Ch  chan struct{}
+}
+
+func NewSpinner(msg string) *Spinner {
+	return &Spinner{
+		Msg: msg,
+		Ch:  make(chan struct{}),
+	}
+}
+
+func (s *Spinner) spinner() {
+	spinners := []string{
+		"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏",
+	}
+	spinIdx := 0
+
+	print := func() {
+		if s.Msg != "" {
+			fmt.Printf("\r%s %s", s.Msg, spinners[spinIdx])
+		} else {
+			fmt.Printf("\r%s", spinners[spinIdx])
+		}
+		spinIdx = (spinIdx + 1) % len(spinners)
+	}
+
+	print()
+	for {
+		select {
+		case <-s.Ch:
+			return
+		default:
+			print()
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+func (s *Spinner) Start() {
+	go s.spinner()
+}
+
+func (s *Spinner) Stop(msg string) {
+	if s.Ch != nil {
+		close(s.Ch)
+		s.Ch = nil
+	}
+	fmt.Printf("\r%s %s\n", s.Msg, msg)
+}

--- a/client/libclient/logsend.go
+++ b/client/libclient/logsend.go
@@ -1,0 +1,253 @@
+package libclient
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha512"
+	"strings"
+
+	"github.com/foks-proj/go-foks/lib/chains"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+)
+
+type ChunkedLog struct {
+	Path   core.Path
+	Blocks []rem.LogSendBlob
+	Hash   proto.StdHash
+	Len    int
+	Data   []byte
+}
+
+func (c *ChunkedLog) compressIfNeeded() error {
+	if strings.HasSuffix(c.Path.Base().String(), ".gz") {
+		return nil // already compressed
+	}
+	dat, err := c.Path.ReadFile()
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err = gz.Write(dat)
+	if err != nil {
+		return err
+	}
+	err = gz.Close()
+	if err != nil {
+		return err
+	}
+	if buf.Len() >= len(dat) {
+		// Compression didn't help, so we won't use it.
+		return nil
+	}
+	c.Data = buf.Bytes()
+	c.Path = core.Path(c.Path.String() + ".gz")
+
+	return nil
+}
+
+func ChunkLog(
+	m MetaContext,
+	path core.Path,
+) (
+	*ChunkedLog,
+	error,
+) {
+	dat, err := path.ReadFile()
+	if err != nil {
+		return nil, err
+	}
+	ret := &ChunkedLog{
+		Path: path,
+		Len:  len(dat),
+		Data: dat,
+	}
+	err = ret.compressIfNeeded()
+	if err != nil {
+		return nil, err
+	}
+	// Might have been compressed, so we need to re-read the data.
+	dat = ret.Data
+
+	h := sha512.New512_256()
+	_, err = h.Write(dat)
+	if err != nil {
+		return nil, err
+	}
+	tmp := h.Sum(nil)
+	if len(tmp) != len(ret.Hash) {
+		return nil, core.InternalError("hash len mismatch")
+	}
+	copy(ret.Hash[:], tmp)
+	chunkSize := 4 * 1024 * 1024 // 4 MiB
+
+	for i := 0; i < len(dat); i += chunkSize {
+		end := min(i+chunkSize, len(dat))
+		chunk := rem.LogSendBlob(dat[i:end])
+		ret.Blocks = append(ret.Blocks, chunk)
+	}
+	return ret, nil
+}
+
+func ListLatestLogs(m MetaContext, n int) ([]core.Path, error) {
+	if n <= 0 {
+		return nil, core.InternalError("bad arguments to ListLatestLogs: n must be > 0")
+	}
+	nm, err := m.G().OutLogPath()
+	if err != nil {
+		return nil, err
+	}
+	var ret []core.Path
+	ret = append(ret, nm)
+	n--
+	if n <= 0 {
+		return ret, nil
+	}
+
+	logs, err := FindRotatedLogs(m, nm)
+	if err != nil {
+		return nil, err
+	}
+	for _, log := range logs {
+		if n <= 0 {
+			break
+		}
+		ret = append(ret, log.Path)
+		n--
+	}
+	return ret, err
+
+}
+
+type logSender struct {
+	logs []core.Path
+	srv  *chains.Probe
+	cli  rem.LogSendClient
+	id   proto.LogSendID
+}
+
+func (l *logSender) run(m MetaContext) error {
+
+	err := l.getServer(m)
+	if err != nil {
+		return err
+	}
+	err = l.initSession(m)
+	if err != nil {
+		return err
+	}
+	for i, log := range l.logs {
+		err = l.sendLog(m, i, log)
+		if err != nil {
+			m.Errorw("logsend failed", "err", err, "log", log)
+		}
+	}
+	return nil
+}
+
+func (l *logSender) sendLog(m MetaContext, idx int, log core.Path) error {
+	clog, err := ChunkLog(m, log)
+	if err != nil {
+		return err
+	}
+	nm := clog.Path.Base()
+	fid := rem.LogSendFileID(idx)
+	m.Infow("logsend", "id", l.id, "log", nm, "fileid", fid, "nchunks", len(clog.Blocks), "hash", clog.Hash, "stage", "sending")
+
+	err = l.cli.LogSendInitFile(m.Ctx(), rem.LogSendInitFileArg{
+		Id:      l.id,
+		FileID:  fid,
+		Name:    nm.Export(),
+		Len:     proto.Size(clog.Len),
+		NBlocks: uint64(len(clog.Blocks)),
+		Hash:    clog.Hash,
+	})
+	if err != nil {
+		return err
+	}
+	m.Infow("logsend", "id", l.id, "fileid", fid, "name", nm, "stage", "sent")
+	for i, block := range clog.Blocks {
+		m.Debugw("logsend", "id", l.id, "fileid", fid, "blockno", i, "stage", "sending block")
+		err = l.cli.LogSendUploadBlock(m.Ctx(), rem.LogSendUploadBlockArg{
+			Id:      l.id,
+			FileID:  fid,
+			BlockNo: uint64(i),
+			Block:   rem.LogSendBlob(block),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *logSender) initSession(m MetaContext) error {
+	id, err := l.cli.LogSendInit(m.Ctx())
+	if err != nil {
+		return err
+	}
+	l.id = id
+	hn, err := l.srv.HostnameWithOptionalPort()
+	if err != nil {
+		return err
+	}
+	m.Infow("logsend", "id", l.id, "server", hn)
+	return nil
+
+}
+
+func LogSend(m MetaContext, logs []core.Path) (*lcl.LogSendRes, error) {
+	m = m.WithLogTag("logsend")
+	ls := &logSender{
+		logs: logs,
+	}
+	err := ls.run(m)
+	if err != nil {
+		return nil, err
+	}
+	hn, err := ls.srv.HostnameWithOptionalPort()
+	if err != nil {
+		m.Warnw("logsend", "stage", "gethostname", "err", err)
+		hn = "-"
+	}
+	res := &lcl.LogSendRes{
+		Id:   ls.id,
+		Host: proto.TCPAddr(hn),
+	}
+	return res, nil
+}
+
+func (l *logSender) getServer(m MetaContext) error {
+	au := m.G().ActiveUser()
+
+	// If active user, then let's connect to that server and then use a logged-in
+	if au != nil {
+		gcli, err := au.UserGCli(m)
+		if err != nil {
+			return err
+		}
+		l.cli = core.NewLogSendClient(gcli, m)
+		l.srv = au.HomeServer()
+		return nil
+	}
+
+	srv := m.G().GetLastServer()
+	if srv == nil {
+		return core.NoDefaultHostError{}
+	}
+
+	// Otherwise, we'll connect to the reg server at the last server, and we have something
+	// to try
+	rcli, err := srv.RegGCli(m)
+	if err != nil {
+		return err
+	}
+	l.cli = core.NewLogSendClient(rcli, m)
+	l.srv = srv
+
+	return nil
+}

--- a/client/libclient/uis.go
+++ b/client/libclient/uis.go
@@ -100,6 +100,13 @@ type SSOLoginUIer interface {
 	ShowSSOLoginResult(m MetaContext, res proto.SSOLoginRes, err error) error
 }
 
+type LogSendUIer interface {
+	ShowStartSend(m MetaContext) error
+	ShowCompleteSend(m MetaContext, err error) error
+	ApproveLogs(m MetaContext, log lcl.LogSendSet) error
+	ShowLogSendRes(m MetaContext, res lcl.LogSendRes) error
+}
+
 type UIs struct {
 	Signup     SignupUIer
 	Terminal   TerminalUIer
@@ -108,4 +115,5 @@ type UIs struct {
 	Backup     BackupUIer
 	SSOLogin   SSOLoginUIer
 	PIN        PINUIer
+	LogSend    LogSendUIer
 }

--- a/lib/core/clockwrap.go
+++ b/lib/core/clockwrap.go
@@ -1,0 +1,69 @@
+package core
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/clockwork"
+)
+
+// ClockWrap works around inherent race conditions in the Clockwork
+// paradigm. The issue is this interleaving:
+//
+//	Go Routine 1: compute sleep duration
+//	Go Routine 2: clock.Advance()
+//	Go Routine 1: After(duration)
+//
+// Now there is no way to wake up GoRoutine 1. If only there was a way to check
+// the time right before the After call in Go Routine 1, but the library
+// doesn't allow for this. We need a different paradigm.
+type ClockWrap struct {
+	sync.Mutex
+	cl clockwork.Clock
+	st ClockWrapState
+}
+
+type ClockWrapState struct {
+	i int
+}
+
+func NewClockWrap(cl clockwork.Clock) *ClockWrap {
+	return &ClockWrap{
+		cl: cl,
+	}
+}
+
+func (c *ClockWrap) At(t time.Time) <-chan time.Time {
+	c.Lock()
+	defer c.Unlock()
+	now := c.cl.Now()
+	diff := t.Sub(now)
+	if diff <= 0 {
+		ret := make(chan time.Time, 1)
+		ret <- now
+		return ret
+	}
+	return c.cl.After(diff)
+}
+
+func (c *ClockWrap) PushTo(t time.Time, st *ClockWrapState) error {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.st.i != st.i {
+		return InternalError("ClockWrap.Advance called with stale state; fighting go-routines?")
+	}
+
+	fake, ok := c.cl.(clockwork.FakeClock)
+	if !ok {
+		return InternalError("ClockWrap.Advance can only be used with FakeClock")
+	}
+	now := fake.Now()
+	c.st.i++
+	diff := t.Sub(now)
+	if diff <= 0 {
+		return nil
+	}
+	fake.Advance(diff)
+	return nil
+}

--- a/lib/core/compat.go
+++ b/lib/core/compat.go
@@ -152,3 +152,12 @@ func NewBeaconClient(gcli rpc.GenericClient, wcw WithContextWarner) rem.BeaconCl
 		CheckResHeader: MakeCheckProtoResHeader(wcw),
 	}
 }
+
+func NewLogSendClient(gcli rpc.GenericClient, wcw WithContextWarner) rem.LogSendClient {
+	return rem.LogSendClient{
+		Cli:            gcli,
+		ErrorUnwrapper: StatusToError,
+		MakeArgHeader:  MakeProtoHeader,
+		CheckResHeader: MakeCheckProtoResHeader(wcw),
+	}
+}

--- a/lib/core/path.go
+++ b/lib/core/path.go
@@ -8,6 +8,9 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
+
+	proto "github.com/foks-proj/go-foks/proto/lib"
 )
 
 type Path string
@@ -186,4 +189,31 @@ func (p Path) Open() (*os.File, error) {
 		return nil, err
 	}
 	return f, nil
+}
+
+func ImportPath(p proto.LocalFSPath) Path {
+	return Path(p.String())
+}
+
+func (p Path) Export() proto.LocalFSPath {
+	return proto.LocalFSPath(p.String())
+}
+
+func (p Path) IsBadFilename() bool {
+	s := p.String()
+	if strings.Contains(s, "..") || strings.Contains(s, "/") || strings.Contains(s, "\\") {
+		return true
+	}
+	return false
+}
+
+func (p Path) StripSuffix(suffix string) (bool, Path) {
+	if !strings.HasSuffix(p.String(), suffix) {
+		return false, p
+	}
+	newPath := strings.TrimSuffix(p.String(), suffix)
+	if newPath == "" {
+		return false, ""
+	}
+	return true, Path(newPath)
 }

--- a/proto-src/lcl/logsend.snowp
+++ b/proto-src/lcl/logsend.snowp
@@ -1,0 +1,27 @@
+@0xb2998bcf3537010f;
+
+go:import "github.com/foks-proj/go-foks/proto/lib" as lib;
+
+struct LogSendSet {
+    files @0 : List(lib.LocalFSPath);
+}
+
+struct LogSendRes {
+    id @0 : lib.LogSendID;
+    host @1 : lib.TCPAddr;
+}
+
+protocol LogSend
+    errors lib.Status
+    argHeader Header
+    resHeader Header @0xfeb332f6 {
+
+    logSendList @1 (
+        n @0 : Uint
+    ) -> LogSendSet;
+
+    logSend @2 (
+        set @0 : LogSendSet
+    ) -> LogSendRes;
+
+}

--- a/proto-src/lib/common.snowp
+++ b/proto-src/lib/common.snowp
@@ -105,6 +105,7 @@ typedef AutocertID = Blob(17);
 typedef OAuth2SessionID = Blob(17);
 typedef SSOConfigID = Blob(17);
 typedef CKSKeyID = Blob(17);
+typedef LogSendID = Blob(17);
 
 enum ID16Type {
     Plan @61; 
@@ -120,7 +121,8 @@ enum ID16Type {
     OAuth2Session @51;
     SSOConfig @50;
     CKSKey @49;
-    MaxEntityType @48;
+    LogSend @48; 
+    MaxEntityType @47;
 }
 
 // A stringified ID16 (with leading prefix).
@@ -131,6 +133,9 @@ typedef TeamRSVPString = Text;
 
 // A stringified OAuth2SessionID (with leading prefix).
 typedef OAuth2SessionIDString = Text;
+
+// A stringified LogSendID (with leading prefix).
+typedef LogSendIDString = Text;
 
 // Milliseconds since Jan 1, 1970.
 typedef Time = Uint;

--- a/proto-src/rem/logsend.snowp
+++ b/proto-src/rem/logsend.snowp
@@ -1,0 +1,32 @@
+@0x9e166032be524272;
+
+go:import "github.com/foks-proj/go-foks/proto/lib" as lib;
+
+typedef LogSendFileID = Uint;
+typedef LogSendBlob = Blob;
+
+protocol LogSend
+    errors lib.Status
+    argHeader lib.Header
+    resHeader lib.Header @0xfa4726d9 {
+
+    logSendInit @1 (
+    ) -> lib.LogSendID;
+
+    logSendInitFile @2 (
+        id @0 : lib.LogSendID,
+        fileID @1 : LogSendFileID,
+        name @2 : lib.LocalFSPath,
+        len @3 : lib.Size,
+        hash @4 : lib.StdHash,
+        nBlocks @5 : Uint 
+    );
+
+    logSendUploadBlock @3 (
+        id @0 : lib.LogSendID,
+        fileID @1 : LogSendFileID,
+        blockNo @2 : Uint,
+        block @3 : LogSendBlob
+    );
+
+}

--- a/proto/lcl/.gitignore
+++ b/proto/lcl/.gitignore
@@ -1,0 +1,1 @@
+logsend.go

--- a/proto/lib/common.go
+++ b/proto/lib/common.go
@@ -1670,6 +1670,41 @@ func (c CKSKeyID) Bytes() []byte {
 	return (c)[:]
 }
 
+type LogSendID [17]byte
+type LogSendIDInternal__ [17]byte
+
+func (l LogSendID) Export() *LogSendIDInternal__ {
+	tmp := (([17]byte)(l))
+	return ((*LogSendIDInternal__)(&tmp))
+}
+func (l LogSendIDInternal__) Import() LogSendID {
+	tmp := ([17]byte)(l)
+	return LogSendID((func(x *[17]byte) (ret [17]byte) {
+		if x == nil {
+			return ret
+		}
+		return *x
+	})(&tmp))
+}
+
+func (l *LogSendID) Encode(enc rpc.Encoder) error {
+	return enc.Encode(l.Export())
+}
+
+func (l *LogSendID) Decode(dec rpc.Decoder) error {
+	var tmp LogSendIDInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*l = tmp.Import()
+	return nil
+}
+
+func (l LogSendID) Bytes() []byte {
+	return (l)[:]
+}
+
 type ID16Type int
 
 const (
@@ -1686,7 +1721,8 @@ const (
 	ID16Type_OAuth2Session    ID16Type = 51
 	ID16Type_SSOConfig        ID16Type = 50
 	ID16Type_CKSKey           ID16Type = 49
-	ID16Type_MaxEntityType    ID16Type = 48
+	ID16Type_LogSend          ID16Type = 48
+	ID16Type_MaxEntityType    ID16Type = 47
 )
 
 var ID16TypeMap = map[string]ID16Type{
@@ -1703,7 +1739,8 @@ var ID16TypeMap = map[string]ID16Type{
 	"OAuth2Session":    51,
 	"SSOConfig":        50,
 	"CKSKey":           49,
-	"MaxEntityType":    48,
+	"LogSend":          48,
+	"MaxEntityType":    47,
 }
 var ID16TypeRevMap = map[ID16Type]string{
 	61: "Plan",
@@ -1719,7 +1756,8 @@ var ID16TypeRevMap = map[ID16Type]string{
 	51: "OAuth2Session",
 	50: "SSOConfig",
 	49: "CKSKey",
-	48: "MaxEntityType",
+	48: "LogSend",
+	47: "MaxEntityType",
 }
 
 type ID16TypeInternal__ ID16Type
@@ -1833,6 +1871,41 @@ func (o *OAuth2SessionIDString) Decode(dec rpc.Decoder) error {
 }
 
 func (o OAuth2SessionIDString) Bytes() []byte {
+	return nil
+}
+
+type LogSendIDString string
+type LogSendIDStringInternal__ string
+
+func (l LogSendIDString) Export() *LogSendIDStringInternal__ {
+	tmp := ((string)(l))
+	return ((*LogSendIDStringInternal__)(&tmp))
+}
+func (l LogSendIDStringInternal__) Import() LogSendIDString {
+	tmp := (string)(l)
+	return LogSendIDString((func(x *string) (ret string) {
+		if x == nil {
+			return ret
+		}
+		return *x
+	})(&tmp))
+}
+
+func (l *LogSendIDString) Encode(enc rpc.Encoder) error {
+	return enc.Encode(l.Export())
+}
+
+func (l *LogSendIDString) Decode(dec rpc.Decoder) error {
+	var tmp LogSendIDStringInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*l = tmp.Import()
+	return nil
+}
+
+func (l LogSendIDString) Bytes() []byte {
 	return nil
 }
 

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -1638,7 +1638,9 @@ func (u UID) StringErr() (string, error)                      { return u.EntityI
 func (h HostID) StringErr() (string, error)                   { return h.EntityID().StringErr() }
 func (t TeamID) StringErr() (string, error)                   { return t.EntityID().StringErr() }
 func (u UID) MarshalJSON() ([]byte, error)                    { return marsh(u) }
+func (u UID) MarshalYAML() (any, error)                       { return marsh(u) }
 func (h HostID) MarshalJSON() ([]byte, error)                 { return marsh(h) }
+func (h HostID) MarshalYAML() (any, error)                    { return marsh(h) }
 func (t TeamID) MarshalJSON() ([]byte, error)                 { return marsh(t) }
 func (y YubiID) StringErr() (string, error)                   { return y.EntityID().StringErr() }
 func (y YubiID) EntityID() EntityID                           { return EntityID(y[:]) }

--- a/proto/rem/.gitignore
+++ b/proto/rem/.gitignore
@@ -1,0 +1,1 @@
+logsend.go

--- a/server/engine/reg.go
+++ b/server/engine/reg.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lib"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
 	"github.com/foks-proj/go-foks/server/shared"
@@ -80,6 +81,7 @@ func (c *RegClientConn) RegisterProtocols(m shared.MetaContext, srv *rpc.Server)
 		rem.ProbeProtocol(c),
 		rem.TeamGuestProtocol(c),
 		rem.TeamLoaderProtocol(c),
+		rem.LogSendProtocol(c),
 	}
 	for _, p := range prots {
 		if err := srv.RegisterV2(p); err != nil {
@@ -1289,6 +1291,27 @@ func (c *RegClientConn) GetClientVersionInfo(
 	return ret, nil
 }
 
+func (c *RegClientConn) LogSendInit(ctx context.Context) (lib.LogSendID, error) {
+	return shared.LogSendInit(shared.NewMetaContextConn(ctx, c))
+}
+
+func (c *RegClientConn) LogSendInitFile(
+	ctx context.Context,
+	arg rem.LogSendInitFileArg,
+) error {
+	m := shared.NewMetaContextConn(ctx, c)
+	return shared.LogSendInitFile(m, arg)
+}
+
+func (c *RegClientConn) LogSendUploadBlock(
+	ctx context.Context,
+	arg rem.LogSendUploadBlockArg,
+) error {
+	m := shared.NewMetaContextConn(ctx, c)
+	return shared.LogSendUploadBlock(m, arg)
+}
+
 var _ rem.RegInterface = (*RegClientConn)(nil)
 var _ rem.KexInterface = (*RegClientConn)(nil)
 var _ rem.ProbeInterface = (*RegClientConn)(nil)
+var _ rem.LogSendInterface = (*RegClientConn)(nil)

--- a/server/engine/user.go
+++ b/server/engine/user.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/proto/infra"
+	"github.com/foks-proj/go-foks/proto/lib"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
 	"github.com/foks-proj/go-foks/server/shared"
@@ -80,6 +81,7 @@ func (c *UserClientConn) RegisterProtocols(m shared.MetaContext, srv *rpc.Server
 		rem.TeamAdminProtocol(c),
 		rem.TeamLoaderProtocol(c),
 		rem.TeamMemberProtocol(c),
+		rem.LogSendProtocol(c),
 	}
 	for _, p := range prots {
 		err := srv.RegisterV2(p)
@@ -1470,6 +1472,27 @@ func (c *UserClientConn) GetAllYubiManagementKeys(
 	return ret, nil
 }
 
+func (c *UserClientConn) LogSendInitFile(
+	ctx context.Context,
+	arg rem.LogSendInitFileArg,
+) error {
+	m := shared.NewMetaContextConn(ctx, c)
+	return shared.LogSendInitFile(m, arg)
+}
+
+func (c *UserClientConn) LogSendUploadBlock(
+	ctx context.Context,
+	arg rem.LogSendUploadBlockArg,
+) error {
+	m := shared.NewMetaContextConn(ctx, c)
+	return shared.LogSendUploadBlock(m, arg)
+}
+
+func (c *UserClientConn) LogSendInit(ctx context.Context) (lib.LogSendID, error) {
+	return shared.LogSendInit(shared.NewMetaContextConn(ctx, c))
+}
+
 var _ rem.UserInterface = (*UserClientConn)(nil)
 var _ infra.TestServicesInterface = (*UserClientConn)(nil)
 var _ rem.ProbeInterface = (*UserClientConn)(nil)
+var _ rem.LogSendInterface = (*UserClientConn)(nil)

--- a/server/foks-tool/logsend.go
+++ b/server/foks-tool/logsend.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/foks-proj/go-foks/client/libterm"
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/server/shared"
+	"github.com/spf13/cobra"
+)
+
+type LogSendCommand struct {
+	CLIAppBase
+	Id  proto.LogSendID
+	Dir core.Path
+}
+
+func (l *LogSendCommand) CobraConfig() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logsend <id> [<dir>]",
+		Short: "Digest logs sent to FOKS server",
+		Long: libterm.MustRewrapSense(`Access packaged logs sent to the 
+FOKS server for debugging purposes. Supply a directory to dump the new logs to.
+If none is supplied, the logs will be dumped to the current directory. In any case,
+a subdirectory named after the logsend ID will be created.
+`, 0),
+	}
+}
+
+func (l *LogSendCommand) CheckArgs(args []string) error {
+	if len(args) < 1 || len(args) > 2 {
+		return core.BadArgsError("expected 1 or 2 arguments")
+	}
+	id, err := proto.LogSendIDString(args[0]).Parse()
+	if err != nil {
+		return err
+	}
+	l.Id = *id
+	if len(args) == 2 {
+		l.Dir = core.Path(args[1])
+	} else {
+		l.Dir = core.Path(".")
+	}
+	return nil
+}
+
+func (l *LogSendCommand) Run(m shared.MetaContext) error {
+
+	set, err := shared.LogSendReassemble(m, l.Id)
+	if err != nil {
+		return err
+	}
+
+	dir := l.Dir.Join(core.Path(fmt.Sprintf("logsend-%s", l.Id.String())))
+	if err := dir.Mkdir(0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+	if err := dir.Chdir(); err != nil {
+		return err
+	}
+
+	type Md struct {
+		HostID proto.HostID    `json:"host_id"`
+		ID     proto.LogSendID `json:"id"`
+		UID    *proto.UID      `json:"uid,omitempty"`
+	}
+
+	metaData := Md{
+		HostID: set.HostID,
+		ID:     set.ID,
+		UID:    set.UID,
+	}
+	out, err := json.MarshalIndent(metaData, "", "  ")
+	if err != nil {
+		return err
+	}
+	err = dir.Join(core.Path("metadata.json")).WriteFile(out, 0644)
+	if err != nil {
+		return err
+	}
+	for _, file := range set.Files {
+		fn := core.ImportPath(file.Name)
+
+		// check the name for malicious content that would write outside the directory
+		if fn.IsBadFilename() {
+			return fmt.Errorf("invalid file name %q in logsend %s", file.Name, l.Id.String())
+		}
+		fpath := dir.Join(core.Path(file.Name))
+		err = fpath.WriteFile(file.RawData, 0644)
+		if err != nil {
+			return err
+		}
+		isGzip, basename := fn.StripSuffix(".gz")
+		if len(file.ExpandedData) > 0 && isGzip {
+			fpath = dir.Join(core.Path(basename))
+			err = fpath.WriteFile(file.ExpandedData, 0644)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (l *LogSendCommand) SetGlobalContext(g *shared.GlobalContext) {}
+
+var _ shared.CLIApp = (*LogSendCommand)(nil)
+
+func init() {
+	AddCmd(&LogSendCommand{})
+}

--- a/server/shared/logsend.go
+++ b/server/shared/logsend.go
@@ -1,0 +1,394 @@
+package shared
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lib"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+	"github.com/jackc/pgx/v5"
+)
+
+func LogSendInit(
+	m MetaContext,
+) (
+	proto.LogSendID,
+	error,
+) {
+	var zed proto.LogSendID
+	id, err := proto.NewLogSendID()
+	if err != nil {
+		return zed, err
+	}
+	db, err := m.Db(DbTypeUsers)
+	if err != nil {
+		return zed, err
+	}
+	var uidBytes []byte
+	if !m.UID().IsZero() {
+		uidBytes = m.UID().ExportToDB()
+	}
+	defer db.Release()
+	tag, err := db.Exec(
+		m.Ctx(),
+		`INSERT INTO log_send (short_host_id, id, uid, ctime) 
+		VALUES ($1, $2, $3, NOW())`,
+		m.ShortHostID().ExportToDB(),
+		id.ExportToDB(),
+		uidBytes,
+	)
+	if err != nil {
+		return zed, err
+	}
+	if tag.RowsAffected() != 1 {
+		return zed, core.InsertError("log_send")
+	}
+	return *id, nil
+}
+
+func LogSendInitFile(
+	m MetaContext,
+	arg rem.LogSendInitFileArg,
+) error {
+
+	return RetryTxUserDB(m, "LogSendInitFile", func(m MetaContext, tx pgx.Tx) error {
+		var dummy int
+		err := tx.QueryRow(
+			m.Ctx(),
+			"SELECT 1 FROM log_send WHERE short_host_id = $1 AND id = $2",
+			m.ShortHostID().ExportToDB(),
+			arg.Id.ExportToDB(),
+		).Scan(&dummy)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return core.NotFoundError("log_send")
+		}
+		if err != nil {
+			return err
+		}
+
+		tag, err := tx.Exec(
+			m.Ctx(),
+			`INSERT INTO log_send_files 
+			(short_host_id, ls_id, file_id, filename, len, nblocks, hsh, ctime)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())`,
+			m.ShortHostID().ExportToDB(),
+			arg.Id.ExportToDB(),
+			int(arg.FileID),
+			arg.Name,
+			int(arg.Len),
+			int(arg.NBlocks),
+			arg.Hash.ExportToDB(),
+		)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			return core.InsertError("log_send_files")
+		}
+		return nil
+	})
+}
+
+func LogSendUploadBlock(
+	m MetaContext,
+	arg rem.LogSendUploadBlockArg,
+) error {
+	return RetryTxUserDB(m, "LogSendUploadBlock", func(m MetaContext, tx pgx.Tx) error {
+		var nblocks int
+		err := tx.QueryRow(
+			m.Ctx(),
+			`SELECT nblocks FROM log_send_files WHERE short_host_id = $1 AND ls_id=$2 AND file_id = $3`,
+			m.ShortHostID().ExportToDB(),
+			arg.Id.ExportToDB(),
+			int(arg.FileID),
+		).Scan(&nblocks)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return core.NotFoundError("log_send_files")
+		}
+		if err != nil {
+			return err
+		}
+		if int(arg.BlockNo) >= nblocks {
+			return core.BadArgsError("block number out of range")
+		}
+		tag, err := tx.Exec(
+			m.Ctx(),
+			`INSERT INTO log_send_blocks 
+			(short_host_id, ls_id, file_id, block_id, block)
+			VALUES ($1, $2, $3, $4, $5)`,
+			m.ShortHostID().ExportToDB(),
+			arg.Id.ExportToDB(),
+			int(arg.FileID),
+			int(arg.BlockNo),
+			arg.Block[:],
+		)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() != 1 {
+			return core.InsertError("log_send_blocks")
+		}
+		return nil
+	})
+}
+
+type LogSendFile struct {
+	Name         lib.LocalFSPath
+	RawData      []byte
+	ExpandedData []byte
+}
+
+type LogSendSet struct {
+	HostID proto.HostID
+	UID    *proto.UID
+	ID     proto.LogSendID
+	Files  []LogSendFile
+}
+
+type logSendFile struct {
+	FileID       rem.LogSendFileID
+	Name         string
+	Len          int
+	NBlocks      int
+	Hash         proto.StdHash
+	Data         []byte
+	ExpandedData []byte
+}
+
+type logSetReassembler struct {
+	id     proto.LogSendID
+	hostid *core.HostID
+	uid    *proto.UID
+	files  []*logSendFile
+}
+
+func (l *logSetReassembler) run(m MetaContext) error {
+	err := l.fetchMetadata(m)
+	if err != nil {
+		return err
+	}
+	err = l.fetchFiles(m)
+	if err != nil {
+		return err
+	}
+	for _, file := range l.files {
+		err = l.fetchBlocks(m, file)
+		if err != nil {
+			return err
+		}
+		err = file.expand()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *logSetReassembler) res() *LogSendSet {
+	ret := LogSendSet{
+		HostID: l.hostid.Id,
+		UID:    l.uid,
+		ID:     l.id,
+	}
+	for _, file := range l.files {
+		ret.Files = append(ret.Files, LogSendFile{
+			Name:         lib.LocalFSPath(file.Name),
+			RawData:      file.Data,
+			ExpandedData: file.ExpandedData,
+		})
+	}
+	return &ret
+}
+
+func LogSendReassemble(
+	m MetaContext,
+	id proto.LogSendID,
+) (
+	*LogSendSet,
+	error,
+) {
+	l := &logSetReassembler{id: id}
+	err := l.run(m)
+	if err != nil {
+		return nil, err
+	}
+	return l.res(), nil
+}
+
+func (l *logSetReassembler) fetchBlocks(
+	m MetaContext,
+	file *logSendFile,
+) error {
+	db, err := m.Db(DbTypeUsers)
+	if err != nil {
+		return err
+	}
+	defer db.Release()
+
+	rows, err := db.Query(
+		m.Ctx(),
+		`SELECT block_id, block
+		FROM log_send_blocks 
+		WHERE short_host_id = $1 AND ls_id = $2 AND file_id = $3 
+		ORDER BY block_id`,
+		l.hostid.Short.ExportToDB(),
+		l.id.ExportToDB(),
+		int(file.FileID),
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	blocks := make([][]byte, file.NBlocks)
+	blockCount := 0
+
+	for rows.Next() {
+		var blockID int
+		var data []byte
+		err := rows.Scan(&blockID, &data)
+		if err != nil {
+			return err
+		}
+
+		if blockID < 0 || blockID >= file.NBlocks {
+			return core.NotFoundError("block ID out of range")
+		}
+
+		if blocks[blockID] != nil {
+			return core.DuplicateError("duplicate block")
+		}
+
+		blocks[blockID] = data
+		blockCount++
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	if blockCount != file.NBlocks {
+		return core.NotFoundError("missing blocks")
+	}
+
+	var result []byte
+	for i, block := range blocks {
+		if block == nil {
+			return core.NotFoundError(fmt.Sprintf("missing block %d", i))
+		}
+		result = append(result, block...)
+	}
+	file.Data = result
+	return nil
+}
+
+func (l *logSetReassembler) fetchMetadata(m MetaContext) error {
+	var hid int
+	var uidBytes []byte
+	db, err := m.Db(DbTypeUsers)
+	if err != nil {
+		return err
+	}
+	defer db.Release()
+
+	err = db.QueryRow(
+		m.Ctx(),
+		`SELECT short_host_id, uid
+		FROM log_send
+		WHERE id = $1`,
+		l.id.ExportToDB(),
+	).Scan(&hid, &uidBytes)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return core.NotFoundError("log_send")
+	}
+	if err != nil {
+		return err
+	}
+	chid, err := m.G().HostIDMap().LookupByShortID(m, core.ShortHostID(hid))
+	if err != nil {
+		return err
+	}
+	l.hostid = chid
+	if len(uidBytes) == 0 {
+		return nil
+	}
+	var uid proto.UID
+	err = uid.ImportFromDB(uidBytes)
+	if err != nil {
+		return err
+	}
+	l.uid = &uid
+	return nil
+}
+
+func (l *logSetReassembler) fetchFiles(m MetaContext) error {
+	db, err := m.Db(DbTypeUsers)
+	if err != nil {
+		return err
+	}
+	defer db.Release()
+
+	rows, err := db.Query(
+		m.Ctx(),
+		`SELECT file_id, filename, len, nblocks, hsh 
+		FROM log_send_files 
+		WHERE short_host_id = $1 AND ls_id = $2 
+		ORDER BY file_id ASC`,
+		l.hostid.Short.ExportToDB(),
+		l.id.ExportToDB(),
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var files []*logSendFile
+	for rows.Next() {
+		var file logSendFile
+		var hashBytes []byte
+		var fileID int
+		err := rows.Scan(&fileID, &file.Name, &file.Len, &file.NBlocks, &hashBytes)
+		if err != nil {
+			return err
+		}
+		file.FileID = rem.LogSendFileID(fileID)
+		if len(hashBytes) != len(file.Hash) {
+			return core.BadServerDataError("hash length mismatch")
+		}
+		copy(file.Hash[:], hashBytes)
+		files = append(files, &file)
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return core.NotFoundError("no files in log send")
+	}
+	l.files = files
+	return nil
+}
+
+func (f *logSendFile) expand() error {
+	if !strings.HasSuffix(f.Name, ".gz") {
+		return nil
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(f.Data))
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	expanded, err := io.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+	f.ExpandedData = expanded
+	return nil
+}

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -40,6 +40,9 @@ var usersPatch1 string
 //go:embed patches/foks_users/p2.sql
 var usersPatch2 string
 
+//go:embed patches/foks_users/p3.sql
+var usersPatch3 string
+
 //go:embed patches/foks_server_config/p1.sql
 var serverConfigPatch1 string
 
@@ -50,6 +53,7 @@ var Patches = map[string]map[int]string{
 	"foks_users": {
 		1: usersPatch1,
 		2: usersPatch2,
+		3: usersPatch3,
 	},
 	"foks_server_config": {
 		1: serverConfigPatch1,

--- a/server/sql/foks_users.sql
+++ b/server/sql/foks_users.sql
@@ -929,6 +929,39 @@ CREATE TABLE team_member_load_floor (
     FOREIGN KEY (short_host_id, team_id) REFERENCES teams(short_host_id, team_id)
 );
 
+CREATE TABLE log_send (
+    short_host_id SMALLINT NOT NULL,
+    id BYTEA NOT NULL, /* a random 16-byte ID */
+    uid BYTEA, /* the UID of the user sending the log, might be NULL if the user can't log in */
+    ctime TIMESTAMP NOT NULL,
+    PRIMARY KEY(short_host_id, id)
+);
+CREATE UNIQUE INDEX log_send_id_idx ON log_send(id);
+
+CREATE TABLE log_send_files (
+    short_host_id SMALLINT NOT NULL,
+    ls_id BYTEA NOT NULL, /* a random 16-byte ID */
+    file_id INTEGER NOT NULL, /* a random 16-byte ID */
+    filename VARCHAR(255) NOT NULL, /* the name of the file */
+    len INTEGER NOT NULL, /* the length of the file */
+    nblocks INTEGER NOT NULL, /* the number of blocks in the file */
+    hsh BYTEA NOT NULL, /* the SHA512/256 hash of the file */
+    ctime TIMESTAMP NOT NULL,
+    PRIMARY KEY(short_host_id, ls_id, file_id),
+    FOREIGN KEY(short_host_id, ls_id) REFERENCES log_send(short_host_id, id)
+);
+
+CREATE TABLE log_send_blocks (
+    short_host_id SMALLINT NOT NULL,
+    ls_id BYTEA NOT NULL, /* a random 16-byte ID */
+    file_id INTEGER NOT NULL, /* a random 16-byte ID */
+    block_id INTEGER NOT NULL, /* the block ID within the file */
+    block BYTEA NOT NULL, /* the block itself */
+    PRIMARY KEY(short_host_id, ls_id, file_id, block_id),
+    FOREIGN KEY(short_host_id, ls_id) REFERENCES log_send(short_host_id, id),
+    FOREIGN KEY(short_host_id, ls_id, file_id) REFERENCES log_send_files(short_host_id, ls_id, file_id)
+);
+
 CREATE TABLE schema_patches (
     id INTEGER NOT NULL PRIMARY KEY,
     ctime TIMESTAMP NOT NULL
@@ -936,3 +969,4 @@ CREATE TABLE schema_patches (
 
 INSERT INTO schema_patches (id, ctime) VALUES (1, NOW());
 INSERT INTO schema_patches (id, ctime) VALUES (2, NOW());
+INSERT INTO schema_patches (id, ctime) VALUES (3, NOW());

--- a/server/sql/patches/foks_users/p3.sql
+++ b/server/sql/patches/foks_users/p3.sql
@@ -1,0 +1,33 @@
+
+CREATE TABLE log_send (
+    short_host_id SMALLINT NOT NULL,
+    id BYTEA NOT NULL, /* a random 16-byte ID */
+    uid BYTEA, /* the UID of the user sending the log, might be NULL if the user can't log in */
+    ctime TIMESTAMP NOT NULL,
+    PRIMARY KEY(short_host_id, id)
+);
+CREATE UNIQUE INDEX log_send_id_idx ON log_send(id);
+
+CREATE TABLE log_send_files (
+    short_host_id SMALLINT NOT NULL,
+    ls_id BYTEA NOT NULL, /* a random 16-byte ID */
+    file_id INTEGER NOT NULL, /* a random 16-byte ID */
+    filename VARCHAR(255) NOT NULL, /* the name of the file */
+    len INTEGER NOT NULL, /* the length of the file */
+    nblocks INTEGER NOT NULL, /* the number of blocks in the file */
+    hsh BYTEA NOT NULL, /* the SHA512/256 hash of the file */
+    ctime TIMESTAMP NOT NULL,
+    PRIMARY KEY(short_host_id, ls_id, file_id),
+    FOREIGN KEY(short_host_id, ls_id) REFERENCES log_send(short_host_id, id)
+);
+
+CREATE TABLE log_send_blocks (
+    short_host_id SMALLINT NOT NULL,
+    ls_id BYTEA NOT NULL, /* a random 16-byte ID */
+    file_id INTEGER NOT NULL, /* a random 16-byte ID */
+    block_id INTEGER NOT NULL, /* the block ID within the file */
+    block BYTEA NOT NULL, /* the block itself */
+    PRIMARY KEY(short_host_id, ls_id, file_id, block_id),
+    FOREIGN KEY(short_host_id, ls_id) REFERENCES log_send(short_host_id, id),
+    FOREIGN KEY(short_host_id, ls_id, file_id) REFERENCES log_send_files(short_host_id, ls_id, file_id)
+);


### PR DESCRIPTION
- cli support
- lcl and rem protocols
- DB tables
- backend service works with reg or user
- clockwrapper class to stave off deadlocks with fakeclock manipulation
- server library function to recreate logs; plumbed through to foks-tool
- close #119
- clean up reassembler
- test failed signup logsend
- db patch
- change indices back to having short_id,id as primary index for log_send metadata
- fixes and run it from the CLI to test
