### PR TITLE
client: fix bugs in TeamMembershipChain updates

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -2,6 +2,13 @@ project: foks
 maintaner: Maxwell Krohn <max@ne43.com>
 
 changelog:
+  - version: 0.1.7
+    urgency: low
+    stable: true
+    date: TBD
+    changes:
+      - desc: fix bug in team membership chain patching
+        closes: ["#240"]
   - version: 0.1.6
     urgency: low
     stable: true

--- a/client/agent/git.go
+++ b/client/agent/git.go
@@ -232,7 +232,7 @@ func (c *AgentConn) GitLs(ctx context.Context, arg lcl.GitLsArg) ([]proto.GitURL
 		return nil, err
 	}
 
-	tmp, err := teamMinder.ListMemberships(m.MetaContext)
+	tmp, err := teamMinder.ListMemberships(m.MetaContext, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/agent/team.go
+++ b/client/agent/team.go
@@ -234,7 +234,7 @@ func (c *AgentConn) TeamListMemberships(
 		return zed, err
 	}
 
-	tmp, err := teamMinder.ListMemberships(m)
+	tmp, err := teamMinder.ListMemberships(m, nil)
 	if err != nil {
 		return zed, err
 	}
@@ -261,6 +261,20 @@ func (c *AgentConn) TeamChangeRoles(
 		return err
 	}
 	return tm.TeamChangeRoles(m, arg)
+}
+
+func (c *AgentConn) TeamDumpMembershipChain(
+	ctx context.Context,
+) (
+	lcl.TeamMembershipChainList,
+	error,
+) {
+	var zed lcl.TeamMembershipChainList
+	m, tm, err := c.teamInit(ctx)
+	if err != nil {
+		return zed, err
+	}
+	return tm.DumpMembershipChain(m)
 }
 
 var _ lcl.TeamInterface = (*AgentConn)(nil)

--- a/client/foks/cmd/team.go
+++ b/client/foks/cmd/team.go
@@ -602,7 +602,35 @@ func teamIndexRangeRaise(m libclient.MetaContext, top *cobra.Command) {
 			})
 		},
 	)
+}
 
