### PR TITLE
cli: better HTTP response codes for KV REST

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -11,6 +11,8 @@ changelog:
         closes: ["#190"]
       - desc: cleaner flags for KV rest stop/start commands
         closes: ["#191"] 
+      - desc: improve HTTP error responses for KV store
+        closes: ["#196"]
   - version: 0.1.2
     urgency: low
     stable: true

--- a/client/foks/cmd/kv.go
+++ b/client/foks/cmd/kv.go
@@ -229,7 +229,8 @@ so all parent directories are created if they do not exist.
 For now, the REST server will run as the same permissions as the 
 currently-active user. That is, the REST server will give the same
 read and write access to user and team KV-entries that the current
-user has via the 'foks kv' command line.
+user has via the 'foks kv' command line. We might allow finer-grained
+access control in the future.
 `, 0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return subcommandHelp(cmd, args)


### PR DESCRIPTION
- 404 for not found
- 404 also for treating a file like a directory
- close #196
- released in v0.1.3
