### PR TITLE
Update team.go

### DIFF
--- a/client/foks/cmd/team.go
+++ b/client/foks/cmd/team.go
@@ -157,7 +157,7 @@ func teamAccept(m libclient.MetaContext, top *cobra.Command) {
 		Aliases: []string{"acc"},
 		Short:   "accept a team invite",
 		Long: libterm.MustRewrapSense(`Accept a team invite given an invite code.
-The invite code is good for exactly on team. By default, accept the invitation for
+The invite code is good for exactly one team. By default, accept the invitation for
 your user, at the role Owner. Optionally, you can specify a team and/or a 
 source role, if you want to accept the invitation on behalf of a team, or with
 a role other than the default.`, 0),


### PR DESCRIPTION
I believe the intended sentence was "...exactly one team" instead of "...exactly on team".  Sorry for such a small PR but figured this was the easiest way to fix.