### PR TITLE
git: handle 0-length files

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -2,6 +2,15 @@ project: foks
 maintaner: Maxwell Krohn <max@ne43.com>
 
 changelog:
+  - version: 0.1.5
+    urgency: low
+    stable: true
+    date: TBD
+    changes:
+      - desc: fix bugs in cert refresh in standup
+        closes: ["#217"]
+      - desc: fix git bug; crasher on empty blobs (found in empty files)
+        closes: ["#219"]
   - version: 0.1.4
     urgency: low
     stable: true

--- a/client/libgit/adapter.go
+++ b/client/libgit/adapter.go
@@ -173,11 +173,16 @@ func (r *readerWithBonusByte) Read(p []byte) (int, error) {
 	}
 	p[0] = r.val
 	r.done = true
+
+	// See issue-219; note that if the blob we are reading is empty,
+	// we'll get ret=0, err=EOF. We can't error out here, we still
+	// need to return the one byte we have. Thus we update ret
+	// in the EOF case as well as the non-error case.
 	ret, err := r.r.Read(p[1:])
-	if err != nil {
-		return ret, err
+	if err == nil || errors.Is(err, io.EOF) {
+		ret += 1
 	}
-	return 1 + ret, nil
+	return ret, err
 }
 
 var _ io.Reader = (*readerWithBonusByte)(nil)

--- a/integration-tests/cli/git_test.go
+++ b/integration-tests/cli/git_test.go
@@ -528,3 +528,23 @@ func TestGetSetDefaultBranch(t *testing.T) {
 	sr4.Git(t, "clone", sr.Origin(), ".")
 	sr4.ReadFile(t, "f2", "22222")
 }
+
+func TestEmptyFile(t *testing.T) {
+	gte, cleanup := newGitTestEnv(t)
+	defer cleanup()
+	au := gte.newAgentAndUser(t)
+	sr := gte.NewScratchRepo(t)
+
+	sr.Git(t, "init")
+	merklePoke(t)
+	au.agent.runCmd(t, nil, "git", "create", gte.Desc.RepoName)
+	sr.WriteFile(t, "f1", "")
+	sr.Git(t, "add", ".")
+	sr.Git(t, "commit", "-m", "f1")
+	sr.Git(t, "remote", "add", "origin", sr.Origin())
+	sr.Git(t, "push", "origin", "main")
+
+	sr2 := gte.NewScratchRepo(t)
+	sr2.Git(t, "clone", sr.Origin(), ".")
+	sr2.ReadFile(t, "f1", "")
+}


### PR DESCRIPTION
- issue repro'ed, test created
- close issue #219
- the bug was that our `readerWithBonusByte` wrapper class did not correctly handle 0-length files
- in these cases, we get n=0, err=EOF, but it's still a valid outcome
- if the git object is 0 bytes, we need to write down 1 byte, since recall our file format is the file type, followed by the blob.
- released in v0.1.5
