### PR TITLE
foks-tool: support BYO-CA

### DIFF
--- a/scripts/srv/build.bash
+++ b/scripts/srv/build.bash
@@ -204,11 +204,25 @@ issue_probe_and_beacon_certs_test() {
 }
 
 issue_probe_cert_prod() {
-    autocert probe
+    if [ -n "$PROBE_KEY" -a -n "$PROBE_CERT_CHAIN" ]; then
+        tool import-cert \
+            --cert ${PROBE_CERT_CHAIN} \
+            --key ${PROBE_KEY} \
+            --type probe
+    else 
+        autocert probe
+    fi
 }
 
 issue_beacon_cert_prod() {
-    if [ "$RUN_BEACON" -eq 1 ]; then
+    if [ "$RUN_BEACON" -eq 0 ]; then
+        return
+    elif [ -n "$BEACON_KEY" -a -n "$BEACON_CERT_CHAIN" ]; then
+        tool import-cert \
+            --cert ${BEACON_CERT_CHAIN} \
+            --key ${BEACON_KEY} \
+            --type beacon
+    else
         autocert beacon
     fi
 }

--- a/server/foks-tool/import_cert.go
+++ b/server/foks-tool/import_cert.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/libterm"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/server/shared"
+	"github.com/spf13/cobra"
+)
+
+type ImportCert struct {
+	CLIAppBase
+	importer *shared.CKSCertImporter
+	host     string
+	cert     string
+	key      string
+	typRaw   string
+}
+
+func (i *ImportCert) CobraConfig() *cobra.Command {
+	ret := &cobra.Command{
+		Use:   "import-cert",
+		Short: "Import a TLS certificate/key pair for a host",
+		Long: libterm.MustRewrapSense(`This command imports a TLS certificate and private key for a specified host.
+Works for either the outward-facing Beacon or Probe server. Use this if you are bringing your own cert/keypair
+and do not want to use the default Let's Encrypt machinery. If you do this, the impetus is on you to refresh
+certs as needed, as there will be no automated mechanism (via the "autocert" process) to do this for you.
+
+When supplying the cert, you should provide a chain of certificates, with the leaf certificate first.
+
+Note that a hostname in the leaf cert must match the host you are working on behalf of. If none specified,
+this will be the default host (specified foks.jsonnet). A host can be specified with the --host flag,
+as either a host name (DNS name) or a host ID.
+`, 0),
+	}
+	ret.Flags().StringVar(&i.host, "host", "", "host name or ID; if none specified, the default host is used")
+	ret.Flags().StringVar(&i.cert, "cert", "", "Path to the TLS certificate file; chain of certs, leaf first")
+	ret.Flags().StringVar(&i.key, "key", "", "Path to the TLS private key file")
+	ret.Flags().StringVar(&i.typRaw, "type", "", "Cert type; one of: beacon, probe; if none specified, probe is assumed")
+	return ret
+}
+
+func (i *ImportCert) CheckArgs(args []string) error {
+	if len(args) != 0 {
+		return core.BadArgsError("no args allowed")
+	}
+
+	for _, s := range []struct {
+		key string
+		val string
+	}{
+		{key: "cert", val: i.cert},
+		{key: "key", val: i.key},
+	} {
+		if len(s.val) == 0 {
+			return core.BadArgsError(fmt.Sprintf("missing required --%s parameter", s.key))
+		}
+	}
+
+	var typ proto.CKSAssetType
+	switch i.typRaw {
+	case "", "probe":
+		typ = proto.CKSAssetType_RootPKIFrontendX509Cert
+	case "beacon":
+		typ = proto.CKSAssetType_RootPKIBeaconX509Cert
+	default:
+		return core.BadArgsError(fmt.Sprintf("invalid cert type: %s", i.typRaw))
+	}
+	i.importer = shared.NewCKSCertImporter()
+
+	err := i.importer.Configure(
+		core.Path(i.key),
+		core.Path(i.cert),
+		typ,
+		i.host,
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *ImportCert) Run(m shared.MetaContext) error {
+	err := shared.InitHostID(m)
+	if err != nil {
+		return err
+	}
+	err = i.importer.Run(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *ImportCert) SetGlobalContext(g *shared.GlobalContext) {}
+
+var _ shared.CLIApp = (*ImportCert)(nil)
+
+func init() {
+	AddCmd(&ImportCert{})
+}

--- a/server/shared/cks_import.go
+++ b/server/shared/cks_import.go
@@ -1,0 +1,121 @@
+package shared
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+type CKSCertImporter struct {
+	typ  proto.CKSAssetType
+	phn  *proto.ParsedHostname
+	cp   *CertPackage
+	chid *core.HostID
+}
+
+func NewCKSCertImporter() *CKSCertImporter {
+	return &CKSCertImporter{}
+}
+
+func (c *CKSCertImporter) Configure(
+	key core.Path,
+	cert core.Path,
+	typ proto.CKSAssetType,
+	host string,
+) error {
+	c.typ = typ
+
+	cp, err := ReadCertPackageFromFiles(core.KeyCertFilePair{
+		Key:  key,
+		Cert: cert,
+	})
+	c.cp = cp
+	if err != nil {
+		return err
+	}
+	if len(c.cp.Certs) == 0 {
+		return core.X509Error("no certs in the cert chain")
+	}
+	if len(host) != 0 {
+		phn, err := proto.HostString(host).Parse()
+		if err != nil {
+			return core.BadArgsError(fmt.Sprintf("invalid host: %s", host))
+		}
+		c.phn = phn
+	}
+	return nil
+}
+
+func (c *CKSCertImporter) checkHostname(m MetaContext) error {
+	mapper := m.G().HostIDMap()
+
+	if c.phn != nil {
+		isName, err := c.phn.GetS()
+		if err != nil {
+			return err
+		}
+		if isName {
+			hn := c.phn.True().Hostname()
+			hid, err := mapper.LookupByHostname(m, hn)
+			if err != nil {
+				return err
+			}
+			c.chid = hid
+		} else {
+			hid := c.phn.False()
+			chid, err := mapper.LookupByHostID(m, hid)
+			if err != nil {
+				return err
+			}
+			c.chid = chid
+		}
+	} else {
+		tmp := m.HostID()
+		c.chid = &tmp
+	}
+
+	hn, err := mapper.Hostname(m, c.chid.Short)
+	if err != nil {
+		return err
+	}
+	var found bool
+	for _, n := range c.cp.Certs[0].DNSNames {
+		if proto.Hostname(n).NormEq(hn) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return core.X509Error(fmt.Sprintf("certificate does not match host: %s", hn))
+	}
+	return nil
+}
+
+func (c *CKSCertImporter) runImport(m MetaContext) error {
+
+	cert := tls.Certificate{
+		PrivateKey:  c.cp.Priv,
+		Leaf:        c.cp.Certs[0],
+		Certificate: c.cp.CertRaw,
+	}
+
+	err := StoreCertToCertMgr(m, c.chid.Id, c.typ, &cert)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CKSCertImporter) Run(m MetaContext) error {
+	err := c.checkHostname(m)
+	if err != nil {
+		return err
+	}
+	err = c.runImport(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
- for those who don't want to use let's encrypt, we now support BYO-CA
- this is good for #136 and also closes #163
- new CLI took: import-cert
- test to work with the cert that LE generates
- plug into the config/bash system
- no support (as of yet) for `foks-tool standup`
