### PR TITLE
allow optional invite codes if configured

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -11,6 +11,8 @@ changelog:
         closes: []
       - desc: logsend feature for debugging problems
         closes: ["#119"]
+      - desc: invite codes are optional for some hosts
+        closes: ["#123"]
   - version: 0.0.21
     urgency: low
     stable: false

--- a/client/agent/general.go
+++ b/client/agent/general.go
@@ -163,6 +163,7 @@ func (c *AgentConn) PutServer(ctx context.Context, arg lcl.PutServerArg) (proto.
 	sess.ssoCfg = cfg.Sso
 	sess.regServerType = arg.Typ
 	sess.hostType = cfg.Typ
+	sess.icr = cfg.Icr // invite code regime
 	return cfg, nil
 
 }

--- a/client/agent/session.go
+++ b/client/agent/session.go
@@ -29,6 +29,7 @@ type SessionBase struct {
 	activeYubiDevice *proto.YubiCardInfo
 	doPinProtect     bool
 	currPIN          *proto.YubiPIN
+	icr              proto.InviteCodeRegime
 }
 
 type Sessioner interface {

--- a/client/foks/cmd/signup.go
+++ b/client/foks/cmd/signup.go
@@ -42,6 +42,7 @@ type baseSignupProvisionState struct {
 	ycli      lcl.YubiClient
 	typ       proto.UISessionType
 	sso       *proto.SSOConfig
+	icr       proto.InviteCodeRegime
 }
 
 type signupState struct {
@@ -131,6 +132,7 @@ func (s *baseSignupProvisionState) pickServer(m libclient.MetaContext) error {
 		return err
 	}
 	s.sso = regCfg.Sso
+	s.icr = regCfg.Icr
 	return nil
 }
 
@@ -152,7 +154,7 @@ func (s *signupState) getInviteCode(m libclient.MetaContext) error {
 	}
 
 	for i := 0; i < 10; i++ {
-		code, err := m.G().UIs().Signup.GetInviteCode(m, i)
+		code, err := m.G().UIs().Signup.GetInviteCode(m, s.icr, i)
 
 		if code == nil && err == (core.CancelSignupError{Stage: core.CancelSignupStageWaitList}) {
 			tmp := s.joinWaitList(m)

--- a/client/foks/cmd/simple_ui/signup.go
+++ b/client/foks/cmd/simple_ui/signup.go
@@ -216,11 +216,21 @@ func (s *SignupUI) GetEmail(m libclient.MetaContext) (*proto.Email, error) {
 	return &tmp, nil
 }
 
-func (s *SignupUI) GetInviteCode(m libclient.MetaContext, attempt int) (*lcl.InviteCodeString, error) {
+func (s *SignupUI) GetInviteCode(
+	m libclient.MetaContext,
+	icr proto.InviteCodeRegime,
+	attempt int,
+) (*lcl.InviteCodeString, error) {
 	var label string
-	if attempt > 0 {
+	isOpt := (icr == proto.InviteCodeRegime_CodeOptional)
+	switch {
+	case isOpt && attempt == 0:
+		label = "✒️  Invite code (optional, push enter to forego it): "
+	case isOpt && attempt > 0:
+		label = fmt.Sprintf("✒️  invalid invite code (%d), try again (or leave blank): ", attempt)
+	case !isOpt && attempt > 0:
 		label = fmt.Sprintf("✒️  invalid invite code (%d), try again (or push enter to join waitlist): ", attempt)
-	} else {
+	default:
 		label = "✒️  Invite code (or push enter to join waitlist): "
 	}
 

--- a/client/libclient/uis.go
+++ b/client/libclient/uis.go
@@ -26,7 +26,7 @@ type SignupUIer interface {
 	PickServer(m MetaContext, def proto.TCPAddr, timeout time.Duration) (*proto.TCPAddr, error)
 	CheckedServer(m MetaContext, addr proto.TCPAddr, e error) error
 
-	GetInviteCode(m MetaContext, attempt int) (*lcl.InviteCodeString, error)
+	GetInviteCode(m MetaContext, icr proto.InviteCodeRegime, attempt int) (*lcl.InviteCodeString, error)
 	CheckedInviteCode(m MetaContext, code lcl.InviteCodeString, e error) error
 
 	ShowWaitListID(m MetaContext, wlid proto.WaitListID) error

--- a/integration-tests/common/env.go
+++ b/integration-tests/common/env.go
@@ -502,6 +502,12 @@ func (e *TestEnv) VHostMakeWithOpts(
 	err = CopyMultiUseInviteCode(m, vhostId.Short)
 	require.NoError(t, err)
 
+	if opts.Icr == proto.InviteCodeRegime_CodeOptional {
+		m = m.WithHostID(vhostId)
+		err = SetInviteCodeOptional(m)
+		require.NoError(t, err)
+	}
+
 	return &core.HostIDAndName{
 		HostID:   *vhostId,
 		Hostname: hostname,

--- a/integration-tests/lib/vhost_test.go
+++ b/integration-tests/lib/vhost_test.go
@@ -67,7 +67,7 @@ func TestVHostCertsDir(t *testing.T) {
 	defer common.DebugEntryAndExit()()
 
 	var hostnames []proto.Hostname
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		d := "foks." + RandomDomain(t)
 		hostnames = append(hostnames, proto.Hostname(d))
 	}

--- a/lib/core/encodings.go
+++ b/lib/core/encodings.go
@@ -33,15 +33,22 @@ func ExportInviteCode(c rem.InviteCode) (string, error) {
 		base := c.Standard()
 		s := basex.Base62StdEncodingStrict.EncodeToString(base)
 		ret = SingleUsePrefix + s
+	case rem.InviteCodeType_Empty:
+		return "", nil
 	default:
 		return "", VersionNotSupportedError("cannot support invitation code type")
 	}
 	return ret, nil
 }
 
-func ImportInviteCode(s string) (rem.InviteCode, error) {
+func ImportInviteCode(s string, icr proto.InviteCodeRegime) (rem.InviteCode, error) {
 	var ret rem.InviteCode
 	switch {
+	case len(s) == 0:
+		if icr == proto.InviteCodeRegime_CodeOptional {
+			return rem.NewInviteCodeWithEmpty(), nil
+		}
+		return ret, BadInviteCodeError{}
 	case strings.HasPrefix(s, SingleUsePrefix):
 		s = s[2:]
 		b, err := basex.Base62StdEncoding.DecodeString(s)

--- a/lib/core/encodings_test.go
+++ b/lib/core/encodings_test.go
@@ -6,6 +6,7 @@ package core
 import (
 	"testing"
 
+	proto "github.com/foks-proj/go-foks/proto/lib"
 	rem "github.com/foks-proj/go-foks/proto/rem"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,7 @@ func TestInviteCodeEncoding(t *testing.T) {
 	code := rem.NewInviteCodeWithMultiuse(txt)
 	s, err := ExportInviteCode(code)
 	require.NoError(t, err)
-	code2, err := ImportInviteCode(s)
+	code2, err := ImportInviteCode(s, proto.InviteCodeRegime_CodeRequired)
 	require.NoError(t, err)
 	typ, err := code2.GetT()
 	require.NoError(t, err)

--- a/lib/core/path.go
+++ b/lib/core/path.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	proto "github.com/foks-proj/go-foks/proto/lib"
@@ -201,7 +202,8 @@ func (p Path) Export() proto.LocalFSPath {
 
 func (p Path) IsBadFilename() bool {
 	s := p.String()
-	if strings.Contains(s, "..") || strings.Contains(s, "/") || strings.Contains(s, "\\") {
+	var validFilename = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	if len(s) == 0 || len(s) > 255 || !validFilename.MatchString(s) {
 		return true
 	}
 	return false

--- a/lib/core/validators.go
+++ b/lib/core/validators.go
@@ -121,6 +121,8 @@ func ValidateInviteCode(c rem.InviteCode) error {
 		return err
 	}
 	switch typ {
+	case rem.InviteCodeType_Empty:
+		return nil
 	case rem.InviteCodeType_Standard:
 		return ValidateStandardInviteCode(c.Standard())
 	case rem.InviteCodeType_MultiUse:
@@ -130,8 +132,8 @@ func ValidateInviteCode(c rem.InviteCode) error {
 	}
 }
 
-func ValidateInviteCodeString(s lcl.InviteCodeString) error {
-	code, err := ImportInviteCode(string(s))
+func ValidateInviteCodeString(s lcl.InviteCodeString, icr proto.InviteCodeRegime) error {
+	code, err := ImportInviteCode(string(s), icr)
 	if err != nil {
 		return err
 	}

--- a/proto-src/lcl/signup.snowp
+++ b/proto-src/lcl/signup.snowp
@@ -148,9 +148,7 @@ protocol Signup
         sessionId @0 : lib.UISessionID
     ) -> lib.Email;
 
-    getSkipInviteCodeSSO @32 (
-        sessionId @0 : lib.UISessionID
-    ) -> Bool;
+    // RPC @32 is deprecated, used to getSkipInviteCodeSSO
 
     finishNKWNewDeviceKey @33 (
         sessionId @0 : lib.UISessionID
@@ -159,4 +157,8 @@ protocol Signup
     finishNKWNewBackupKey @34 (
         sessionId @0 : lib.UISessionID
     ) -> BackupHESP;
+
+    getInviteCodeRegime @35 (
+        sessionId @0 : lib.UISessionID
+    ) -> lib.InviteCodeRegime;
 }

--- a/proto-src/lib/config.snowp
+++ b/proto-src/lib/config.snowp
@@ -32,4 +32,5 @@ struct HostConfig {
     metering @0 : Metering;
     viewership @1 : HostViewership;
     typ @2 : HostType;
+    icr @3 : InviteCodeRegime;
 }

--- a/proto-src/lib/user.snowp
+++ b/proto-src/lib/user.snowp
@@ -26,10 +26,18 @@ struct UserContext {
     networkStatus @6 : Status;
 }
 
+enum InviteCodeRegime {
+    None @0;
+    CodeRequired @1;
+    CodeOptional @2;
+    SkipViaSSO @3;
+}
+
 struct RegServerConfig {
     sso @0 : Option(SSOConfig);
     typ @1 : HostType; 
     view @2 : HostViewership;
+    icr @3 : InviteCodeRegime;
 }
 
 typedef Email = Text;

--- a/proto-src/rem/invite.snowp
+++ b/proto-src/rem/invite.snowp
@@ -10,11 +10,12 @@ enum InviteCodeType {
     Standard @1;
     MultiUse @2;
     SSO @3;
+    Empty @4;
 }
 
 variant InviteCode switch (t : InviteCodeType) {
     default: void;
     case Standard @1 : Blob;
     case MultiUse @2 : MultiUseInviteCode;
-    case SSO: void;
+    case SSO, Empty: void;
 }

--- a/proto/lcl/signup.go
+++ b/proto/lcl/signup.go
@@ -1358,45 +1358,6 @@ func (g *GetEmailSSOArg) Decode(dec rpc.Decoder) error {
 
 func (g *GetEmailSSOArg) Bytes() []byte { return nil }
 
-type GetSkipInviteCodeSSOArg struct {
-	SessionId lib.UISessionID
-}
-type GetSkipInviteCodeSSOArgInternal__ struct {
-	_struct   struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
-	SessionId *lib.UISessionIDInternal__
-}
-
-func (g GetSkipInviteCodeSSOArgInternal__) Import() GetSkipInviteCodeSSOArg {
-	return GetSkipInviteCodeSSOArg{
-		SessionId: (func(x *lib.UISessionIDInternal__) (ret lib.UISessionID) {
-			if x == nil {
-				return ret
-			}
-			return x.Import()
-		})(g.SessionId),
-	}
-}
-func (g GetSkipInviteCodeSSOArg) Export() *GetSkipInviteCodeSSOArgInternal__ {
-	return &GetSkipInviteCodeSSOArgInternal__{
-		SessionId: g.SessionId.Export(),
-	}
-}
-func (g *GetSkipInviteCodeSSOArg) Encode(enc rpc.Encoder) error {
-	return enc.Encode(g.Export())
-}
-
-func (g *GetSkipInviteCodeSSOArg) Decode(dec rpc.Decoder) error {
-	var tmp GetSkipInviteCodeSSOArgInternal__
-	err := dec.Decode(&tmp)
-	if err != nil {
-		return err
-	}
-	*g = tmp.Import()
-	return nil
-}
-
-func (g *GetSkipInviteCodeSSOArg) Bytes() []byte { return nil }
-
 type FinishNKWNewDeviceKeyArg struct {
 	SessionId lib.UISessionID
 }
@@ -1475,6 +1436,45 @@ func (f *FinishNKWNewBackupKeyArg) Decode(dec rpc.Decoder) error {
 
 func (f *FinishNKWNewBackupKeyArg) Bytes() []byte { return nil }
 
+type GetInviteCodeRegimeArg struct {
+	SessionId lib.UISessionID
+}
+type GetInviteCodeRegimeArgInternal__ struct {
+	_struct   struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	SessionId *lib.UISessionIDInternal__
+}
+
+func (g GetInviteCodeRegimeArgInternal__) Import() GetInviteCodeRegimeArg {
+	return GetInviteCodeRegimeArg{
+		SessionId: (func(x *lib.UISessionIDInternal__) (ret lib.UISessionID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(g.SessionId),
+	}
+}
+func (g GetInviteCodeRegimeArg) Export() *GetInviteCodeRegimeArgInternal__ {
+	return &GetInviteCodeRegimeArgInternal__{
+		SessionId: g.SessionId.Export(),
+	}
+}
+func (g *GetInviteCodeRegimeArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(g.Export())
+}
+
+func (g *GetInviteCodeRegimeArg) Decode(dec rpc.Decoder) error {
+	var tmp GetInviteCodeRegimeArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*g = tmp.Import()
+	return nil
+}
+
+func (g *GetInviteCodeRegimeArg) Bytes() []byte { return nil }
+
 type SignupInterface interface {
 	LoginAs(context.Context, LoginAsArg) error
 	PutInviteCode(context.Context, PutInviteCodeArg) error
@@ -1501,9 +1501,9 @@ type SignupInterface interface {
 	SignupWaitForSsoLogin(context.Context, lib.UISessionID) (lib.SSOLoginRes, error)
 	GetUsernameSSO(context.Context, lib.UISessionID) (lib.NameUtf8, error)
 	GetEmailSSO(context.Context, lib.UISessionID) (lib.Email, error)
-	GetSkipInviteCodeSSO(context.Context, lib.UISessionID) (bool, error)
 	FinishNKWNewDeviceKey(context.Context, lib.UISessionID) error
 	FinishNKWNewBackupKey(context.Context, lib.UISessionID) (BackupHESP, error)
+	GetInviteCodeRegime(context.Context, lib.UISessionID) (lib.InviteCodeRegime, error)
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h Header) error
 	MakeResHeader() Header
@@ -2117,30 +2117,6 @@ func (c SignupClient) GetEmailSSO(ctx context.Context, sessionId lib.UISessionID
 	res = tmp.Data.Import()
 	return
 }
-func (c SignupClient) GetSkipInviteCodeSSO(ctx context.Context, sessionId lib.UISessionID) (res bool, err error) {
-	arg := GetSkipInviteCodeSSOArg{
-		SessionId: sessionId,
-	}
-	warg := &rpc.DataWrap[Header, *GetSkipInviteCodeSSOArgInternal__]{
-		Data: arg.Export(),
-	}
-	if c.MakeArgHeader != nil {
-		warg.Header = c.MakeArgHeader()
-	}
-	var tmp rpc.DataWrap[Header, bool]
-	err = c.Cli.Call2(ctx, rpc.NewMethodV2(SignupProtocolID, 32, "Signup.getSkipInviteCodeSSO"), warg, &tmp, 0*time.Millisecond, signupErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
-	if err != nil {
-		return
-	}
-	if c.CheckResHeader != nil {
-		err = c.CheckResHeader(ctx, tmp.Header)
-		if err != nil {
-			return
-		}
-	}
-	res = tmp.Data
-	return
-}
 func (c SignupClient) FinishNKWNewDeviceKey(ctx context.Context, sessionId lib.UISessionID) (err error) {
 	arg := FinishNKWNewDeviceKeyArg{
 		SessionId: sessionId,
@@ -2176,6 +2152,30 @@ func (c SignupClient) FinishNKWNewBackupKey(ctx context.Context, sessionId lib.U
 	}
 	var tmp rpc.DataWrap[Header, BackupHESPInternal__]
 	err = c.Cli.Call2(ctx, rpc.NewMethodV2(SignupProtocolID, 34, "Signup.finishNKWNewBackupKey"), warg, &tmp, 0*time.Millisecond, signupErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	res = tmp.Data.Import()
+	return
+}
+func (c SignupClient) GetInviteCodeRegime(ctx context.Context, sessionId lib.UISessionID) (res lib.InviteCodeRegime, err error) {
+	arg := GetInviteCodeRegimeArg{
+		SessionId: sessionId,
+	}
+	warg := &rpc.DataWrap[Header, *GetInviteCodeRegimeArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[Header, lib.InviteCodeRegimeInternal__]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(SignupProtocolID, 35, "Signup.getInviteCodeRegime"), warg, &tmp, 0*time.Millisecond, signupErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
 	if err != nil {
 		return
 	}
@@ -2907,35 +2907,6 @@ func SignupProtocol(i SignupInterface) rpc.ProtocolV2 {
 				},
 				Name: "getEmailSSO",
 			},
-			32: {
-				ServeHandlerDescription: rpc.ServeHandlerDescription{
-					MakeArg: func() interface{} {
-						var ret rpc.DataWrap[Header, *GetSkipInviteCodeSSOArgInternal__]
-						return &ret
-					},
-					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
-						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *GetSkipInviteCodeSSOArgInternal__])
-						if !ok {
-							err := rpc.NewTypeError((*rpc.DataWrap[Header, *GetSkipInviteCodeSSOArgInternal__])(nil), args)
-							return nil, err
-						}
-						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
-							return nil, err
-						}
-						typedArg := typedWrappedArg.Data
-						tmp, err := i.GetSkipInviteCodeSSO(ctx, (typedArg.Import()).SessionId)
-						if err != nil {
-							return nil, err
-						}
-						ret := rpc.DataWrap[Header, bool]{
-							Data:   tmp,
-							Header: i.MakeResHeader(),
-						}
-						return &ret, nil
-					},
-				},
-				Name: "getSkipInviteCodeSSO",
-			},
 			33: {
 				ServeHandlerDescription: rpc.ServeHandlerDescription{
 					MakeArg: func() interface{} {
@@ -2992,6 +2963,35 @@ func SignupProtocol(i SignupInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "finishNKWNewBackupKey",
+			},
+			35: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[Header, *GetInviteCodeRegimeArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *GetInviteCodeRegimeArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[Header, *GetInviteCodeRegimeArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						tmp, err := i.GetInviteCodeRegime(ctx, (typedArg.Import()).SessionId)
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[Header, *lib.InviteCodeRegimeInternal__]{
+							Data:   tmp.Export(),
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "getInviteCodeRegime",
 			},
 		},
 		WrapError: SignupMakeGenericErrorWrapper(i.ErrorWrapper()),

--- a/proto/lib/config.go
+++ b/proto/lib/config.go
@@ -178,12 +178,14 @@ type HostConfig struct {
 	Metering   Metering
 	Viewership HostViewership
 	Typ        HostType
+	Icr        InviteCodeRegime
 }
 type HostConfigInternal__ struct {
 	_struct    struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
 	Metering   *MeteringInternal__
 	Viewership *HostViewershipInternal__
 	Typ        *HostTypeInternal__
+	Icr        *InviteCodeRegimeInternal__
 }
 
 func (h HostConfigInternal__) Import() HostConfig {
@@ -206,6 +208,12 @@ func (h HostConfigInternal__) Import() HostConfig {
 			}
 			return x.Import()
 		})(h.Typ),
+		Icr: (func(x *InviteCodeRegimeInternal__) (ret InviteCodeRegime) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(h.Icr),
 	}
 }
 func (h HostConfig) Export() *HostConfigInternal__ {
@@ -213,6 +221,7 @@ func (h HostConfig) Export() *HostConfigInternal__ {
 		Metering:   h.Metering.Export(),
 		Viewership: h.Viewership.Export(),
 		Typ:        h.Typ.Export(),
+		Icr:        h.Icr.Export(),
 	}
 }
 func (h *HostConfig) Encode(enc rpc.Encoder) error {

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -4802,3 +4802,34 @@ func (i TeamRemoteMemberViewTokenInner) GetPTKRole() (*Role, error) {
 	}
 	return &ret, nil
 }
+
+func (i *InviteCodeRegime) ImportFromString(s string) error {
+	switch s {
+	case "none":
+		*i = InviteCodeRegime_None
+	case "optional":
+		*i = InviteCodeRegime_CodeOptional
+	case "required":
+		*i = InviteCodeRegime_CodeRequired
+	case "skip_via_sso":
+		*i = InviteCodeRegime_SkipViaSSO
+	default:
+		return DataError("bad invite code regime")
+	}
+	return nil
+}
+
+func (i InviteCodeRegime) String() string {
+	switch i {
+	case InviteCodeRegime_None:
+		return "none"
+	case InviteCodeRegime_CodeOptional:
+		return "optional"
+	case InviteCodeRegime_CodeRequired:
+		return "required"
+	case InviteCodeRegime_SkipViaSSO:
+		return "skip_via_sso"
+	default:
+		return "error"
+	}
+}

--- a/proto/lib/user.go
+++ b/proto/lib/user.go
@@ -268,16 +268,49 @@ func (u *UserContext) Decode(dec rpc.Decoder) error {
 
 func (u *UserContext) Bytes() []byte { return nil }
 
+type InviteCodeRegime int
+
+const (
+	InviteCodeRegime_None         InviteCodeRegime = 0
+	InviteCodeRegime_CodeRequired InviteCodeRegime = 1
+	InviteCodeRegime_CodeOptional InviteCodeRegime = 2
+	InviteCodeRegime_SkipViaSSO   InviteCodeRegime = 3
+)
+
+var InviteCodeRegimeMap = map[string]InviteCodeRegime{
+	"None":         0,
+	"CodeRequired": 1,
+	"CodeOptional": 2,
+	"SkipViaSSO":   3,
+}
+var InviteCodeRegimeRevMap = map[InviteCodeRegime]string{
+	0: "None",
+	1: "CodeRequired",
+	2: "CodeOptional",
+	3: "SkipViaSSO",
+}
+
+type InviteCodeRegimeInternal__ InviteCodeRegime
+
+func (i InviteCodeRegimeInternal__) Import() InviteCodeRegime {
+	return InviteCodeRegime(i)
+}
+func (i InviteCodeRegime) Export() *InviteCodeRegimeInternal__ {
+	return ((*InviteCodeRegimeInternal__)(&i))
+}
+
 type RegServerConfig struct {
 	Sso  *SSOConfig
 	Typ  HostType
 	View HostViewership
+	Icr  InviteCodeRegime
 }
 type RegServerConfigInternal__ struct {
 	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
 	Sso     *SSOConfigInternal__
 	Typ     *HostTypeInternal__
 	View    *HostViewershipInternal__
+	Icr     *InviteCodeRegimeInternal__
 }
 
 func (r RegServerConfigInternal__) Import() RegServerConfig {
@@ -306,6 +339,12 @@ func (r RegServerConfigInternal__) Import() RegServerConfig {
 			}
 			return x.Import()
 		})(r.View),
+		Icr: (func(x *InviteCodeRegimeInternal__) (ret InviteCodeRegime) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Icr),
 	}
 }
 func (r RegServerConfig) Export() *RegServerConfigInternal__ {
@@ -318,6 +357,7 @@ func (r RegServerConfig) Export() *RegServerConfigInternal__ {
 		})(r.Sso),
 		Typ:  r.Typ.Export(),
 		View: r.View.Export(),
+		Icr:  r.Icr.Export(),
 	}
 }
 func (r *RegServerConfig) Encode(enc rpc.Encoder) error {

--- a/proto/rem/invite.go
+++ b/proto/rem/invite.go
@@ -51,6 +51,7 @@ const (
 	InviteCodeType_Standard InviteCodeType = 1
 	InviteCodeType_MultiUse InviteCodeType = 2
 	InviteCodeType_SSO      InviteCodeType = 3
+	InviteCodeType_Empty    InviteCodeType = 4
 )
 
 var InviteCodeTypeMap = map[string]InviteCodeType{
@@ -58,12 +59,14 @@ var InviteCodeTypeMap = map[string]InviteCodeType{
 	"Standard": 1,
 	"MultiUse": 2,
 	"SSO":      3,
+	"Empty":    4,
 }
 var InviteCodeTypeRevMap = map[InviteCodeType]string{
 	0: "None",
 	1: "Standard",
 	2: "MultiUse",
 	3: "SSO",
+	4: "Empty",
 }
 
 type InviteCodeTypeInternal__ InviteCodeType
@@ -103,7 +106,7 @@ func (i InviteCode) GetT() (ret InviteCodeType, err error) {
 		if i.F_2__ == nil {
 			return ret, errors.New("unexpected nil case for F_2__")
 		}
-	case InviteCodeType_SSO:
+	case InviteCodeType_SSO, InviteCodeType_Empty:
 		break
 	}
 	return i.T, nil
@@ -146,6 +149,11 @@ func NewInviteCodeWithMultiuse(v MultiUseInviteCode) InviteCode {
 func NewInviteCodeWithSso() InviteCode {
 	return InviteCode{
 		T: InviteCodeType_SSO,
+	}
+}
+func NewInviteCodeWithEmpty() InviteCode {
+	return InviteCode{
+		T: InviteCodeType_Empty,
 	}
 }
 func (i InviteCodeInternal__) Import() InviteCode {

--- a/server/engine/reg.go
+++ b/server/engine/reg.go
@@ -131,6 +131,16 @@ func (c *RegClientConn) signupInviteCode(
 	}
 	var tags pgconn.CommandTag
 	switch typ {
+	case rem.InviteCodeType_Empty:
+		cfg, err := m.HostConfig()
+		if err != nil {
+			return err
+		}
+		if cfg.Icr != proto.InviteCodeRegime_CodeOptional {
+			m.Warnw("signup", "stage", "invite code", "err", "invite code required by server")
+			return core.BadInviteCodeError{}
+		}
+		return nil
 	case rem.InviteCodeType_MultiUse:
 		tags, err = tx.Exec(m.Ctx(),
 			`UPDATE multiuse_invite_codes 

--- a/server/shared/hostchains.go
+++ b/server/shared/hostchains.go
@@ -848,14 +848,16 @@ func (h *HostChain) writeChainToDB(m MetaContext, eld proto.HostchainLinkOuter, 
 func (h *HostChain) writeConfigToDB(m MetaContext, tx pgx.Tx) error {
 	tag, err := tx.Exec(m.Ctx(),
 		`INSERT INTO host_config (short_host_id, user_metering,
-		  vhost_metering, per_vhost_disk_metering, host_type, user_viewing)
-		VALUES($1, $2, $3, $4, $5, $6)`,
+		  vhost_metering, per_vhost_disk_metering, host_type, user_viewing,
+		  invite_code_regime)
+		VALUES($1, $2, $3, $4, $5, $6, $7)`,
 		int(h.hostID.Short),
 		h.cfg.Metering.Users,
 		h.cfg.Metering.VHosts,
 		h.cfg.Metering.PerVHostDisk,
 		h.cfg.Typ.String(),
 		proto.ViewershipMode_Closed.String(),
+		proto.InviteCodeRegime_CodeRequired.String(),
 	)
 	if err != nil {
 		return err

--- a/server/shared/hostconfig.go
+++ b/server/shared/hostconfig.go
@@ -16,11 +16,12 @@ func GetServerConfig(
 	}
 	var ret proto.RegServerConfig
 	ret.Sso = ssoCfg
-	cfg, err := m.G().HostIDMap().Config(m, m.ShortHostID())
+	cfg, err := m.HostConfig()
 	if err != nil {
 		return nil, err
 	}
 	ret.Typ = cfg.Typ
 	ret.View = cfg.Viewership
+	ret.Icr = cfg.Icr
 	return &ret, nil
 }

--- a/server/shared/vhosts.go
+++ b/server/shared/vhosts.go
@@ -204,6 +204,7 @@ type VHostInitOpts struct {
 	Config        proto.HostConfig
 	MerklePoke    func() error
 	MakeProbeCert func(m MetaContext) error
+	Icr           proto.InviteCodeRegime // invite code regime, if any
 }
 
 func VHostInit(

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -49,6 +49,9 @@ var serverConfigPatch1 string
 //go:embed patches/foks_server_config/p2.sql
 var serverConfigPatch2 string
 
+//go:embed patches/foks_server_config/p3.sql
+var serverConfigPatch3 string
+
 var Patches = map[string]map[int]string{
 	"foks_users": {
 		1: usersPatch1,
@@ -58,5 +61,6 @@ var Patches = map[string]map[int]string{
 	"foks_server_config": {
 		1: serverConfigPatch1,
 		2: serverConfigPatch2,
+		3: serverConfigPatch3,
 	},
 }

--- a/server/sql/foks_server_config.sql
+++ b/server/sql/foks_server_config.sql
@@ -112,6 +112,8 @@ CREATE TYPE host_type AS ENUM('big_top', 'vhost_management', 'vhost', 'standalon
 
 CREATE TYPE viewership_mode AS ENUM('closed', 'open_to_admin', 'open');
 
+CREATE TYPE invite_code_regime AS ENUM('none', 'required', 'optional');
+
 /*
  * one row in host-config for every host, whether virtual or not.
  */
@@ -123,8 +125,8 @@ CREATE TABLE host_config (
     per_vhost_disk_metering BOOLEAN NOT NULL, /* disk quota for this vhost */
 
     user_viewing viewership_mode NOT NULL, /* allow users to openly view signchains on this vhost */
-
-    host_type host_type NOT NULL
+    host_type host_type NOT NULL,
+    invite_code_regime invite_code_regime NOT NULL DEFAULT 'none' /* how to handle invite codes */
 );
 
 CREATE TYPE sso_protocol_type AS ENUM('none', 'oauth2', 'saml');
@@ -248,4 +250,5 @@ CREATE TABLE schema_patches (
     ctime TIMESTAMP NOT NULL
 );
 
-INSERT INTO schema_patches (id, ctime) VALUES (1, NOW());
+INSERT INTO schema_patches (id, ctime) VALUES 
+    (1, NOW()), (2, NOW()), (3, NOW());

--- a/server/sql/patches/foks_server_config/p3.sql
+++ b/server/sql/patches/foks_server_config/p3.sql
@@ -1,0 +1,5 @@
+
+CREATE TYPE invite_code_regime AS ENUM('none', 'required', 'optional');
+
+ALTER TABLE host_config
+    ADD COLUMN invite_code_regime invite_code_regime NOT NULL DEFAULT 'none';


### PR DESCRIPTION
- changes to CLI: signup and simple signup flow get config from server and allow skipping input of invite code
- server: plumb configuration options through; allow reg flow with empty invite code; change verification to allow for empty code if configuration agrees
- lib test, and CLI test
- close #123
