### PR TITLE
cli: fix crash in `key switch` and `key remove`

### DIFF
--- a/client/foks/cmd/key.go
+++ b/client/foks/cmd/key.go
@@ -302,6 +302,13 @@ func (s *switchCmdCfg) parse() (*lcl.LocalUserIndexParsed, error) {
 	if err != nil {
 		return nil, err
 	}
+	if fqu == nil && len(eid) > 0 {
+		return nil, ArgsError("user must be specified if key-id is provided")
+	}
+
+	if fqu == nil {
+		return nil, nil
+	}
 
 	ret := lcl.LocalUserIndexParsed{
 		Fqu:   *fqu,


### PR DESCRIPTION
- most of the time, --user is not specified, but with this bug, the CLI front-end would crash
- bug introduced in #209
- close #210
- released in v0.1.4 (emergency fix)
