### PR TITLE
debian: downgrade depdendency to libpcsclite-dev (>= 1.9.5)

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -9,6 +9,8 @@ changelog:
     changes:
       - desc: add more online documentation for `team` admin commands
         closes: ["#128"]
+      - desc: downgrade dependency on debian to libpcsclite-dev (>= 1.9.5)
+        closes: ["#140"]
   - version: 0.1.0
     urgency: low
     stable: false

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -58,7 +58,7 @@ Section: utils
 Priority: optional
 Architecture: ${plat}
 Maintainer: Maxwell Krohn <max@ne43.com>
-Depends: libpcsclite-dev (>= 1.9.9), libc6 (>= 2.31)
+Depends: libpcsclite-dev (>= 1.9.5), libc6 (>= 2.31)
 Description: Access the Federated Open Key Service (FOKS)
  with this single CLI-application. Supplies signup, key management,
  team management, KV-store put-get and also git remote helper.


### PR DESCRIPTION
- close #140
- will be in release v0.1.1
