### PR TITLE
Small shell script tweaks

### DIFF
--- a/client/foks/cmd/git.go
+++ b/client/foks/cmd/git.go
@@ -93,7 +93,7 @@ func gitShellConfig(m libclient.MetaContext, top *cobra.Command) {
 			if err != nil {
 				return err
 			}
-			term.Printf("export FOKS_CONFIG=%s\n", cfg)
+			term.Printf("export FOKS_CONFIG='%s'\n", cfg)
 			path := filepath.Dir(os.Args[0])
 			if path != "" && path != "." && path != "./" {
 				term.Printf("export PATH=%s:$PATH\n", path)

--- a/scripts/git-link.sh
+++ b/scripts/git-link.sh
@@ -2,5 +2,9 @@
 # Copyright (c) 2025 ne43, Inc.
 # Licensed under the MIT License. See LICENSE in the project root for details.
 
-
-(cd $(dirname $(which foks)) && ln -sf foks git-remote-foks) 
+FOKS_BIN_PATH=$(which foks)
+if [ -z "$FOKS_BIN_PATH" ]; then
+    echo "foks binary not found in PATH, cannot create git-remote-foks link"
+    exit 1
+fi
+(cd $(dirname $FOKS_BIN_PATH) && ln -sf foks git-remote-foks) 


### PR DESCRIPTION
On macOS, the FOKS_CONFIG lives in a path that has a space, which if unquoted results in the variable being incorrectly set after running `make shell-config`.
`export FOKS_CONFIG=/Users/jaroddeweese/Library/Application Support/foks/config.jsonnet` actually is getting set as `export FOKS_CONFIG=/Users/jaroddeweese/Library/Application`

This PR fixes this, as well as adds a check and logging to the `git-link.sh` script