### PR TITLE
cli: `foks key remove`

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -9,6 +9,8 @@ changelog:
     changes:
       - desc: improve error conditions and messages w/r/t `kv mkdir root`
         closes: ["#163"]
+      - desc: add CLI command `foks key remove` 
+        closes: ["#167"]
   - version: 0.1.1
     urgency: low
     stable: true

--- a/client/libclient/all_users.go
+++ b/client/libclient/all_users.go
@@ -415,7 +415,7 @@ func LookupSimpleInAllUsers(
 func LookupUserInAllUsers(
 	m MetaContext,
 	u lcl.LocalUserIndexParsed,
-	getDefaultHostID func() (proto.HostID, error),
+	getDefaultHostID func(MetaContext) (proto.HostID, error),
 ) (*proto.UserInfo, error) {
 	users, err := ReadAllUsers(m)
 	if err != nil {
@@ -428,7 +428,7 @@ func LookupUserInAllUsers(
 		if !defHostID.IsZero() {
 			return defHostID, nil
 		}
-		tmp, err := getDefaultHostID()
+		tmp, err := getDefaultHostID(m)
 		if err != nil {
 			return defHostID, err
 		}

--- a/integration-tests/cli/remove_test.go
+++ b/integration-tests/cli/remove_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/integration-tests/common"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyRemove(t *testing.T) {
+	defer common.DebugEntryAndExit()()
+	stopper := runMerkleActivePoker(t)
+	defer stopper()
+
+	x := newTestAgent(t)
+	x.runAgent(t)
+	defer x.stop(t)
+	name := proto.DeviceName("device A.1")
+	vh := vHost(t, 1)
+	signupUi := newMockSignupUI().withDeviceName(name).withServer(vh.Addr)
+	x.runCmdWithUIs(t, libclient.UIs{Signup: signupUi}, "--simple-ui", "signup")
+	var klres lcl.KeyListRes
+	x.runCmdToJSON(t, &klres, "key", "list")
+	require.Equal(t, 1, len(klres.AllUsers))
+	require.Equal(t, 1, len(klres.CurrUserAllKeys))
+	yubiKeyID := klres.CurrUserAllKeys[0].Di.Key.Member.Id.Entity
+	yubiKeyIDStr, err := yubiKeyID.StringErr()
+	require.NoError(t, err)
+	fqu := klres.AllUsers[0].Info.Fqu
+	fqus, err := fqu.StringErr()
+	require.NoError(t, err)
+
+	x.runCmd(t, nil, "key", "dev", "perm", "--name", "device B.2")
+
+	x.runCmdToJSON(t, &klres, "key", "list")
+	require.Equal(t, 2, len(klres.AllUsers))
+	require.Equal(t, 2, len(klres.CurrUserAllKeys))
+
+	x.runCmd(t, nil, "key", "remove", "--user", fqus, "--key-id", yubiKeyIDStr)
+
+	x.runCmdToJSON(t, &klres, "key", "list")
+	require.Equal(t, 1, len(klres.AllUsers))
+	require.Equal(t, 2, len(klres.CurrUserAllKeys))
+	devKeyID := klres.AllUsers[0].Info.Key
+	devKeyIDStr, err := devKeyID.StringErr()
+	require.NoError(t, err)
+
+	require.NotEqual(t, yubiKeyIDStr, devKeyIDStr)
+	err = x.runCmdErr(nil, "key", "remove", "--user", fqus, "--key-id", devKeyIDStr)
+	require.Error(t, err)
+	require.Equal(t, core.BadArgsError("cannot remove device key"), err)
+}

--- a/proto-src/lcl/user.snowp
+++ b/proto-src/lcl/user.snowp
@@ -51,4 +51,6 @@ protocol User
         sessionId @0 : lib.UISessionID
     ) -> lib.SSOLoginRes;
 
+    removeKey @14 ( key @0 : LocalUserIndexParsed );
+    removeKeyByInfo @15 ( info @0 : lib.UserInfo );
 }

--- a/proto/lcl/user.go
+++ b/proto/lcl/user.go
@@ -664,6 +664,84 @@ func (l *LoginWaitForSsoLoginArg) Decode(dec rpc.Decoder) error {
 
 func (l *LoginWaitForSsoLoginArg) Bytes() []byte { return nil }
 
+type RemoveKeyArg struct {
+	Key LocalUserIndexParsed
+}
+type RemoveKeyArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Key     *LocalUserIndexParsedInternal__
+}
+
+func (r RemoveKeyArgInternal__) Import() RemoveKeyArg {
+	return RemoveKeyArg{
+		Key: (func(x *LocalUserIndexParsedInternal__) (ret LocalUserIndexParsed) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Key),
+	}
+}
+func (r RemoveKeyArg) Export() *RemoveKeyArgInternal__ {
+	return &RemoveKeyArgInternal__{
+		Key: r.Key.Export(),
+	}
+}
+func (r *RemoveKeyArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RemoveKeyArg) Decode(dec rpc.Decoder) error {
+	var tmp RemoveKeyArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RemoveKeyArg) Bytes() []byte { return nil }
+
+type RemoveKeyByInfoArg struct {
+	Info lib.UserInfo
+}
+type RemoveKeyByInfoArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Info    *lib.UserInfoInternal__
+}
+
+func (r RemoveKeyByInfoArgInternal__) Import() RemoveKeyByInfoArg {
+	return RemoveKeyByInfoArg{
+		Info: (func(x *lib.UserInfoInternal__) (ret lib.UserInfo) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Info),
+	}
+}
+func (r RemoveKeyByInfoArg) Export() *RemoveKeyByInfoArgInternal__ {
+	return &RemoveKeyByInfoArgInternal__{
+		Info: r.Info.Export(),
+	}
+}
+func (r *RemoveKeyByInfoArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RemoveKeyByInfoArg) Decode(dec rpc.Decoder) error {
+	var tmp RemoveKeyByInfoArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RemoveKeyByInfoArg) Bytes() []byte { return nil }
+
 type UserInterface interface {
 	Clear(context.Context) error
 	AgentStatus(context.Context) (AgentStatus, error)
@@ -679,6 +757,8 @@ type UserInterface interface {
 	Ping(context.Context) (lib.FQUser, error)
 	LoginStartSsoLoginFlow(context.Context, lib.UISessionID) (SsoLoginFlow, error)
 	LoginWaitForSsoLogin(context.Context, lib.UISessionID) (lib.SSOLoginRes, error)
+	RemoveKey(context.Context, LocalUserIndexParsed) error
+	RemoveKeyByInfo(context.Context, lib.UserInfo) error
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h Header) error
 	MakeResHeader() Header
@@ -1052,6 +1132,52 @@ func (c UserClient) LoginWaitForSsoLogin(ctx context.Context, sessionId lib.UISe
 		}
 	}
 	res = tmp.Data.Import()
