### PR TITLE
mcp: add team MCP server and test team KV parameter (#238)

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -17,6 +17,8 @@ changelog:
         closes : []
       - desc: Claude security audit; 2 highs, and 1 medium; all server-side
         closes : []
+      - desc: MCP interface for teams
+        closes : ["#238"]
   - version: 0.1.5
     urgency: low
     stable: true

--- a/client/foks/cmd/mcp.go
+++ b/client/foks/cmd/mcp.go
@@ -38,6 +38,7 @@ func mcpCmd(m libclient.MetaContext) *cobra.Command {
 		},
 	}
 	mcpKVCmd(m, top)
+	mcpTeamCmd(m, top)
 	return top
 }
 

--- a/client/foks/cmd/mcp_team.go
+++ b/client/foks/cmd/mcp_team.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-snowpack-rpc/rpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/spf13/cobra"
+)
+
+type mcpTeam struct {
+	m   libclient.MetaContext
+	cli lcl.TeamClient
+}
+
+type mcpTeamListInput struct {
+	Team string `json:"team" jsonschema:"team name or ID to list members of"`
+}
+
+func (t *mcpTeam) list(ctx context.Context, req *mcp.CallToolRequest, input mcpTeamListInput) (*mcp.CallToolResult, any, error) {
+	fqt, err := core.ParseFQTeam(proto.FQTeamString(input.Team))
+	if err != nil {
+		return mcpKVErrorResult(err), nil, nil
+	}
+	roster, err := t.cli.TeamList(ctx, *fqt)
+	if err != nil {
+		return mcpKVErrorResult(err), nil, nil
+	}
+	var sb strings.Builder
+	for _, mem := range roster.Members {
+		srcRole, err := mem.SrcRole.ShortStringErr()
+		if err != nil {
+			return mcpKVErrorResult(err), nil, nil
+		}
+		dstRole, err := mem.DstRole.ShortStringErr()
+		if err != nil {
+			return mcpKVErrorResult(err), nil, nil
+		}
+		name := string(mem.Mem.Name)
+		if mem.Mem.Fqp.Party.IsTeam() {
+			name += " (team)"
+		}
+		host := "-"
+		if !roster.Fqp.Fqp.Host.Eq(mem.Mem.Fqp.Host) {
+			host = string(mem.Mem.Host)
+		}
+		added := mem.Added.Time.Import().UTC().Format("2006-01-02T15:04:05Z")
+		fmt.Fprintf(&sb, "%s\t%s\t%s\t%s\t%s\n", name, host, srcRole, dstRole, added)
+	}
+	return mcpKVTextResult(sb.String()), nil, nil
+}
+
+type mcpTeamListMembershipsInput struct{}
+
+func (t *mcpTeam) listMemberships(ctx context.Context, req *mcp.CallToolRequest, input mcpTeamListMembershipsInput) (*mcp.CallToolResult, any, error) {
+	res, err := t.cli.TeamListMemberships(ctx)
+	if err != nil {
+		return mcpKVErrorResult(err), nil, nil
+	}
+	var sb strings.Builder
+	for _, tm := range res.Teams {
+		srcRole, err := tm.SrcRole.ShortStringErr()
+		if err != nil {
+			return mcpKVErrorResult(err), nil, nil
+		}
+		dstRole, err := tm.DstRole.ShortStringErr()
+		if err != nil {
+			return mcpKVErrorResult(err), nil, nil
+		}
+		teamName := string(tm.Team.Name)
+		if !res.HomeHost.Eq(tm.Team.Fqp.Host) {
+			teamName = fmt.Sprintf("%s@%s", teamName, tm.Team.Host)
+		}
+		via := "-"
+		if tm.Via != nil {
+			via = string(tm.Via.Name)
+			if !res.HomeHost.Eq(tm.Via.Fqp.Host) {
+				via = fmt.Sprintf("%s@%s", via, tm.Via.Host)
+			}
+		}
+		rr := core.RationalRange{RationalRange: tm.Tir}
+		fmt.Fprintf(&sb, "%s\t%s\t%s\t%s\t%s\n", teamName, srcRole, dstRole, via, rr.String())
+	}
+	return mcpKVTextResult(sb.String()), nil, nil
+}
+
+func newMCPTeamServer(m libclient.MetaContext, gcli rpc.GenericClient) *mcp.Server {
+	tm := &mcpTeam{
+		m:   m,
+		cli: libclient.NewRpcTypedClient[lcl.TeamClient](m, gcli),
+	}
+
+	srv := mcp.NewServer(&mcp.Implementation{
+		Name:    "foks-team",
+		Version: core.CurrentSoftwareVersion.String(),
+	}, nil)
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list",
+		Description: "List the members of a FOKS team",
+	}, tm.list)
+
+	mcp.AddTool(srv, &mcp.Tool{
+		Name:        "list-memberships",
+		Description: "List all teams the current user is a member of",
+	}, tm.listMemberships)
+
+	return srv
+}
+
+func mcpTeamCmd(m libclient.MetaContext, top *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:          "team",
+		Short:        "Run MCP server for team operations",
+		Long:         "Run an MCP (Model Context Protocol) server over stdio exposing FOKS team operations",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			gcli, cleanFn, err := runMCPServer(m)
+			if err != nil {
+				return err
+			}
+			defer cleanFn()
+			srv := newMCPTeamServer(m, gcli)
+			var transport mcp.Transport
+			if mcpUI := m.G().UIs().MCP; mcpUI != nil {
+				transport = mcpUI.Transport()
+			} else {
+				transport = &mcp.StdioTransport{}
+			}
+			return srv.Run(m.Ctx(), transport)
+		},
+	}
+	top.AddCommand(cmd)
+}

