### PR TITLE
autocert: fix standup and CLI one-shot

### DIFF
--- a/proto-src/infra/autocert.snowp
+++ b/proto-src/infra/autocert.snowp
@@ -12,6 +12,7 @@ struct AutocertPackage {
     hostid @1 : lib.HostID;
     styp @2 : lib.ServerType;
     isVanity @3 : Bool;
+    forceNow @4 : Bool;
 }
 
 protocol Autocert errors lib.Status @0xb9515d98 {

--- a/proto/infra/autocert.go
+++ b/proto/infra/autocert.go
@@ -52,6 +52,7 @@ type AutocertPackage struct {
 	Hostid   lib.HostID
 	Styp     lib.ServerType
 	IsVanity bool
+	ForceNow bool
 }
 type AutocertPackageInternal__ struct {
 	_struct  struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -59,6 +60,7 @@ type AutocertPackageInternal__ struct {
 	Hostid   *lib.HostIDInternal__
 	Styp     *lib.ServerTypeInternal__
 	IsVanity *bool
+	ForceNow *bool
 }
 
 func (a AutocertPackageInternal__) Import() AutocertPackage {
@@ -87,6 +89,12 @@ func (a AutocertPackageInternal__) Import() AutocertPackage {
 			}
 			return *x
 		})(a.IsVanity),
+		ForceNow: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(a.ForceNow),
 	}
 }
 func (a AutocertPackage) Export() *AutocertPackageInternal__ {
@@ -95,6 +103,7 @@ func (a AutocertPackage) Export() *AutocertPackageInternal__ {
 		Hostid:   a.Hostid.Export(),
 		Styp:     a.Styp.Export(),
 		IsVanity: &a.IsVanity,
+		ForceNow: &a.ForceNow,
 	}
 }
 func (a *AutocertPackage) Encode(enc rpc.Encoder) error {

--- a/server/shared/autocert.go
+++ b/server/shared/autocert.go
@@ -94,6 +94,8 @@ func (a *RealAutocertDoer) Stop() {
 
 func (a *RealAutocertDoer) DoOne(m MetaContext, pkg AutocertPackage) error {
 
+	m.Infow("RealAutocertDoer.DoOne", "hn", pkg.Hostname)
+
 	err := a.fetchCerts(m, pkg)
 	if err != nil {
 		return err


### PR DESCRIPTION
- standup wrote out a buggy docker-compose, neglecting to expose the HTTP port to the docker container for the autocert service
  - as we know, LetsEncrypt probes this port for proof of DNS ownership over HTTP.
  - extend docker-compose to include this port exposure
- fix `foks-tool autocert`, which broke when we switched to a background autocert looper
- close #217
