### PR TITLE
git: address bug in repo without a main branch

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -13,6 +13,8 @@ changelog:
         closes: ["#191"] 
       - desc: improve HTTP error responses for KV store
         closes: ["#196"]
+      - desc: fix git checkout with no main brain
+        closes: ["#187"]
   - version: 0.1.2
     urgency: low
     stable: true

--- a/client/libkv/gitrefs.go
+++ b/client/libkv/gitrefs.go
@@ -299,7 +299,7 @@ func (g *gitRefSet) loadIn(inp []*gitRef) {
 	}
 	for i := len(inp) - 1; i >= 0; i-- {
 		e := inp[i]
-		if g.latest.IsZero() || g.latest == e.tm {
+		if g.latest.IsZero() || g.latest.Equal(e.tm) {
 			g.latest = e.tm
 			g.latestEntries[e.ei] = struct{}{}
 		}

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/docker/go-connections v0.5.0
 	github.com/fatih/color v1.18.0
 	github.com/foks-proj/go-ctxlog v0.0.0-20250303173751-8f2c09f6847f
-	github.com/foks-proj/go-git-remhelp v0.0.2
+	github.com/foks-proj/go-git-remhelp v0.0.3
 	github.com/foks-proj/go-snowpack-rpc v0.0.2
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-git/go-git/v5 v5.14.0

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ github.com/foks-proj/go-ctxlog v0.0.0-20250303173751-8f2c09f6847f h1:+a3x6K1YmVr
 github.com/foks-proj/go-ctxlog v0.0.0-20250303173751-8f2c09f6847f/go.mod h1:Krvn7SJOuBi1gZx2r40NBOAjftGg2j++3nHiAPis9Oo=
 github.com/foks-proj/go-git-remhelp v0.0.2 h1:DPAJAm26TdK2KOVdu66ZvleOLsQ1LlXCGiuZBf7i1bQ=
 github.com/foks-proj/go-git-remhelp v0.0.2/go.mod h1:64ubmkraJ8SDpgHcsnSyTapwpZgYF/NXZHN8Jx0f1FM=
+github.com/foks-proj/go-git-remhelp v0.0.3 h1:WWlSBjcfXD4znWtgF7g0Pkoi2cMYPjIHkjaM+eUGTxI=
+github.com/foks-proj/go-git-remhelp v0.0.3/go.mod h1:64ubmkraJ8SDpgHcsnSyTapwpZgYF/NXZHN8Jx0f1FM=
 github.com/foks-proj/go-snowpack-compiler v0.0.5 h1:06u7A6/1LRV8B6Y16SXQRlg04V9NnCzEopXXT2snjPg=
 github.com/foks-proj/go-snowpack-compiler v0.0.5/go.mod h1:8XQT6+B9p0g3eluzp6L3ujtk6OuoFOMbkUXTVcytL+E=
 github.com/foks-proj/go-snowpack-rpc v0.0.2 h1:2aYoOTBMMRzvAAJdToEeAEjcNWzUVFHl1J1zpF2lPWI=

--- a/integration-tests/cli/git_test.go
+++ b/integration-tests/cli/git_test.go
@@ -341,6 +341,30 @@ func TestGitMainVsMaster(t *testing.T) {
 	sr2.ReadFile(t, "f1", "11111")
 }
 
+func TestIssue187(t *testing.T) {
+	gte, cleanup := newGitTestEnv(t)
+	defer cleanup()
+	au := gte.newAgentAndUser(t)
+	sr := gte.NewScratchRepo(t)
+
+	merklePoke(t)
+	au.agent.runCmd(t, nil, "git", "create", gte.Desc.RepoName)
+
+	sr.Git(t, "init", "-b", "dev")
+	sr.Git(t, "remote", "add", "origin", sr.Origin())
+
+	sr.WriteFile(t, "a", "11111")
+	sr.Git(t, "add", ".")
+	sr.Git(t, "commit", "-m", "commit 1")
+	sr.Git(t, "push", "-u", "origin", "dev")
+
+	sr2 := gte.NewScratchRepo(t)
+	sr2.Git(t, "clone", sr.Origin())
+
+	sr3 := gte.NewScratchRepo(t)
+	sr3.Git(t, "clone", "-b", "dev", sr.Origin())
+}
+
 func TestGitForcePush(t *testing.T) {
 
 	gte, cleanup := newGitTestEnv(t)


### PR DESCRIPTION
- use time.Equal rather than ==, as suggested by code analysis tools
- bump go-git-remhelp to v0.0.3
- test that repros the issue
- partial fix for #187:
- If you try: `git clone foks://b.k3n.gg/adog1/t2 c2`, you'll get:

```
Cloning into 'c2'...
🦊 Initializing FOKS ... ✅ done
🏗️  Building pack index ... ✅ done
🐕 Fetching from remote ... obj a641ccc5 ... ✅ done
⬇️  Downloading remaining objects 66.6667% (2 of 3) ... ✅ done
warning: remote HEAD refers to nonexistent ref, unable to checkout
```

- note we still have a dangling ref for main and can't check that out
- but checking out non-main directly seems to work:

- `git clone -b dev foks://b.k3n.gg/adog1/t2 c2` yields:

```
Cloning into 'c2'...
🦊 Initializing FOKS ... ✅ done
🏗️  Building pack index ... ✅ done
🐕 Fetching from remote ... obj a641ccc5 ... ✅ done
⬇️  Downloading remaining objects 66.6667% (2 of 3) ... ✅ done
```

- in a following PR, we'll update the HEAD reference accordingly
