### PR TITLE
cli: fix broken `revoke` of bot-tokens

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -9,6 +9,10 @@ changelog:
     changes:
       - desc: fix autocert refresh intervals to use what LE sends backout
         closes: ["#225"]
+      - desc: Fix bug in revoking bot-token keys
+        closes: ["#231"]
+      - desc: Improve log rotation on `standup` 
+        closes: ["#228"]
   - version: 0.1.5
     urgency: low
     stable: true

--- a/integration-tests/cli/bot_token_test.go
+++ b/integration-tests/cli/bot_token_test.go
@@ -101,4 +101,9 @@ func TestBotTokenNewAndLoad(t *testing.T) {
 	require.Equal(t, nm, ad.Di.Dn.Name)
 	require.Equal(t, bkid, ad.Di.Key.Member.Id.Entity)
 	require.Equal(t, proto.DeviceType_BotToken, ad.Di.Dn.Label.DeviceType)
+
+	// Revoke the bot token key (issue #231 repro).
+	bkidStr, err := bkid.StringErr()
+	require.NoError(t, err)
+	b.runCmd(t, nil, "key", "revoke", bkidStr)
 }

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -3555,6 +3555,8 @@ func (e EntityType) KeyGenus() (KeyGenus, error) {
 		kg = KeyGenus_Yubi
 	case EntityType_BackupKey:
 		kg = KeyGenus_Backup
+	case EntityType_BotTokenKey:
+		kg = KeyGenus_BotToken
 	default:
 		return kg, DataError("bad entity type")
 	}


### PR DESCRIPTION
- repro the issue
- revoke worked but fizzled out when trying to clean up local keys, making an ugly error
- close #231
- live in 0.1.6
