### PR TITLE
kv-store: fix bug that prevents cross-host FS usage

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -11,6 +11,8 @@ changelog:
         closes: ["#217"]
       - desc: fix git bug; crasher on empty blobs (found in empty files)
         closes: ["#219"]
+      - desc: fix kv-store bug that disallowed cross-host teams from accessing files
+        closes: ["#215"]
   - version: 0.1.4
     urgency: low
     stable: true

--- a/lib/core/errors.go
+++ b/lib/core/errors.go
@@ -398,7 +398,7 @@ type HostMismatchError struct {
 }
 
 func (h HostMismatchError) Error() string {
-	ret := "hostname mismatch"
+	ret := "host mismatch"
 	if h.Which != "" {
 		ret += ": " + h.Which
 	}

--- a/lib/core/rpc_client.go
+++ b/lib/core/rpc_client.go
@@ -534,6 +534,10 @@ func MakeConfigConnHook(
 		clienter = func(cli *rpc.Client) selector {
 			return NewRegClient(cli, wcw)
 		}
+	case proto.ServerType_KVStore:
+		clienter = func(cli *rpc.Client) selector {
+			return NewKVStoreClient(cli, wcw)
+		}
 	case proto.ServerType_MerkleQuery:
 		clienter = func(cli *rpc.Client) selector {
 			return NewMerkleQueryClient(cli, wcw)

--- a/proto-src/rem/kv.snowp
+++ b/proto-src/rem/kv.snowp
@@ -164,4 +164,8 @@ protocol KVStore
     kvUsage @17 (
         auth @0 : KVAuth
     ) -> lib.KVUsage;
+
+    selectVHost @18 (
+        host @0 : lib.HostID
+    ) : KVSelectVhost;
 }

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -11,6 +11,7 @@ import (
 	"crypto/elliptic"
 	"crypto/hmac"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -4602,15 +4603,18 @@ func (k CKSEncKeyString) Parse() (*CKSEncKey, error) {
 	return &ret, nil
 }
 
-func (t ServerType) ClientCAType() CKSAssetType {
+func (t ServerType) ClientCAType() (CKSAssetType, tls.ClientAuthType) {
+	cat := tls.NoClientCert
 	switch t {
 	case ServerType_Queue, ServerType_Quota, ServerType_MerkleBatcher,
 		ServerType_MerkleBuilder, ServerType_MerkleSigner, ServerType_Autocert:
-		return CKSAssetType_InternalClientCA
-	case ServerType_User, ServerType_KVStore:
-		return CKSAssetType_ExternalClientCA
+		return CKSAssetType_InternalClientCA, tls.RequireAndVerifyClientCert
+	case ServerType_User:
+		return CKSAssetType_ExternalClientCA, tls.RequireAndVerifyClientCert
+	case ServerType_KVStore:
+		return CKSAssetType_ExternalClientCA, tls.VerifyClientCertIfGiven
 	default:
-		return CKSAssetType_None
+		return CKSAssetType_None, cat
 	}
 }
 

--- a/server/kv-store/server.go
+++ b/server/kv-store/server.go
@@ -163,8 +163,8 @@ func (c *ClientConn) auth(
 		}
 		pid = idOrName.True().ToPartyID()
 		role = tmp.Role
-		if !tmp.Req.Member.Host.Eq(m.HostID().Id) {
-			return core.HostMismatchError{}
+		if !tmp.Req.Team.Host.Eq(m.HostID().Id) {
+			return core.HostMismatchError{Which: "team host in kv-store auth"}
 		}
 	default:
 		return core.BadArgsError("invalid auth type")
@@ -415,6 +415,13 @@ func (c *ClientConn) KvUsage(
 		})
 	return res, err
 
+}
+
+func (c *ClientConn) SelectVHost(
+	ctx context.Context,
+	arg proto.HostID,
+) error {
+	return shared.SelectVHost(ctx, c, arg)
 }
 
 var _ rem.KVStoreInterface = (*ClientConn)(nil)

--- a/server/shared/cks.go
+++ b/server/shared/cks.go
@@ -646,14 +646,17 @@ func (c *CertVaultCKS) MakeGetConfigForClient(
 
 		ret := cfg.Clone()
 
-		ccat := styp.ClientCAType()
-		if ccat == proto.CKSAssetType_InternalClientCA ||
-			ccat == proto.CKSAssetType_ExternalClientCA {
-			pool, err := c.Pool(m, nil, ccat, hn)
+		cliCAType, authMode := styp.ClientCAType()
+		if cliCAType == proto.CKSAssetType_InternalClientCA ||
+			cliCAType == proto.CKSAssetType_ExternalClientCA {
+			pool, err := c.Pool(m, nil, cliCAType, hn)
 			if err != nil {
 				return nil, err
 			}
-			ret.ClientAuth = tls.RequireAndVerifyClientCert
+			if authMode != tls.RequireAndVerifyClientCert && authMode != tls.VerifyClientCertIfGiven {
+				return nil, core.InternalError("bad client auth mode from server type")
+			}
+			ret.ClientAuth = authMode
 			ret.ClientCAs = pool
 		}
 


### PR DESCRIPTION
- repro of #215 - TestCrossHostKV
- change the client auth mechanism for KV store server
  - don't require client certs, make them optional
  - for local-host usecases we'll use x509 client cert auth, as before
  - for remote-host team usecases, we'll use team vo bearer token, and no client certs (new)
  - so it turns out kv store needs flexibility -- it sometimes uses client CAs, and sometimes not -- so we have to change the TLS framework to allow for that
  - this capability is generic, if other servers need to use it later
- fix a bug in host ID matching in team vo bearer token auth, which we never hit
- this solves the issue and all tests pass
- close #215
- needs new server software, since kv-store server needs slightly different auth
- fix bug in hostid checking
- released with v0.1.5
- tighten up host mismatch error message
