### PR TITLE
cli: wrap backup key display via `key new`

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -15,6 +15,8 @@ changelog:
         closes: ["#173"]
       - desc: add bot-token keys, which are like backup keys, but special-cased for bots
         closes: ["#172"]
+      - desc: wrap backup keys on narrow terminals in `key new`
+        closes: ["#148"]
   - version: 0.1.1
     urgency: low
     stable: true

--- a/client/foks/cmd/ui/signup.go
+++ b/client/foks/cmd/ui/signup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/client/libyubi"
 	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/libterm"
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 )
@@ -1568,10 +1569,17 @@ func (s stateFinishNKWNewBackupKey) view(sfb stateFinishBase) string {
 		return fmt.Sprintf("\n %s\n", ErrorStyle.Render("Unexpected state: no backup key"))
 	}
 
+	hespFlat := hesp.Flatten()
+	hespFlatWrapped := libterm.MustRewrapSense(hespFlat.String(), 6)
+
+	instr := libterm.MustRewrapSense(
+		"Here is your key. Please write it down and keep it in a safe place:",
+		2)
+
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s\n", h2Style.Render("💾 New Backup Key Activated 💾"))
-	fmt.Fprintf(&b, " Here is your key. Please write it down and keep it in a safe place:\n")
-	fmt.Fprintf(&b, "\n   %s\n\n", strings.Join(*hesp, " "))
+	fmt.Fprintf(&b, "%s\n", instr)
+	fmt.Fprintf(&b, "\n%s\n\n", hespFlatWrapped)
 	fmt.Fprintf(&b, "\n%s\n\n", pushAnyKeyToExit())
 	return b.String()
 }

--- a/proto/lcl/extras.go
+++ b/proto/lcl/extras.go
@@ -188,6 +188,10 @@ func (s BackupHESP) Flatten() BackupHESPString {
 	return BackupHESPString(strings.Join(s, " "))
 }
 
+func (s BackupHESPString) String() string {
+	return string(s)
+}
+
 func (s SKMWK) String() string                  { return lib.B62Encode(s[:]) }
 func (s SKMWK) MarshalJSON() ([]byte, error)    { return json.Marshal(s.String()) }
 func (s *SKMWK) UnmarshalJSON(dat []byte) error { return lib.UnmarshalJsonFixed((*s)[:], dat) }


### PR DESCRIPTION
- mainly useful for narrow terminals
- close #148
- released in v0.1.2