+func teamDumpMembershipChain(m libclient.MetaContext, top *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:     "dump-membership-chain",
+		Aliases: nil,
+		Short:   "dump the team membership chain for a user (testing and debugging)",
+		Long: `The team membership chain is the chain that keeps track of which
+teams a user is a member of, and what role they have on their team. This
+command dumps the contents of this chain for the current user as JSON.
+For now, it's limited to only the user's chain, and also, only showed
+links in the "approved" state, last-writer wins. We might expand this
+in the future.`,
+		SilenceUsage: true,
+		Hidden:       true,
+		RunE: func(cmd *cobra.Command, arg []string) error {
+			if len(arg) != 0 {
+				return ArgsError("expected no arguments")
+			}
+			return quickStartLambda(m, &teamOpts, func(cli lcl.TeamClient) error {
+				res, err := cli.TeamDumpMembershipChain(m.Ctx())
+				if err != nil {
+					return err
+				}
+				return JSONOutput(m, res)
+			})
+		},
+	}
+	top.AddCommand(cmd)
 }
 
 func teamIndexRangeCmd(m libclient.MetaContext) *cobra.Command {
@@ -671,6 +699,7 @@ commands.`, 0),
 	teamAdd(m, top)
 	teamAll(m, top)
 	teamChangeRoles(m, top)
+	teamDumpMembershipChain(m, top)
 	top.AddCommand(teamIndexRangeCmd(m))
 	return top
 }

--- a/client/libclient/active_party.go
+++ b/client/libclient/active_party.go
@@ -38,7 +38,7 @@ func ActivePartyNamed(
 		return &ret, nil
 	}
 	tm := au.TeamMinder()
-	fqt, err := tm.ResolveAndReindex(m, *actingAs)
+	fqt, err := tm.ResolveAndReindex(m, *actingAs, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/libclient/team_clkr.go
+++ b/client/libclient/team_clkr.go
@@ -52,7 +52,7 @@ func NewCLKR(
 
 func (c *CLKR) explore(m MetaContext) error {
 	var err error
-	c.estate, err = c.tm.Explore(m)
+	c.estate, err = c.tm.Explore(m, nil)
 	if err != nil {
 		return err
 	}

--- a/client/libclient/team_membership_loader.go
+++ b/client/libclient/team_membership_loader.go
@@ -4,6 +4,7 @@
 package libclient
 
 import (
+	"context"
 	"slices"
 
 	"github.com/foks-proj/go-foks/lib/core"
@@ -33,6 +34,11 @@ type TMLParty interface {
 	// convenient to keep it close to the chain data.
 	RoleInChain() proto.Role
 	LatestSharedKey() core.SharedPrivateSuiter
+
+	// For users, this is going to be the current device key (for updating, let's say, the
+	// user's team membership chain). For teams, this is going to be the team's latest shared
+	// key.
+	SigningKey(ctx context.Context) (core.PrivateSuiter, error)
 
 	PostLink(m MetaContext, arg rem.PostGenericLinkArg) error
 }
@@ -122,6 +128,14 @@ func (t *TMLTeam) HostID() proto.HostID {
 
 func (t *TMLTeam) RoleInChain() proto.Role {
 	return t.ric
+}
+
+func (t *TMLTeam) SigningKey(_ context.Context) (core.PrivateSuiter, error) {
+	ret := t.LatestSharedKey()
+	if ret == nil {
+		return nil, core.KeyNotFoundError{Which: "LatestSharedKey for team"}
+	}
+	return ret, nil
 }
 
 func (t *TMLTeam) LatestSharedKey() core.SharedPrivateSuiter {
@@ -230,6 +244,10 @@ func (t *TMLUser) HostID() proto.HostID {
 
 func (t *TMLUser) LatestSharedKey() core.SharedPrivateSuiter {
 	return t.au.PrivKeys.LatestPuk()
+}
+
+func (t *TMLUser) SigningKey(ctx context.Context) (core.PrivateSuiter, error) {
+	return t.au.Devkey(ctx)
 }
 
 func (t *TMLUser) PostLink(m MetaContext, arg rem.PostGenericLinkArg) error {
@@ -436,14 +454,14 @@ func (t *TeamMembershipLoader) postLink(
 	}
 	glp := proto.NewGenericLinkPayloadWithTeammembership(tml)
 
-	lsk := t.party.LatestSharedKey()
-	if lsk == nil {
-		return core.KeyNotFoundError{Which: "LatestSharedKey"}
+	signingKey, err := t.party.SigningKey(m.Ctx())
+	if err != nil {
+		return err
 	}
 	glink, err := core.MakeGenericLink(
 		t.party.EntityID(),
 		t.party.HostID(),
-		lsk,
+		signingKey,
 		glp,
 		t.gcl.res.Tail.Base.Seqno+1,
 		t.gcl.lastHash,

--- a/client/libclient/team_minder.go
+++ b/client/libclient/team_minder.go
@@ -173,7 +173,7 @@ func (t *TeamMinder) checkSingleTeamInMembershipChain(
 	if err != nil {
 		return false, nil, err
 	}
-	if appr == nil {
+	if appr == nil || !appr.Approved {
 		return false, &fqt, nil
 	}
 	eq, err := appr.SrcRole.Eq(tm.SrcRole)
@@ -228,6 +228,7 @@ func (t *TeamRecord) Member() CryptoPartier {
 type LoadTeamOpts struct {
 	LoadMembers bool
 	Refresh     bool
+	NoUpdates   bool
 }
 
 func (t *TeamMinder) GetTeam(fqt proto.FQTeam) *TeamRecord {
@@ -258,7 +259,7 @@ func (t *TeamMinder) loadTeamMembership(
 	*TeamMembershipWrapper,
 	error,
 ) {
-	tr, err := t.getTeamWithRefresh(m, fqt, opts.Refresh)
+	tr, err := t.getTeamWithRefresh(m, fqt, &opts)
 	if err != nil {
 		return nil, err
 	}
@@ -278,15 +279,15 @@ func (t *TeamMinder) loadTeamMembership(
 func (t *TeamMinder) getTeamWithRefresh(
 	m MetaContext,
 	fqt proto.FQTeam,
-	refresh bool,
+	opts *LoadTeamOpts,
 ) (
 	*TeamRecord,
 	error,
 ) {
 	get := func() *TeamRecord { return t.getTeam(fqt) }
 	tr := get()
-	if tr == nil && refresh {
-		err := t.ExploreAndIndex(m)
+	if tr == nil && opts != nil && opts.Refresh {
+		err := t.ExploreAndIndex(m, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +309,7 @@ func (t *TeamMinder) LoadTeamWithFQTeam(
 	*TeamRecord,
 	error,
 ) {
-	tr, err := t.getTeamWithRefresh(m, fqt, opts.Refresh)
+	tr, err := t.getTeamWithRefresh(m, fqt, &opts)
 	if err != nil {
 		return nil, err
 	}
@@ -765,6 +766,7 @@ func (t *TeamMembershipLoaderAndWrapper) explore(
 
 func (t *TeamMinder) Explore(
 	m MetaContext,
+	opts *LoadTeamOpts,
 ) (
 	*ExploreState,
 	error,
@@ -828,6 +830,11 @@ func (t *TeamMinder) Explore(
 				queue = append(queue, t)
 			}
 		}
+	}
+
+	// Early-out before updates if we have the NoUpdates flag set
+	if opts != nil && opts.NoUpdates {
+		return state, nil
 	}
 
 	for _, w := range state.Warnings {
@@ -957,8 +964,8 @@ func NewTeamMinder(u *UserContext) *TeamMinder {
 	return &TeamMinder{au: u}
 }
 
-func (t *TeamMinder) ExploreAndIndex(m MetaContext) error {
-	state, err := t.Explore(m)
+func (t *TeamMinder) ExploreAndIndex(m MetaContext, opts *LoadTeamOpts) error {
+	state, err := t.Explore(m, opts)
 	if err != nil {
 		return err
 	}
@@ -1062,7 +1069,14 @@ func (t *TeamMinder) Resolve(m MetaContext, arg proto.FQTeamParsed) (*proto.FQTe
 	return t.resolveTeam(arg)
 }
 
-func (t *TeamMinder) ResolveAndReindex(m MetaContext, arg proto.FQTeamParsed) (*proto.FQTeam, error) {
+func (t *TeamMinder) ResolveAndReindex(
+	m MetaContext,
+	arg proto.FQTeamParsed,
+	opts *LoadTeamOpts,
+) (
+	*proto.FQTeam,
+	error,
+) {
 	fqt, err := t.resolveTeam(arg)
 	if err != nil {
 		return nil, err
@@ -1070,7 +1084,7 @@ func (t *TeamMinder) ResolveAndReindex(m MetaContext, arg proto.FQTeamParsed) (*
 	if fqt != nil {
 		return fqt, nil
 	}
-	err = t.ExploreAndIndex(m)
+	err = t.ExploreAndIndex(m, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -1092,7 +1106,7 @@ func (t *TeamMinder) LoadTeam(
 	*TeamWrapper,
 	error,
 ) {
-	fqt, err := t.ResolveAndReindex(m, arg)
+	fqt, err := t.ResolveAndReindex(m, arg, &opts)
 	if err != nil {
 		return nil, err
 	}
@@ -1112,7 +1126,7 @@ func (t *TeamMinder) withLoadedTeam(
 	opts LoadTeamOpts,
 	f func(m MetaContext, tm *TeamRecord) error,
 ) error {
-	fqt, err := t.ResolveAndReindex(m, arg)
+	fqt, err := t.ResolveAndReindex(m, arg, &opts)
 	if err != nil {
 		return err
 	}
@@ -1132,7 +1146,7 @@ func (t *TeamMinder) withLoadedTeamAndAdminToken(
 	opts LoadTeamOpts,
 	f func(m MetaContext, tr *TeamRecord, token *rem.TeamBearerToken) error,
 ) error {
-	fqt, err := t.ResolveAndReindex(m, arg)
+	fqt, err := t.ResolveAndReindex(m, arg, &opts)
 	if err != nil {
 		return err
 	}
@@ -1417,12 +1431,13 @@ func (arg LoadTeamArg) makeKeyRingRefresher() func(m MetaContext) (SharedKeySequ
 
 func (t *TeamMinder) ListMemberships(
 	m MetaContext,
+	opts *LoadTeamOpts,
 ) (
 	*lcl.ListMembershipsRes,
 	error,
 ) {
 	var ret lcl.ListMembershipsRes
-	err := t.ExploreAndIndex(m)
+	err := t.ExploreAndIndex(m, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -1503,4 +1518,39 @@ func (t *TeamMinder) loadConfig(
 	t.config = &cfg
 	tmp := cfg
 	return &tmp, nil
+}
+
+func (t *TeamMinder) DumpMembershipChain(
+	m MetaContext,
+) (
+	lcl.TeamMembershipChainList,
+	error,
+) {
+	err := t.loadUserTMLLocked(m)
+	if err != nil {
+		return nil, err
+	}
+	wr := t.userTMW.Wrapper
+	if wr == nil {
+		return nil, nil
+	}
+	var ret lcl.TeamMembershipChainList
+	for _, v := range wr.Map {
+		typ, err := v.State.GetT()
+		if err != nil {
+			return nil, err
+		}
+		if typ != proto.TeamMembershipLinkState_Approved {
+			continue
+		}
+		appr := v.State.Approved()
+		link := lcl.TeamMembershipChainTeam{
+			Team:    v.Team,
+			SrcRole: v.SrcRole,
+			DstRole: appr.Dst.Role,
+			Seqno:   appr.Dst.Seqno,
+		}
+		ret = append(ret, link)
+	}
+	return ret, nil
 }

--- a/client/libclient/team_minder_inbox.go
+++ b/client/libclient/team_minder_inbox.go
@@ -824,7 +824,7 @@ func (t *TeamMinder) AcceptInvite(
 	var actAsTeam *proto.TeamID
 
 	if arg.ActingAs != nil {
-		fqt, err := t.ResolveAndReindex(m, arg.ActingAs.Fqtp)
+		fqt, err := t.ResolveAndReindex(m, arg.ActingAs.Fqtp, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1072,7 +1072,7 @@ func (t *TeamMinder) TeamInbox(
 	*lcl.TeamInbox,
 	error,
 ) {
-	fqt, err := t.ResolveAndReindex(m, fqtp)
+	fqt, err := t.ResolveAndReindex(m, fqtp, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1184,7 +1184,7 @@ func (t *TeamMinder) TeamAdmit(
 	m MetaContext,
 	arg lcl.TeamAdmitArg,
 ) error {
-	fqt, err := t.ResolveAndReindex(m, arg.Team)
+	fqt, err := t.ResolveAndReindex(m, arg.Team, nil)
 	if err != nil {
 		return err
 	}

--- a/client/libclient/team_minder_index_range.go
+++ b/client/libclient/team_minder_index_range.go
@@ -105,7 +105,7 @@ func (t *TeamMinder) setIndexRangeCommon(
 	error,
 ) {
 
-	fqt, err := t.ResolveAndReindex(m, arg)
+	fqt, err := t.ResolveAndReindex(m, arg, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/libkv/app.go
+++ b/client/libkv/app.go
@@ -53,7 +53,7 @@ func (a *App) Minder(m MetaContext, actingAs *proto.FQTeamParsed) (*Minder, erro
 	if actingAs == nil {
 		return a.getUser(), nil
 	}
-	fqp, err := a.parent.TeamMinder().ResolveAndReindex(m.MetaContext, *actingAs)
+	fqp, err := a.parent.TeamMinder().ResolveAndReindex(m.MetaContext, *actingAs, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/integration-tests/cli/team_test.go
+++ b/integration-tests/cli/team_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/lib/team"
 	"github.com/foks-proj/go-foks/proto/lcl"
+	"github.com/foks-proj/go-foks/proto/lib"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/server/shared"
 	"github.com/keybase/clockwork"
@@ -32,6 +33,8 @@ func TestCreateInviteSequence(t *testing.T) {
 	x := newTestAgent(t)
 	x.runAgent(t)
 	defer x.stop(t)
+	stopper := runMerkleActivePoker(t)
+	defer stopper()
 	newUserWithAgentAtVHost(t, x, 0)
 	merklePoke(t)
 	merklePoke(t)
@@ -178,6 +181,9 @@ func TestCreateAdmitLoad(t *testing.T) {
 	x := newTestAgent(t)
 	x.runAgent(t)
 	defer x.stop(t)
+
+	stopper := runMerkleActivePoker(t)
+	defer stopper()
 
 	newUserWithAgentAtVHost(t, x, 0)
 	merklePoke(t)
@@ -625,4 +631,67 @@ func TestTeamChangeMembershipClosedViewership(t *testing.T) {
 	// specify the source role
 	x.runCmd(t, nil, "team", "change-roles", teamName, yuid+"/o->m/0")
 	merklePoke(t)
+}
+
+func TestTeamChangeMembershipClosedViewershipTestReload(t *testing.T) {
+
+	x := newTestAgent(t)
+	x.runAgent(t)
+	defer x.stop(t)
+	stopper := runMerkleActivePoker(t)
+	defer stopper()
+
+	newUserWithAgentAtVHost(t, x, 0)
+	merklePoke(t)
+
+	var res lcl.TeamCreateRes
+	teamName := "minnesota_wild"
+	x.runCmdToJSON(t, &res, "team", "create", teamName)
+
+	var res3 proto.TeamInvite
+	x.runCmdToJSON(t, &res3, "team", "invite", teamName)
+	inviteStr, err := team.ExportTeamInvite(res3)
+	require.NoError(t, err)
+
+	y := newTestAgent(t)
+	y.runAgent(t)
+	defer y.stop(t)
+	newUserWithAgentAtVHost(t, y, 0)
+	y.runCmd(t, nil, "team", "accept", inviteStr)
+
+	var inb lcl.TeamInbox
+	x.runCmdToJSON(t, &inb, "team", "inbox", teamName)
+	require.Equal(t, 1, len(inb.Rows))
+	x.runCmd(t, nil, "team", "admit", teamName, string(inb.Rows[0].Tok.String())+"/m/4")
+
+	// we expect this dump to show us 0 links until we rectify the
+	// user's team membership chain, which comes as a result of
+	// listing the team
+	var dump lcl.TeamMembershipChainList
+	y.runCmdToJSON(t, &dump, "team", "dump-membership-chain")
+	require.Equal(t, 0, len(dump))
+
+	y.runCmd(t, nil, "team", "list", teamName)
+
+	// Now the membership chain should be fixed.
+	y.runCmdToJSON(t, &dump, "team", "dump-membership-chain")
+	require.Equal(t, 1, len(dump))
+	eq, err := lib.NewRoleWithMember(4).Eq(dump[0].DstRole)
+	require.NoError(t, err)
+	require.True(t, eq)
+
+	ystat := y.status(t)
+	yusername := ystat.Users[0].Info.Username.NameUtf8
+
+	y.runCmd(t, nil, "team", "list-memberships")
+
+	x.runCmd(t, nil, "team", "change-roles", teamName, yusername.String()+"->o")
+
+	y.runCmd(t, nil, "team", "list-memberships")
+
+	y.runCmdToJSON(t, &dump, "team", "dump-membership-chain")
+	require.Equal(t, 1, len(dump))
+	eq, err = lib.OwnerRole.Eq(dump[0].DstRole)
+	require.NoError(t, err)
+	require.True(t, eq)
 }

--- a/integration-tests/lib/open_view_test.go
+++ b/integration-tests/lib/open_view_test.go
@@ -144,7 +144,7 @@ func TestOpenUserViewAndTeamAdd(t *testing.T) {
 		},
 	}
 	require.NoError(t, err)
-	membs, err := tmindDeb.ListMemberships(mcDeb)
+	membs, err := tmindDeb.ListMemberships(mcDeb, nil)
 	require.NoError(t, err)
 	require.Len(t, membs.Teams, 1)
 	require.Equal(t, membs.Teams[0].Team.Name, tm.nm)

--- a/integration-tests/lib/team_clkr_test.go
+++ b/integration-tests/lib/team_clkr_test.go
@@ -201,6 +201,12 @@ func TestLongChainCLKR(t *testing.T) {
 	au := mu.G().ActiveUser()
 	require.NotNil(t, au)
 	tmm := libclient.NewTeamMinder(au)
+	tmm.TestHooks = &libclient.TeamMinderTestHooks{
+		PostChainHook: func() error {
+			tew.DirectDoubleMerklePokeInTest(t)
+			return nil
+		},
+	}
 
 	mu.Infow("TestSimpleCLKR", "stage", "no-op CLKR")
 

--- a/integration-tests/lib/team_explore_test.go
+++ b/integration-tests/lib/team_explore_test.go
@@ -148,7 +148,7 @@ func TestTeamMembershipMinderExplore(t *testing.T) {
 			return nil
 		},
 	}
-	exstate, err := tmm.Explore(mc)
+	exstate, err := tmm.Explore(mc, nil)
 	require.NoError(t, err)
 
 	allTeams := []*teamObj{t0, t1, t2}
@@ -173,7 +173,7 @@ func TestTeamMembershipMinderExplore(t *testing.T) {
 	)
 	tew.DirectDoubleMerklePokeInTest(t)
 
-	estate, err := tmm.Explore(mc)
+	estate, err := tmm.Explore(mc, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(estate.Warnings))
 	wrn := estate.Warnings[t2.FQTeam(t)]
@@ -181,7 +181,7 @@ func TestTeamMembershipMinderExplore(t *testing.T) {
 	require.True(t, core.IsPermissionError(wrn.Err))
 
 	tew.DirectDoubleMerklePokeInTest(t)
-	estate, err = tmm.Explore(mc)
+	estate, err = tmm.Explore(mc, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(estate.Warnings))
 
@@ -267,7 +267,7 @@ func TestExactRolesInTeamGraphRemovals(t *testing.T) {
 			return nil
 		},
 	}
-	exstate, err := tmm.Explore(mc)
+	exstate, err := tmm.Explore(mc, nil)
 	require.NoError(t, err)
 
 	checkTeams := func(state *libclient.ExploreState, teams []*teamObj, visitTeams []*teamObj) {
@@ -298,7 +298,7 @@ func TestExactRolesInTeamGraphRemovals(t *testing.T) {
 	)
 	tew.DirectDoubleMerklePokeInTest(t)
 
-	exstate, err = tmm.Explore(mc)
+	exstate, err = tmm.Explore(mc, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(exstate.Warnings))
 	wrn := exstate.Warnings[t1.FQTeam(t)]
@@ -310,7 +310,7 @@ func TestExactRolesInTeamGraphRemovals(t *testing.T) {
 	checkTeams(exstate, []*teamObj{t0}, []*teamObj{t0, t1})
 
 	tew.DirectDoubleMerklePokeInTest(t)
-	exstate, err = tmm.Explore(mc)
+	exstate, err = tmm.Explore(mc, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(exstate.Warnings))
 	checkTeams(exstate, []*teamObj{t0}, nil)
@@ -318,6 +318,8 @@ func TestExactRolesInTeamGraphRemovals(t *testing.T) {
 
 func TestTeamFixViaUpgrade(t *testing.T) {
 	tew := testEnvBeta(t)
+	stopper := runMerkleActivePoker(t, tew)
+	defer stopper()
 	tew.DirectMerklePoke(t)
 	bluey := tew.NewTestUser(t)
 	bingo := tew.NewTestUser(t)
@@ -335,11 +337,18 @@ func TestTeamFixViaUpgrade(t *testing.T) {
 	require.NotNil(t, au)
 	tmm := libclient.NewTeamMinder(au)
 
+	tmm.TestHooks = &libclient.TeamMinderTestHooks{
+		PostChainHook: func() error {
+			tew.DirectDoubleMerklePokeInTest(t)
+			return nil
+		},
+	}
+
 	runLocalJoinSequenceForUser(t, m, t0, bluey, bingo, proto.AdminRole,
 		&localJoinHooks{
 			preTeamEdit: func() {
 				tew.DirectMerklePokeInTest(t)
-				estate, err := tmm.Explore(mc)
+				estate, err := tmm.Explore(mc, nil)
 				require.NoError(t, err)
 				require.NotNil(t, estate)
 				require.Equal(t, 0, len(estate.Teams))
@@ -355,7 +364,7 @@ func TestTeamFixViaUpgrade(t *testing.T) {
 		},
 	)
 	tew.DirectMerklePokeInTest(t)
-	estate, err := tmm.Explore(mc)
+	estate, err := tmm.Explore(mc, nil)
 	require.NoError(t, err)
 	require.NotNil(t, estate)
 	require.Equal(t, 1, len(estate.Teams))

--- a/integration-tests/lib/team_membership_loader_test.go
+++ b/integration-tests/lib/team_membership_loader_test.go
@@ -245,7 +245,7 @@ func TestTeamMembershipMinder(t *testing.T) {
 			return nil
 		},
 	}
-	_, err := tmm.Explore(mc)
+	_, err := tmm.Explore(mc, nil)
 	require.NoError(t, err)
 
 	var key libclient.FQTeamSrcRole

--- a/integration-tests/lib/team_test.go
+++ b/integration-tests/lib/team_test.go
@@ -1594,7 +1594,7 @@ func TestTeamListMemberships(t *testing.T) {
 	tmm, err := mc.G().TeamMinder()
 	require.NoError(t, err)
 
-	lst, err := tmm.ListMemberships(mc)
+	lst, err := tmm.ListMemberships(mc, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(lst.Teams))
 

--- a/proto-src/lcl/team.snowp
+++ b/proto-src/lcl/team.snowp
@@ -97,6 +97,16 @@ struct TeamMembership {
     tir @4 : lib.RationalRange; // The index range of the team
 }
 
+// One item in a user or team's TeamMembershipChain; can be multiple
+struct TeamMembershipChainTeam {
+    team @0 : lib.FQTeam;
+    srcRole @1 : lib.Role;
+    dstRole @2 : lib.Role;
+    seqno @3 : lib.Seqno;  // The seqno of the last change to this team/srcRole
+}
+
+typedef TeamMembershipChainList = List(TeamMembershipChainTeam);
+
 struct ListMembershipsRes {
     homeHost @0 : lib.HostID;
     teams @1 : List(TeamMembership);
@@ -186,4 +196,8 @@ protocol Team
         team @0 : lib.FQTeamParsed,
         changes @1 : List(RoleChange)
     );
+
+    // used largely in testing and in debugging
+    teamDumpMembershipChain @15 (
+    ) -> TeamMembershipChainList;
 }

--- a/proto/lcl/team.go
+++ b/proto/lcl/team.go
@@ -1025,6 +1025,128 @@ func (t *TeamMembership) Decode(dec rpc.Decoder) error {
 
 func (t *TeamMembership) Bytes() []byte { return nil }
 
+type TeamMembershipChainTeam struct {
+	Team    lib.FQTeam
+	SrcRole lib.Role
+	DstRole lib.Role
+	Seqno   lib.Seqno
+}
+type TeamMembershipChainTeamInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Team    *lib.FQTeamInternal__
+	SrcRole *lib.RoleInternal__
+	DstRole *lib.RoleInternal__
+	Seqno   *lib.SeqnoInternal__
+}
+
+func (t TeamMembershipChainTeamInternal__) Import() TeamMembershipChainTeam {
+	return TeamMembershipChainTeam{
+		Team: (func(x *lib.FQTeamInternal__) (ret lib.FQTeam) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(t.Team),
+		SrcRole: (func(x *lib.RoleInternal__) (ret lib.Role) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(t.SrcRole),
+		DstRole: (func(x *lib.RoleInternal__) (ret lib.Role) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(t.DstRole),
+		Seqno: (func(x *lib.SeqnoInternal__) (ret lib.Seqno) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(t.Seqno),
+	}
+}
+func (t TeamMembershipChainTeam) Export() *TeamMembershipChainTeamInternal__ {
+	return &TeamMembershipChainTeamInternal__{
+		Team:    t.Team.Export(),
+		SrcRole: t.SrcRole.Export(),
+		DstRole: t.DstRole.Export(),
+		Seqno:   t.Seqno.Export(),
+	}
+}
+func (t *TeamMembershipChainTeam) Encode(enc rpc.Encoder) error {
+	return enc.Encode(t.Export())
+}
+
+func (t *TeamMembershipChainTeam) Decode(dec rpc.Decoder) error {
+	var tmp TeamMembershipChainTeamInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*t = tmp.Import()
+	return nil
+}
+
+func (t *TeamMembershipChainTeam) Bytes() []byte { return nil }
+
+type TeamMembershipChainList []TeamMembershipChainTeam
+type TeamMembershipChainListInternal__ [](*TeamMembershipChainTeamInternal__)
+
+func (t TeamMembershipChainList) Export() *TeamMembershipChainListInternal__ {
+	tmp := (([]TeamMembershipChainTeam)(t))
+	return ((*TeamMembershipChainListInternal__)((func(x []TeamMembershipChainTeam) *[](*TeamMembershipChainTeamInternal__) {
+		if len(x) == 0 {
+			return nil
+		}
+		ret := make([](*TeamMembershipChainTeamInternal__), len(x))
+		for k, v := range x {
+			ret[k] = v.Export()
+		}
+		return &ret
+	})(tmp)))
+}
+func (t TeamMembershipChainListInternal__) Import() TeamMembershipChainList {
+	tmp := ([](*TeamMembershipChainTeamInternal__))(t)
+	return TeamMembershipChainList((func(x *[](*TeamMembershipChainTeamInternal__)) (ret []TeamMembershipChainTeam) {
+		if x == nil || len(*x) == 0 {
+			return nil
+		}
+		ret = make([]TeamMembershipChainTeam, len(*x))
+		for k, v := range *x {
+			if v == nil {
+				continue
+			}
+			ret[k] = (func(x *TeamMembershipChainTeamInternal__) (ret TeamMembershipChainTeam) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(v)
+		}
+		return ret
+	})(&tmp))
+}
+
+func (t *TeamMembershipChainList) Encode(enc rpc.Encoder) error {
+	return enc.Encode(t.Export())
+}
+
+func (t *TeamMembershipChainList) Decode(dec rpc.Decoder) error {
+	var tmp TeamMembershipChainListInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*t = tmp.Import()
+	return nil
+}
+
+func (t TeamMembershipChainList) Bytes() []byte {
+	return nil
+}
+
 type ListMembershipsRes struct {
 	HomeHost lib.HostID
 	Teams    []TeamMembership
@@ -1862,6 +1984,34 @@ func (t *TeamChangeRolesArg) Decode(dec rpc.Decoder) error {
 
 func (t *TeamChangeRolesArg) Bytes() []byte { return nil }
 
+type TeamDumpMembershipChainArg struct {
+}
+type TeamDumpMembershipChainArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+}
+
+func (t TeamDumpMembershipChainArgInternal__) Import() TeamDumpMembershipChainArg {
+	return TeamDumpMembershipChainArg{}
+}
+func (t TeamDumpMembershipChainArg) Export() *TeamDumpMembershipChainArgInternal__ {
+	return &TeamDumpMembershipChainArgInternal__{}
+}
+func (t *TeamDumpMembershipChainArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(t.Export())
+}
+
+func (t *TeamDumpMembershipChainArg) Decode(dec rpc.Decoder) error {
+	var tmp TeamDumpMembershipChainArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*t = tmp.Import()
+	return nil
+}
+
+func (t *TeamDumpMembershipChainArg) Bytes() []byte { return nil }
+
 type TeamInterface interface {
 	TeamCreate(context.Context, lib.NameUtf8) (TeamCreateRes, error)
 	TeamList(context.Context, lib.FQTeamParsed) (TeamRoster, error)
@@ -1878,6 +2028,7 @@ type TeamInterface interface {
 	TeamListMemberships(context.Context) (ListMembershipsRes, error)
 	TeamAdd(context.Context, TeamAddArg) error
 	TeamChangeRoles(context.Context, TeamChangeRolesArg) error
+	TeamDumpMembershipChain(context.Context) (TeamMembershipChainList, error)
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h Header) error
 	MakeResHeader() Header
@@ -2255,6 +2406,28 @@ func (c TeamClient) TeamChangeRoles(ctx context.Context, arg TeamChangeRolesArg)
 			return
 		}
 	}
+	return
+}
+func (c TeamClient) TeamDumpMembershipChain(ctx context.Context) (res TeamMembershipChainList, err error) {
+	var arg TeamDumpMembershipChainArg
+	warg := &rpc.DataWrap[Header, *TeamDumpMembershipChainArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[Header, TeamMembershipChainListInternal__]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(TeamProtocolID, 15, "Team.teamDumpMembershipChain"), warg, &tmp, 0*time.Millisecond, teamErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	res = tmp.Data.Import()
 	return
 }
 func TeamProtocol(i TeamInterface) rpc.ProtocolV2 {
@@ -2692,6 +2865,34 @@ func TeamProtocol(i TeamInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "teamChangeRoles",
+			},
+			15: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[Header, *TeamDumpMembershipChainArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *TeamDumpMembershipChainArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[Header, *TeamDumpMembershipChainArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						tmp, err := i.TeamDumpMembershipChain(ctx)
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[Header, *TeamMembershipChainListInternal__]{
+							Data:   tmp.Export(),
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "teamDumpMembershipChain",
 			},
 		},
 		WrapError: TeamMakeGenericErrorWrapper(i.ErrorWrapper()),

--- a/server/foks-tool/dump_sigchain.go
+++ b/server/foks-tool/dump_sigchain.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/server/shared"
+	"github.com/spf13/cobra"
+)
+
+type DumpSigchain struct {
+	CLIAppBase
+	partyID string
+}
+
+func (d *DumpSigchain) CobraConfig() *cobra.Command {
+	ret := &cobra.Command{
+		Use:   "dump-sigchain <party-id>",
+		Short: "Dump all sigchain links for a given party (user or team) in human-readable form",
+	}
+	return ret
+}
+
+func (d *DumpSigchain) CheckArgs(args []string) error {
+	if len(args) != 1 {
+		return core.BadArgsError("must supply a party ID via positional arg")
+	}
+	d.partyID = args[0]
+	return nil
+}
+
+func (d *DumpSigchain) Run(m shared.MetaContext) error {
+	eid, err := proto.ImportEntityIDFromString(d.partyID)
+	if err != nil {
+		return fmt.Errorf("parsing party ID: %w", err)
+	}
+	pid, err := eid.ToPartyID()
+	if err != nil {
+		return fmt.Errorf("converting to party ID: %w", err)
+	}
+
+	db, err := m.Db(shared.DbTypeUsers)
+	if err != nil {
+		return err
+	}
+	defer db.Release()
+
+	rows, err := db.Query(
+		m.Ctx(),
+		`SELECT chain_type, seqno, body, hash, ctime
+		 FROM links
+		 WHERE short_host_id=$1 AND entity_id=$2
+		 ORDER BY chain_type ASC, seqno ASC`,
+		m.ShortHostID().ExportToDB(),
+		pid.ExportToDB(),
+	)
+	if err != nil {
+		return fmt.Errorf("querying links: %w", err)
+	}
+	defer rows.Close()
+
+	pidStr, _ := pid.StringErr()
+	fmt.Printf("=== Sigchain dump for party %s ===\n\n", pidStr)
+
+	count := 0
+	var lastChainType proto.ChainType = -1
+
+	for rows.Next() {
+		var chainType int
+		var seqno int64
+		var body []byte
+		var hash []byte
+		var ctime time.Time
+
+		if err := rows.Scan(&chainType, &seqno, &body, &hash, &ctime); err != nil {
+			return fmt.Errorf("scanning row: %w", err)
+		}
+
+		ct := proto.ChainType(chainType)
+		if ct != lastChainType {
+			ctName := proto.ChainTypeRevMap[ct]
+			if ctName == "" {
+				ctName = fmt.Sprintf("unknown(%d)", chainType)
+			}
+			fmt.Printf("--- Chain: %s (type=%d) ---\n\n", ctName, chainType)
+			lastChainType = ct
+		}
+
+		var linkHash proto.LinkHash
+		if len(hash) == len(linkHash) {
+			copy(linkHash[:], hash)
+		}
+
+		fmt.Printf("Link #%d  hash=%s  ctime=%s\n",
+			seqno,
+			linkHash.String(),
+			ctime.UTC().Format(time.RFC3339),
+		)
+
+		var link proto.LinkOuter
+		if err := core.DecodeFromBytes(&link, body); err != nil {
+			fmt.Printf("  ERROR decoding LinkOuter: %v\n\n", err)
+			continue
+		}
+
+		v, err := link.GetV()
+		if err != nil {
+			fmt.Printf("  ERROR getting link version: %v\n\n", err)
+			continue
+		}
+		fmt.Printf("  version: %d\n", int(v))
+
+		if v != proto.LinkVersion_V1 {
+			fmt.Printf("  (unsupported link version, skipping inner decode)\n\n")
+			continue
+		}
+
+		lov1 := link.V1()
+		printSignatures(lov1.Signatures)
+
+		inner, err := lov1.Inner.AllocAndDecode(core.DecoderFactory{})
+		if err != nil {
+			fmt.Printf("  ERROR decoding inner blob: %v\n\n", err)
+			continue
+		}
+
+		lt, err := inner.GetT()
+		if err != nil {
+			fmt.Printf("  ERROR getting link type: %v\n\n", err)
+			continue
+		}
+
+		switch lt {
+		case proto.LinkType_GROUP_CHANGE:
+			printGroupChange(inner.GroupChange())
+		case proto.LinkType_GENERIC:
+			printGenericLink(inner.Generic())
+		default:
+			fmt.Printf("  link type: unknown(%d)\n", int(lt))
+		}
+
+		fmt.Println()
+		count++
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating rows: %w", err)
+	}
+
+	fmt.Printf("=== Total: %d links ===\n", count)
+	return nil
+}
+
+func (d *DumpSigchain) SetGlobalContext(g *shared.GlobalContext) {}
+
+var _ shared.CLIApp = (*DumpSigchain)(nil)
+
+func init() {
+	AddCmd(&DumpSigchain{})
+}
+
+func entityStr(eid proto.EntityID) string {
+	s, err := eid.StringErr()
+	if err != nil {
+		return fmt.Sprintf("<error: %v>", err)
+	}
+	return s
+}
+
+func hostStr(hid proto.HostID) string {
+	s, err := hid.StringErr()
+	if err != nil {
+		return fmt.Sprintf("<error: %v>", err)
+	}
+	return s
+}
+
+func roleStr(r proto.Role) string {
+	name, ok := proto.RoleTypeRevMap[r.T]
+	if !ok {
+		return fmt.Sprintf("unknown(%d)", int(r.T))
+	}
+	return name
+}
+
+func printChainer(c proto.HidingChainer) {
+	b := c.Base
+	fmt.Printf("  chainer:\n")
+	fmt.Printf("    seqno: %d\n", int(b.Seqno))
+	if b.Prev != nil {
+		fmt.Printf("    prev:  %s\n", b.Prev.String())
+	} else {
+		fmt.Printf("    prev:  <nil> (eldest)\n")
+	}
+	fmt.Printf("    time:  %s\n", b.Time.Import().Format(time.RFC3339))
+}
+
+func printSignatures(sigs []proto.Signature) {
+	for i, sig := range sigs {
+		typName, ok := proto.SignatureTypeRevMap[sig.T]
+		if !ok {
+			typName = fmt.Sprintf("unknown(%d)", int(sig.T))
+		}
+		fmt.Printf("  sig[%d]: type=%s\n", i, typName)
+	}
+}
+
+func printGroupChange(gc proto.GroupChange) {
+	fmt.Printf("  type: GROUP_CHANGE\n")
+	printChainer(gc.Chainer)
+	fmt.Printf("  entity: %s @ %s\n", entityStr(gc.Entity.Entity), hostStr(gc.Entity.Host))
+	fmt.Printf("  signer: key=%s\n", entityStr(gc.Signer.Key))
+	if gc.Signer.KeyOwner != nil {
+		ko := gc.Signer.KeyOwner
+		pid, _ := ko.Party.StringErr()
+		fmt.Printf("    key-owner: party=%s src-role=%s\n", pid, roleStr(ko.SrcRole))
+	}
+
+	if len(gc.Changes) > 0 {
+		fmt.Printf("  changes:\n")
+		for i, mr := range gc.Changes {
+			mem := mr.Member
+			fmt.Printf("    [%d] dst-role=%s\n", i, roleStr(mr.DstRole))
+			fmt.Printf("        member: %s\n", entityStr(mem.Id.Entity))
+			if mem.Id.Host != nil {
+				fmt.Printf("        host:   %s\n", hostStr(*mem.Id.Host))
+			}
+			fmt.Printf("        src-role=%s\n", roleStr(mem.SrcRole))
+		}
+	}
+
+	if len(gc.SharedKeys) > 0 {
+		fmt.Printf("  shared-keys: %d key(s)\n", len(gc.SharedKeys))
+	}
+
+	if len(gc.Metadata) > 0 {
+		fmt.Printf("  metadata:\n")
+		for i, cm := range gc.Metadata {
+			ctName, ok := proto.ChangeTypeRevMap[cm.T]
+			if !ok {
+				ctName = fmt.Sprintf("unknown(%d)", int(cm.T))
+			}
+			fmt.Printf("    [%d] type=%s\n", i, ctName)
+		}
+	}
+}
+
+func printGenericLink(gl proto.GenericLink) {
+	fmt.Printf("  type: GENERIC\n")
+	printChainer(gl.Chainer)
+	fmt.Printf("  entity: %s @ %s\n", entityStr(gl.Entity.Entity), hostStr(gl.Entity.Host))
+	fmt.Printf("  signer: %s\n", entityStr(gl.Signer.Entity))
+	if gl.Signer.Host != nil {
+		fmt.Printf("    host: %s\n", hostStr(*gl.Signer.Host))
+	}
+
+	pt, err := gl.Payload.GetT()
+	if err != nil {
+		fmt.Printf("  payload: ERROR getting type: %v\n", err)
+		return
+	}
+
+	ctName := proto.ChainTypeRevMap[pt]
+	fmt.Printf("  payload-type: %s\n", ctName)
+
+	switch pt {
+	case proto.ChainType_UserSettings:
+		us := gl.Payload.Usersettings()
+		usName, ok := proto.UserSettingsTypeRevMap[us.T]
+		if !ok {
+			usName = fmt.Sprintf("unknown(%d)", int(us.T))
+		}
+		fmt.Printf("  user-settings: %s\n", usName)
+	case proto.ChainType_TeamMembership:
+		tm := gl.Payload.Teammembership()
+		fmt.Printf("  team-membership:\n")
+		fmt.Printf("    team: %s @ %s\n",
+			entityStr(tm.Team.Team.EntityID()),
+			hostStr(tm.Team.Host),
+		)
+		fmt.Printf("    src-role: %s\n", roleStr(tm.SrcRole))
+		stateName, ok := proto.TeamMembershipLinkStateRevMap[tm.State.T]
+		if !ok {
+			stateName = fmt.Sprintf("unknown(%d)", int(tm.State.T))
+		}
+		fmt.Printf("    state: %s\n", stateName)
+	}
+}

--- a/server/shared/team_loader.go
+++ b/server/shared/team_loader.go
@@ -267,8 +267,8 @@ func (l *TeamLoader) loadKeyBoxes(m MetaContext) error {
 	rows, err := l.db.Query(m.Ctx(),
 		`SELECT role_type, viz_level, gen
 		 FROM shared_key_generations
-		 WHERE short_host_id=$1 AND entity_id=$2 AND role_type >= $3`,
-		m.ShortHostID(), l.Arg.Team.Team.ExportToDB(), myRk.Lev,
+		 WHERE short_host_id=$1 AND entity_id=$2 AND role_type <= $3`,
+		m.ShortHostID(), l.Arg.Team.Team.ExportToDB(), myRk.Typ,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
- close #240
- in attempting to repro, we found another bug, issue with team chain PTK unboxing
- fix security bug in server-side load sigchain: we were returning the wrong boxes, and maybe some the viewer was not authorized to see
  - the viewer was not able to decrypt them, so saved by e2ee and defense-in-depth
- repro of issue, and now the test is failing with the same failure we see in prod
- fix tests broken by Explore()/teamMembershipChain fixes
- fix: we were signing with the user's PUK rather than the user's device key
- add options to TeamMinder so that we don't want updates in some cases
- make a tool for testing what's in the user team membership chain
- add debugging/tooling to test that the team membership chain for the user is correct
- will be released in 0.1.7
