### PR TITLE
cli: improved KV ls behavior

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -2,6 +2,13 @@ project: foks
 maintaner: Maxwell Krohn <max@ne43.com>
 
 changelog:
+  - version: 0.1.3
+    urgency: low
+    stable: true
+    date: not yet decided
+    changes:
+      - desc: improve directory listing in KV rest to include file type of entries
+        closes: ["#190"]
   - version: 0.1.2
     urgency: low
     stable: true

--- a/client/libkv/minder.go
+++ b/client/libkv/minder.go
@@ -1869,9 +1869,13 @@ func openDirentToKVListEntry(
 		return name, nil, core.VerifyError("dirent binding mac")
 	}
 	// Tombstoned dirents are not included in the list,
-
 	if de.Value.IsTombstone() {
 		return pyld.Name, nil, nil
+	}
+
+	typ, err := de.Type()
+	if err != nil {
+		return name, nil, err
 	}
 	kvle := lcl.KVListEntry{
 		De:    de.Id,
@@ -1879,6 +1883,7 @@ func openDirentToKVListEntry(
 		Write: de.WriteRole,
 		Value: de.Value,
 		Mtime: de.Ctime, // The Mtime for this directory entry is the CTime of the most recent write
+		Typ:   typ,
 	}
 	return pyld.Name, &kvle, nil
 }

--- a/client/libkv/rest.go
+++ b/client/libkv/rest.go
@@ -411,6 +411,7 @@ type ListEntryJSON struct {
 	Write string    `json:"write"`
 	Mtime time.Time `json:"mtime"`
 	Ctime time.Time `json:"ctime"`
+	Type  string    `json:"type"`
 }
 
 type PaginationJSON struct {
@@ -431,6 +432,19 @@ type ListPageJSON struct {
 
 func MarshalListToJSON(targ http.ResponseWriter, list *lcl.CliKVListRes) error {
 
+	typeToString := func(typ proto.KVNodeType) string {
+		switch typ {
+		case proto.KVNodeType_File, proto.KVNodeType_SmallFile:
+			return "file"
+		case proto.KVNodeType_Dir:
+			return "dir"
+		case proto.KVNodeType_Symlink:
+			return "symlink"
+		default:
+			return "unknown"
+		}
+	}
+
 	var ents []ListEntryJSON
 	for _, e := range list.Ents {
 		wr, err := e.Write.ShortStringErr()
@@ -441,6 +455,7 @@ func MarshalListToJSON(targ http.ResponseWriter, list *lcl.CliKVListRes) error {
 			Name:  e.Name.ToPath().String(),
 			Write: wr,
 			Mtime: e.Mtime.Import(),
+			Type:  typeToString(e.Typ),
 		}
 		ents = append(ents, kvle)
 	}

--- a/proto-src/lcl/kv.snowp
+++ b/proto-src/lcl/kv.snowp
@@ -92,6 +92,7 @@ struct KVListEntry {
     value @3 : lib.KVNodeID;
     mtime @4 : lib.TimeMicro;
     // ctime @5 : lib.TimeMicro; -- retired since this is not easily knowable
+    typ @6 : lib.KVNodeType;
 }
 
 struct ChunkNoncePayload @0xadba174b7e8dcc08 {

--- a/proto/lcl/kv.go
+++ b/proto/lcl/kv.go
@@ -1088,14 +1088,17 @@ type KVListEntry struct {
 	Write lib.Role
 	Value lib.KVNodeID
 	Mtime lib.TimeMicro
+	Typ   lib.KVNodeType
 }
 type KVListEntryInternal__ struct {
-	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
-	De      *lib.DirentIDInternal__
-	Name    *lib.KVPathComponentInternal__
-	Write   *lib.RoleInternal__
-	Value   *lib.KVNodeIDInternal__
-	Mtime   *lib.TimeMicroInternal__
+	_struct     struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	De          *lib.DirentIDInternal__
+	Name        *lib.KVPathComponentInternal__
+	Write       *lib.RoleInternal__
+	Value       *lib.KVNodeIDInternal__
+	Mtime       *lib.TimeMicroInternal__
+	Deprecated5 *struct{}
+	Typ         *lib.KVNodeTypeInternal__
 }
 
 func (k KVListEntryInternal__) Import() KVListEntry {
@@ -1130,6 +1133,12 @@ func (k KVListEntryInternal__) Import() KVListEntry {
 			}
 			return x.Import()
 		})(k.Mtime),
+		Typ: (func(x *lib.KVNodeTypeInternal__) (ret lib.KVNodeType) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(k.Typ),
 	}
 }
 func (k KVListEntry) Export() *KVListEntryInternal__ {
@@ -1139,6 +1148,7 @@ func (k KVListEntry) Export() *KVListEntryInternal__ {
 		Write: k.Write.Export(),
 		Value: k.Value.Export(),
 		Mtime: k.Mtime.Export(),
+		Typ:   k.Typ.Export(),
 	}
 }
 func (k *KVListEntry) Encode(enc rpc.Encoder) error {

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -3931,6 +3931,10 @@ func (k KVPathComponent) ToPath() KVPath {
 	return KVPath(string(k))
 }
 
+func (k KVPathComponent) String() string {
+	return string(k)
+}
+
 func (n NameUtf8) String() string {
 	return string(n)
 }


### PR DESCRIPTION
- in REST mode, say whether the entry is a file, dir, symlink; look in the "type" field
- test new REST ls fields
- options for kv ls: -l, -F, and -U
- will be released in v0.1.3
- close #190
