### PR TITLE
claude security audit: 2 highs, 1 medium

### DIFF
--- a/integration-tests/common/env.go
+++ b/integration-tests/common/env.go
@@ -383,7 +383,7 @@ func (w *TestEnv) BeaconRegisterReturnErr() error {
 	}
 	port := proto.Port(addr.Port)
 	hostID := m.G().HostID().Id
-	err = shared.BeaconRegisterSrv(m, hostname, port, hostID, time.Hour)
+	err = shared.BeaconRegisterSrv(m, hostname, port, hostID, time.Hour, "")
 	return err
 
 }

--- a/integration-tests/common/setup.go
+++ b/integration-tests/common/setup.go
@@ -375,6 +375,10 @@ func configureServers(
 	}
 	config.Apps.Merkle = &merkleBuilderConfigData
 
+	config.Apps.Beacon = &shared.BeaconConfigJSON{
+		AllowPrivateIPs_: true,
+	}
+
 	config.Apps.Quota = &shared.QuotaConfigJSON{
 		LooperConfigJSON: shared.LooperConfigJSON{
 			PollWaitMilliseconds_: 1000 * 60 * 60, // one hour, so it basically is driven by active poking.

--- a/integration-tests/lib/beacon_test.go
+++ b/integration-tests/lib/beacon_test.go
@@ -48,7 +48,7 @@ func TestBeaconProbe(t *testing.T) {
 
 	tester := func() {
 
-		err = shared.BeaconRegisterSrv(m, hostname, port, hostID, time.Hour)
+		err = shared.BeaconRegisterSrv(m, hostname, port, hostID, time.Hour, "")
 		require.NoError(t, err)
 		ret, err := shared.BeaconLookup(m, hostID)
 		require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestBeaconProbe(t *testing.T) {
 	tester()
 
 	hostID[5] ^= 0x01
-	err = shared.BeaconRegisterSrv(m, hostname, port, hostID, time.Hour)
+	err = shared.BeaconRegisterSrv(m, hostname, port, hostID, time.Hour, "")
 	require.Error(t, err)
 	require.Equal(t, core.HostMismatchError{Which: "hostID"}, err)
 
@@ -107,11 +107,11 @@ func TestBeaconHostnames(t *testing.T) {
 	// It still works to connect to p1 via the alias p2, but
 	// we check hostname equality in the beacon registration, and it
 	// should fail.
-	err := shared.BeaconRegisterSrv(m, p2, port, hostID, time.Hour)
+	err := shared.BeaconRegisterSrv(m, p2, port, hostID, time.Hour, "")
 	require.Error(t, err)
 	require.Equal(t, core.HostMismatchError{Which: "hostname"}, err)
 
-	err = shared.BeaconRegisterSrv(m, proto.Hostname(strings.ToUpper(string(p1))), port, hostID, time.Hour)
+	err = shared.BeaconRegisterSrv(m, proto.Hostname(strings.ToUpper(string(p1))), port, hostID, time.Hour, "")
 	require.NoError(t, err)
 
 	ret, err := shared.BeaconLookup(m, hostID)

--- a/lib/core/rpc_client.go
+++ b/lib/core/rpc_client.go
@@ -196,6 +196,9 @@ func (c *connectionMgr) makeTlsConfig(m RpcClientMetaContexter) (*tls.Config, er
 			cfg.Certificates = []tls.Certificate{*cert}
 		}
 	}
+	if c.opts != nil && c.opts.ServerName != "" {
+		cfg.ServerName = c.opts.ServerName
+	}
 	return cfg, nil
 }
 
@@ -326,7 +329,8 @@ type RpcClientOpts struct {
 	MinConnectWait     time.Duration
 	ConfigConnHook     func(context.Context, rpc.Transporter) error
 
-	DebugName string
+	DebugName  string
+	ServerName string // if set, override TLS ServerName (for connecting to a pre-resolved IP)
 
 	// For testing purposes
 	Clock                clockwork.Clock

--- a/server/engine/beacon.go
+++ b/server/engine/beacon.go
@@ -6,6 +6,7 @@ package engine
 import (
 	"context"
 	"flag"
+	"net"
 	"time"
 
 	"github.com/foks-proj/go-foks/lib/core"
@@ -54,13 +55,48 @@ func (c *BeaconClientConn) ErrorWrapper() func(error) proto.Status {
 	return core.ErrorToStatus
 }
 
+func isPrivateIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsLinkLocalUnicast()
+}
+
+// checkDialAddr checks that the resolves DNS name doesn't point to an internal
+// IP address, to avoid SSRF attacks.
+func checkDialAddr(m shared.MetaContext, host proto.Hostname, port proto.Port) (proto.TCPAddr, error) {
+	var ret proto.TCPAddr
+	bcfg, err := m.G().Config().BeaconServerConfig(m.Ctx())
+	if err != nil {
+		return ret, err
+	}
+	if bcfg.AllowPrivateIPs() {
+		return ret, nil
+	}
+	ips, err := net.LookupIP(host.String())
+	if err != nil {
+		return ret, core.BadArgsError("cannot resolve hostname")
+	}
+
+	for _, ip := range ips {
+		if isPrivateIP(ip) {
+			return ret, core.BadArgsError("cannot register a hostname that resolves to a private IP address")
+		}
+	}
+	if len(ips) > 0 {
+		ret = proto.NewTCPAddr(proto.Hostname(ips[0].String()), port)
+	}
+	return ret, nil
+}
+
 func (c *BeaconClientConn) BeaconRegister(ctx context.Context, arg rem.BeaconRegisterArg) error {
 	m := shared.NewMetaContext(ctx, c.srv.G())
 	timeout := 3 * time.Minute
 	if arg.Host.IsIPAddr() {
 		return core.BadArgsError("cannot register an IP address")
 	}
-	return shared.BeaconRegisterSrv(m, arg.Host, arg.Port, arg.HostID, timeout)
+	dialAddr, err := checkDialAddr(m, arg.Host, arg.Port)
+	if err != nil {
+		return err
+	}
+	return shared.BeaconRegisterSrv(m, arg.Host, arg.Port, arg.HostID, timeout, dialAddr)
 }
 
 func (c *BeaconClientConn) BeaconLookup(ctx context.Context, arg proto.HostID) (proto.TCPAddr, error) {

--- a/server/foks-tool/standup.go
+++ b/server/foks-tool/standup.go
@@ -1032,8 +1032,8 @@ func (e *StandupEng) makeFoksUser(m shared.MetaContext) (err error) {
 			if err != nil {
 				return err
 			}
-			if strings.Contains(e.dbpw, "'") {
-				return core.BadArgsError("database password cannot contain single quotes")
+			if strings.Contains(e.dbpw, "'") || strings.Contains(e.dbpw, "\\") {
+				return core.BadArgsError("database password cannot contain single quotes or backslashes")
 			}
 			_, err = conn.Exec(
 				m.Ctx(),

--- a/server/shared/aws.go
+++ b/server/shared/aws.go
@@ -58,7 +58,6 @@ func (r *AWSRoute53DNSSetter) awsConfig(m MetaContext) (*aws.Config, error) {
 		return nil, core.ConfigError("missing AWS secret key")
 	}
 
-	m.Infow("AWSRoute53.awsConfig", "access_key", r.creds.AccessKey())
 	customCreds := aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(
 		r.creds.AccessKey(),
 		r.creds.SecretKey(),

--- a/server/shared/beacon_probe.go
+++ b/server/shared/beacon_probe.go
@@ -17,25 +17,31 @@ import (
 // only stores one row per host, for now. This storage is in SQL not SQLite. So it's
 // slightly different.
 type BeaconProbe struct {
-	host    proto.Hostname
-	port    proto.Port
-	addr    proto.TCPAddr
-	hostID  proto.HostID
-	timeout time.Duration
-	res     *rem.ProbeRes
-	prev    *core.Hostchain
-	ch      *core.Hostchain
-	pz      *proto.PublicZone
+	host     proto.Hostname
+	port     proto.Port
+	addr     proto.TCPAddr
+	dialAddr proto.TCPAddr
+	hostID   proto.HostID
+	timeout  time.Duration
+	res      *rem.ProbeRes
+	prev     *core.Hostchain
+	ch       *core.Hostchain
+	pz       *proto.PublicZone
 }
 
-func NewBeaconProbe(h proto.Hostname, p proto.Port, i proto.HostID, t time.Duration) *BeaconProbe {
+func NewBeaconProbe(h proto.Hostname, p proto.Port, i proto.HostID, t time.Duration, dialAddr proto.TCPAddr) *BeaconProbe {
+	addr := proto.NewTCPAddr(h, p)
+	if dialAddr == "" {
+		dialAddr = addr
+	}
 	return &BeaconProbe{
-		host:    h,
-		port:    p,
-		hostID:  i,
-		timeout: t,
-		prev:    nil,
-		addr:    proto.NewTCPAddr(h, p),
+		host:     h,
+		port:     p,
+		hostID:   i,
+		timeout:  t,
+		prev:     nil,
+		addr:     addr,
+		dialAddr: dialAddr,
 	}
 }
 
@@ -78,12 +84,17 @@ func (b *BeaconProbe) probe(m MetaContext) error {
 		return err
 	}
 	rm := RpcClientMetaContext{MetaContext: m}
+	var opts *core.RpcClientOpts
+	if b.dialAddr != b.addr {
+		opts = core.NewRpcClientOpts()
+		opts.ServerName = b.addr.Hostname().String()
+	}
 	cli := core.NewRpcClient(
 		rm,
-		b.addr,
+		b.dialAddr,
 		rootCAs,
 		nil,
-		nil,
+		opts,
 	)
 	defer cli.Shutdown()
 	pcli := core.NewProbeClient(cli, m)
@@ -237,8 +248,8 @@ func (b *BeaconProbe) Run(m MetaContext) error {
 	})
 }
 
-func BeaconRegisterSrv(m MetaContext, host proto.Hostname, port proto.Port, hid proto.HostID, timeout time.Duration) error {
-	return NewBeaconProbe(host, port, hid, timeout).Run(m)
+func BeaconRegisterSrv(m MetaContext, host proto.Hostname, port proto.Port, hid proto.HostID, timeout time.Duration, dialAddr proto.TCPAddr) error {
+	return NewBeaconProbe(host, port, hid, timeout, dialAddr).Run(m)
 }
 
 func BeaconLookup(m MetaContext, hid proto.HostID) (proto.TCPAddr, error) {

--- a/server/shared/config.go
+++ b/server/shared/config.go
@@ -242,6 +242,7 @@ type Config interface {
 	// configurations.
 	MerkleBuilderServerConfig(ctx context.Context) (MerkleBuilderServerConfigger, error)
 	QuotaServerConfig(ctx context.Context) (QuotaServerConfigger, error)
+	BeaconServerConfig(ctx context.Context) (BeaconServerConfigger, error)
 
 	// Get the address and x509 cert to use to connect to the external beacon service,
 	// which for now is a single service running across all FOKS servers.
@@ -333,6 +334,16 @@ func (d DefaultQuotaServerConfig) GetDelay() time.Duration { return time.Minute 
 func (d DefaultQuotaServerConfig) GetNoPlanMaxTeams() int  { return 2 }
 
 var _ QuotaServerConfigger = DefaultQuotaServerConfig{}
+
+type BeaconServerConfigger interface {
+	AllowPrivateIPs() bool
+}
+
+type DefaultBeaconServerConfig struct{}
+
+func (d DefaultBeaconServerConfig) AllowPrivateIPs() bool { return false }
+
+var _ BeaconServerConfigger = DefaultBeaconServerConfig{}
 
 type DefaultTeamConfig struct{}
 
@@ -564,6 +575,9 @@ func (c *EmptyConfig) MerkleBuilderServerConfig(ctx context.Context) (MerkleBuil
 	return nil, NewEmptyConfigError()
 }
 func (c *EmptyConfig) QuotaServerConfig(ctx context.Context) (QuotaServerConfigger, error) {
+	return nil, NewEmptyConfigError()
+}
+func (c *EmptyConfig) BeaconServerConfig(ctx context.Context) (BeaconServerConfigger, error) {
 	return nil, NewEmptyConfigError()
 }
 func (c *EmptyConfig) QueueServiceConfig(ctx context.Context) (*QueueServiceConfig, error) {

--- a/server/shared/config_jsonnet.go
+++ b/server/shared/config_jsonnet.go
@@ -86,6 +86,19 @@ type VHostsConfigJSON struct {
 var _ StripeConfigger = (*StripeConfigJSON)(nil)
 var _ VHostsConfigger = (*VHostsConfigJSON)(nil)
 
+type BeaconConfigJSON struct {
+	AllowPrivateIPs_ bool `json:"allow_private_ips"`
+}
+
+func (b *BeaconConfigJSON) AllowPrivateIPs() bool {
+	if b == nil {
+		return false
+	}
+	return b.AllowPrivateIPs_
+}
+
+var _ BeaconServerConfigger = (*BeaconConfigJSON)(nil)
+
 type UserServerConfigJSON struct {
 	BadLoginRateLimit_ RateLimit `json:"bad_login_rate_limit"`
 }
@@ -300,6 +313,7 @@ type JSonnetTemplateNoLog struct {
 		Merkle  *MerkleConfigJSON        `json:"merkle"`
 		Quota   *QuotaConfigJSON         `json:"quota"`
 		Web     *WebConfigJSON           `json:"web"`
+		Beacon  *BeaconConfigJSON        `json:"beacon"`
 	} `json:"apps"`
 	CKS    *CKSConfigJSON    `json:"cks"`
 	PKIX   *PKIXConfigJSON   `json:"pkix"`
@@ -656,6 +670,14 @@ func (c *ConfigJSonnet) QuotaServerConfig(ctx context.Context) (QuotaServerConfi
 		return c.Data.Apps.Quota, nil
 	}
 	return DefaultQuotaServerConfig{}, nil
+}
+func (c *ConfigJSonnet) BeaconServerConfig(ctx context.Context) (BeaconServerConfigger, error) {
+	c.RLock()
+	defer c.RUnlock()
+	if c.Data.Apps.Beacon != nil {
+		return c.Data.Apps.Beacon, nil
+	}
+	return DefaultBeaconServerConfig{}, nil
 }
 func (c *ConfigJSonnet) QueueServiceConfig(ctx context.Context) (*QueueServiceConfig, error) {
 	c.RLock()

--- a/server/shared/oauth2.go
+++ b/server/shared/oauth2.go
@@ -397,7 +397,7 @@ func (o *oauth2Session) postExchange(m MetaContext, arg *proto.OAuth2Code) error
 	}
 	data.Set("redirect_uri", o.cfg.RedirectURI.String())
 	data.Set("client_id", o.cfg.ClientID.String())
-	if o.cfg.ClientSecret.IsZero() {
+	if !o.cfg.ClientSecret.IsZero() {
 		data.Set("client_secret", o.cfg.ClientSecret.String())
 	}
 	if o.pkceVerifier != "" {

--- a/server/web/lib/cookie.go
+++ b/server/web/lib/cookie.go
@@ -25,6 +25,15 @@ func SetSessionCookie(
 		Value:    string(ws.EncodeToString()),
 		Expires:  time.Now().Add(time.Duration(7*24) * time.Hour),
 		HttpOnly: true,
+		Path:     "/",
+		SameSite: http.SameSiteStrictMode,
+	}
+	wcfg, err := m.G().Config().WebConfig(m.Ctx())
+	if err != nil {
+		return err
+	}
+	if wcfg.UseTLS() {
+		cook.Secure = true
 	}
 	http.SetCookie(w, &cook)
 	return nil


### PR DESCRIPTION
Performed a Claude security audit. I don't think any of these issues are exploitable, but for defense-in-depth, it makes sense to fix them. CVE scores are based on what Claude output, but might be overstated:

- crit: backwards logic on oauth client secret check in exchange; this didn't really matter since we weren't using client_secret, we were using PKCE verifier instead.
   - Note: this is *not* a crit, on further reflection; I don't think it's even a security bug. If neither code_verifier or client_secret is supplied, the IdP will fail the exchange. It's just a logic bug. I didn't test the client_secret path enough to hit this bug, because i often just use code_verifier.
   - I'm actually saying this isn't a security issue at all, since the Oauth2 flow will just fail with this bug.
- high: unexploitable potential SQL injection on `foks-tool standup`
   - I think this is a medium
- high: clamp down session cookie in admin interface
- high: SSRF via reflection off beacon sever can reveal details about the beacon's configuration
