### PR TITLE
cli: simplify args to `key switch` and `key remove`

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -21,6 +21,8 @@ changelog:
         closes: ["#197"]
       - desc: clean up key switch and key remove to display device names better
         closes: ["#193"]
+      - desc: simplify args to key switch and removal (no find via key "genus" or role)
+        closes: ["#208"]
   - version: 0.1.2
     urgency: low
     stable: true

--- a/client/foks/cmd/parse.go
+++ b/client/foks/cmd/parse.go
@@ -20,13 +20,6 @@ func (s BadSubCommandError) Error() string {
 	return "bad subcommand: " + string(s)
 }
 
-func parseRole(s string, def *proto.Role) (*proto.Role, error) {
-	if len(s) == 0 {
-		return def, nil
-	}
-	return proto.RoleString(s).Parse()
-}
-
 func parseFqu(s string) (*proto.FQUserParsed, error) {
 	if len(s) == 0 {
 		return nil, nil

--- a/client/libclient/all_users.go
+++ b/client/libclient/all_users.go
@@ -491,13 +491,6 @@ func LookupUserInAllUsers(
 		if !ok {
 			return false, nil
 		}
-		ok, err = u.Role.Eq(i.Role)
-		if err != nil {
-			return false, err
-		}
-		if !ok {
-			return false, nil
-		}
 		return true, nil
 	}
 
@@ -513,9 +506,6 @@ func LookupUserInAllUsers(
 			continue
 		}
 
-		if u.KeyGenus != nil && e.KeyGenus != *u.KeyGenus {
-			continue
-		}
 		if u.KeyID != nil && !e.Key.Eq(u.KeyID) {
 			continue
 		}

--- a/integration-tests/cli/revoke_test.go
+++ b/integration-tests/cli/revoke_test.go
@@ -277,7 +277,9 @@ func TestSelfProvisionThenRevoke(t *testing.T) {
 	require.True(t, findDevice())
 
 	aInfoDev := getActiveUser(t, a)
-	a.runCmd(t, nil, "key", "switch", "--yubi", "-u", aStr)
+	yubiDev, err := aInfoYubi.Key.StringErr()
+	require.NoError(t, err)
+	a.runCmd(t, nil, "key", "switch", "-u", aStr, "--key-id", yubiDev)
 
 	dev, err := aInfoDev.Key.StringErr()
 	require.NoError(t, err)

--- a/proto-src/lcl/user.snowp
+++ b/proto-src/lcl/user.snowp
@@ -7,8 +7,8 @@ go:import "github.com/foks-proj/go-foks/proto/lib" as lib;
 
 struct LocalUserIndexParsed {
     fqu @0 : lib.FQUserParsed;
-    role @1 : lib.Role;
-    keyGenus @2 : Option(lib.KeyGenus);
+    // role @1 : lib.Role; // Deprecated 
+    // keyGenus @2 : Option(lib.KeyGenus); // Deprecated
     keyID @3 : lib.EntityID; // optional, for disambiguation
 }
 

--- a/proto-src/lib/common.snowp
+++ b/proto-src/lib/common.snowp
@@ -347,7 +347,7 @@ struct PartyName {
 enum PartyType {
     User @0;
     Team @1;
-gte.Desc.RepoName}
+}
 
 variant ParsedParty switch (s : bool) {
     case false @0 : PartyID;

--- a/proto/lcl/user.go
+++ b/proto/lcl/user.go
@@ -13,17 +13,15 @@ import (
 import lib "github.com/foks-proj/go-foks/proto/lib"
 
 type LocalUserIndexParsed struct {
-	Fqu      lib.FQUserParsed
-	Role     lib.Role
-	KeyGenus *lib.KeyGenus
-	KeyID    lib.EntityID
+	Fqu   lib.FQUserParsed
+	KeyID lib.EntityID
 }
 type LocalUserIndexParsedInternal__ struct {
-	_struct  struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
-	Fqu      *lib.FQUserParsedInternal__
-	Role     *lib.RoleInternal__
-	KeyGenus *lib.KeyGenusInternal__
-	KeyID    *lib.EntityIDInternal__
+	_struct     struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Fqu         *lib.FQUserParsedInternal__
+	Deprecated1 *struct{}
+	Deprecated2 *struct{}
+	KeyID       *lib.EntityIDInternal__
 }
 
 func (l LocalUserIndexParsedInternal__) Import() LocalUserIndexParsed {
@@ -34,24 +32,6 @@ func (l LocalUserIndexParsedInternal__) Import() LocalUserIndexParsed {
 			}
 			return x.Import()
 		})(l.Fqu),
-		Role: (func(x *lib.RoleInternal__) (ret lib.Role) {
-			if x == nil {
-				return ret
-			}
-			return x.Import()
-		})(l.Role),
-		KeyGenus: (func(x *lib.KeyGenusInternal__) *lib.KeyGenus {
-			if x == nil {
-				return nil
-			}
-			tmp := (func(x *lib.KeyGenusInternal__) (ret lib.KeyGenus) {
-				if x == nil {
-					return ret
-				}
-				return x.Import()
-			})(x)
-			return &tmp
-		})(l.KeyGenus),
 		KeyID: (func(x *lib.EntityIDInternal__) (ret lib.EntityID) {
 			if x == nil {
 				return ret
@@ -62,14 +42,7 @@ func (l LocalUserIndexParsedInternal__) Import() LocalUserIndexParsed {
 }
 func (l LocalUserIndexParsed) Export() *LocalUserIndexParsedInternal__ {
 	return &LocalUserIndexParsedInternal__{
-		Fqu:  l.Fqu.Export(),
-		Role: l.Role.Export(),
-		KeyGenus: (func(x *lib.KeyGenus) *lib.KeyGenusInternal__ {
-			if x == nil {
-				return nil
-			}
-			return (*x).Export()
-		})(l.KeyGenus),
+		Fqu:   l.Fqu.Export(),
 		KeyID: l.KeyID.Export(),
 	}
 }


### PR DESCRIPTION
- no more query-by-key-genus or role
- provide an FQU, which works if not ambiguous
- if ambiguous, you can also provide a keyID
- no ability to just use a KeyID though it should work, so maybe we add this late
- close #208
- released in v0.1.3
