### PR TITLE
cli: fix `key switch` and `key remove` UIs

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -19,6 +19,8 @@ changelog:
         closes: ["#204"]  
       - desc: add --all-teams feature to git ls
         closes: ["#197"]
+      - desc: clean up key switch and key remove to display device names better
+        closes: ["#193"]
   - version: 0.1.2
     urgency: low
     stable: true

--- a/client/foks/cmd/common_ui/user.go
+++ b/client/foks/cmd/common_ui/user.go
@@ -60,18 +60,31 @@ func FormatUserInfoAsPromptItem(u proto.UserInfo, opts *FormatUserInfoOpts) (str
 		parts = append(parts, "["+s+"]")
 	}
 
-	if u.YubiInfo != nil && (opts == nil || !opts.NoDeviceName) {
-		s := fmt.Sprintf("<🔑 %s / serial=%d / slot=%d>", u.YubiInfo.Card.Name, u.YubiInfo.Card.Serial, u.YubiInfo.Key.Slot)
-		parts = append(parts, s)
-	}
-
-	if u.KeyGenus == proto.KeyGenus_Backup && (opts == nil || !opts.NoDeviceName) {
-		nm := string(u.Devname)
-		if nm == "" {
-			nm, _ = u.Key.StringErr()
+	if opts == nil || !opts.NoDeviceName {
+		info := string(u.Devname)
+		if info == "" {
+			info, _ = u.Key.StringErr()
 		}
-		s := fmt.Sprintf("<💾 backup key: %s>", nm)
-		parts = append(parts, s)
+		var sgen string
+		switch u.KeyGenus {
+		case proto.KeyGenus_Device:
+			sgen = "📱 device"
+		case proto.KeyGenus_Backup:
+			sgen = "💾 backup key"
+		case proto.KeyGenus_BotToken:
+			sgen = "🤖 bot token"
+		case proto.KeyGenus_Yubi:
+			sgen = "🔑 YubiKey"
+			if u.YubiInfo != nil {
+				sgen = "🔑 " + string(u.YubiInfo.Card.Name)
+				info = fmt.Sprintf("serial=%d / slot=%d",
+					u.YubiInfo.Card.Serial,
+					u.YubiInfo.Key.Slot,
+				)
+			}
+		}
+		part := fmt.Sprintf("<%s: %s>", sgen, info)
+		parts = append(parts, part)
 	}
 
 	if u.Active && (opts == nil || opts.Active) {


### PR DESCRIPTION
- give better information on device names
- include bot-tokens
- yubikey device info in a more consistent form
- code-cleanup
- close #193
- released in v0.1.3