--- a/integration-tests/cli/mcp_kv_test.go
+++ b/integration-tests/cli/mcp_kv_test.go
@@ -419,6 +419,93 @@ func TestMCPKVBinaryPutGet(t *testing.T) {
 	})
 }
 
+func TestMCPKVTeamStore(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	merklePoke(t)
+	merklePoke(t)
+
+	// Create a team to use as a KV store scope
+	bob.agent.runCmd(t, nil, "team", "create", "kv-team-test")
+	merklePoke(t)
+
+	mcpKVTest(t, bob.agent, func(t *testing.T, session *mcp.ClientSession, ctx context.Context) {
+		// Put a file in the team's KV store
+		text := mcpCallTool(t, session, ctx, "put", map[string]any{
+			"path":    "/team-file.txt",
+			"content": "team data",
+			"team":    "kv-team-test",
+		})
+		require.Equal(t, "ok", text)
+
+		// Get it back from team store
+		text = mcpCallTool(t, session, ctx, "get", map[string]any{
+			"path": "/team-file.txt",
+			"team": "kv-team-test",
+		})
+		require.Equal(t, "team data", text)
+
+		// List team store root
+		text = mcpCallTool(t, session, ctx, "list", map[string]any{
+			"path": "/",
+			"team": "kv-team-test",
+		})
+		require.Contains(t, text, "team-file.txt")
+
+		// Stat the file in team store
+		text = mcpCallTool(t, session, ctx, "stat", map[string]any{
+			"path": "/team-file.txt",
+			"team": "kv-team-test",
+		})
+		require.Contains(t, text, "\"De\"")
+
+		// Usage for team store
+		text = mcpCallTool(t, session, ctx, "usage", map[string]any{
+			"team": "kv-team-test",
+		})
+		require.Contains(t, text, "Num Files:")
+
+		// Personal store should NOT have this file
+		errText := mcpCallToolExpectError(t, session, ctx, "get", map[string]any{
+			"path": "/team-file.txt",
+		})
+		require.NotEmpty(t, errText)
+
+		// Mkdir in team store
+		text = mcpCallTool(t, session, ctx, "mkdir", map[string]any{
+			"path": "/team-dir",
+			"team": "kv-team-test",
+		})
+		require.Contains(t, text, "DirID:")
+
+		// Mv in team store
+		mcpCallTool(t, session, ctx, "put", map[string]any{
+			"path":    "/team-dir/mv-src.txt",
+			"content": "to move",
+			"team":    "kv-team-test",
+		})
+		text = mcpCallTool(t, session, ctx, "mv", map[string]any{
+			"src":  "/team-dir/mv-src.txt",
+			"dst":  "/team-dir/mv-dst.txt",
+			"team": "kv-team-test",
+		})
+		require.Equal(t, "ok", text)
+
+		text = mcpCallTool(t, session, ctx, "get", map[string]any{
+			"path": "/team-dir/mv-dst.txt",
+			"team": "kv-team-test",
+		})
+		require.Equal(t, "to move", text)
+
+		// Rm in team store
+		text = mcpCallTool(t, session, ctx, "rm", map[string]any{
+			"path":      "/team-dir",
+			"team":      "kv-team-test",
+			"recursive": true,
+		})
+		require.Equal(t, "ok", text)
+	})
+}
+
 func TestMCPKVPathNormalization(t *testing.T) {
 	bob := makeBobAndHisAgent(t)
 	merklePoke(t)

--- a/integration-tests/cli/mcp_team_test.go
+++ b/integration-tests/cli/mcp_team_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// mcpTeamTest runs a test against the real `foks mcp team` command.
+func mcpTeamTest(
+	t *testing.T,
+	a *testAgent,
+	fn func(t *testing.T, session *mcp.ClientSession, ctx context.Context),
+) {
+	t.Helper()
+	mock := newMockMCPUI()
+	hook := func(m libclient.MetaContext) error {
+		uis := m.G().UIs()
+		uis.MCP = mock
+		m.G().SetUIs(uis)
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.runCmdErr(hook, "mcp", "team")
+	}()
+
+	ctx := context.Background()
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "foks-mcp-team-test",
+		Version: "1.0.0",
+	}, nil)
+	session, err := client.Connect(ctx, mock.clientTransport, nil)
+	require.NoError(t, err)
+	defer session.Close()
+
+	fn(t, session, ctx)
+}
+
+func TestMCPTeamListTools(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	merklePoke(t)
+	merklePoke(t)
+
+	mcpTeamTest(t, bob.agent, func(t *testing.T, session *mcp.ClientSession, ctx context.Context) {
+		tools, err := session.ListTools(ctx, nil)
+		require.NoError(t, err)
+		require.NotNil(t, tools)
+
+		names := make(map[string]bool)
+		for _, tool := range tools.Tools {
+			names[tool.Name] = true
+		}
+		for _, name := range []string{"list", "list-memberships"} {
+			require.True(t, names[name], "expected tool %q in list", name)
+		}
+	})
+}
+
+func TestMCPTeamListMemberships(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	merklePoke(t)
+	merklePoke(t)
+
+	// Create a team so there's something to list
+	bob.agent.runCmd(t, nil, "team", "create", "mcp-test-team")
+	merklePoke(t)
+
+	mcpTeamTest(t, bob.agent, func(t *testing.T, session *mcp.ClientSession, ctx context.Context) {
+		text := mcpCallTool(t, session, ctx, "list-memberships", map[string]any{})
+		require.Contains(t, text, "mcp-test-team")
+	})
+}
+
+func TestMCPTeamList(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	merklePoke(t)
+	merklePoke(t)
+
+	bob.agent.runCmd(t, nil, "team", "create", "mcp-roster-team")
+	merklePoke(t)
+
+	mcpTeamTest(t, bob.agent, func(t *testing.T, session *mcp.ClientSession, ctx context.Context) {
+		text := mcpCallTool(t, session, ctx, "list", map[string]any{
+			"team": "mcp-roster-team",
+		})
+		// The creator should be listed as a member
+		require.Contains(t, text, string(bob.username))
+	})
+}
+
+func TestMCPTeamListNotFound(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	merklePoke(t)
+	merklePoke(t)
+
+	mcpTeamTest(t, bob.agent, func(t *testing.T, session *mcp.ClientSession, ctx context.Context) {
+		_ = mcpCallToolExpectError(t, session, ctx, "list", map[string]any{
+			"team": "nonexistent-team-xyz",
+		})
+	})
+}


### PR DESCRIPTION
Add MCP server for team operations exposing team list and
team list-memberships via Model Context Protocol. Also add
integration tests for the KV store team parameter to verify
team-scoped put/get/list/stat/usage/mkdir/mv/rm operations.

Close #238

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
