### PR TITLE
autocert: on refresh, update the row, and stomp over the old cert

### DIFF
--- a/scripts/srv/deploy.sh
+++ b/scripts/srv/deploy.sh
@@ -25,4 +25,4 @@ ssh ${ROOT_PROD_SSH} "cd ${REMOTE_TOPDIR}/bin && \
     sudo setcap cap_net_bind_service=+ep foks-server.${rev} && \
     sudo setcap cap_net_bind_service=+ep foks-tool.${rev}"
 
-scp ${SRCDIR}/scripts/build.bash ${PROD_SSH}:${REMOTE_TOPDIR}/scripts/
+scp ${SRCDIR}/scripts/srv/build.bash ${PROD_SSH}:${REMOTE_TOPDIR}/scripts/


### PR DESCRIPTION
- fix deploy script for foks.app-style deploys after #159 fix
- tested and deployed to foks.app
- close #161 