+	return
+}
+func (c UserClient) RemoveKey(ctx context.Context, key LocalUserIndexParsed) (err error) {
+	arg := RemoveKeyArg{
+		Key: key,
+	}
+	warg := &rpc.DataWrap[Header, *RemoveKeyArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[Header, interface{}]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(UserProtocolID, 14, "User.removeKey"), warg, &tmp, 0*time.Millisecond, userErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+func (c UserClient) RemoveKeyByInfo(ctx context.Context, info lib.UserInfo) (err error) {
+	arg := RemoveKeyByInfoArg{
+		Info: info,
+	}
+	warg := &rpc.DataWrap[Header, *RemoveKeyByInfoArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[Header, interface{}]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(UserProtocolID, 15, "User.removeKeyByInfo"), warg, &tmp, 0*time.Millisecond, userErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
 	return
 }
 func UserProtocol(i UserInterface) rpc.ProtocolV2 {
@@ -1462,6 +1588,62 @@ func UserProtocol(i UserInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "loginWaitForSsoLogin",
+			},
+			14: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[Header, *RemoveKeyArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *RemoveKeyArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[Header, *RemoveKeyArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						err := i.RemoveKey(ctx, (typedArg.Import()).Key)
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[Header, interface{}]{
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "removeKey",
+			},
+			15: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[Header, *RemoveKeyByInfoArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *RemoveKeyByInfoArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[Header, *RemoveKeyByInfoArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						err := i.RemoveKeyByInfo(ctx, (typedArg.Import()).Info)
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[Header, interface{}]{
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "removeKeyByInfo",
 			},
 		},
 		WrapError: UserMakeGenericErrorWrapper(i.ErrorWrapper()),


### PR DESCRIPTION
- removes a yubikey or backup key from your key list
- interactive or flag-driven mode
- reuse a lot of machinery from `foks key switch`
- add a test
- close #167
- will be in v0.1.2
