### PR TITLE
sso: fix offline_access scope rejection for Google OAuth

### DIFF
--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,173 @@
+# OAuth2/OIDC SSO Flow
+
+## Overview
+
+FOKS implements OAuth2 Authorization Code flow with PKCE and OIDC ID token validation.
+The flow spans three participants: the **client** (CLI agent), the **FOKS server**, and the
+**Identity Provider (IdP)** (e.g., Google, Okta).
+
+## Flow Diagram
+
+```
+Client (CLI)                    FOKS Server                        IdP (Google, Okta, etc.)
+    |                               |                                   |
+    |  1. PrepOAuth2Session()       |                                   |
+    |  - generate nonce binding     |                                   |
+    |  - generate PKCE verifier     |                                   |
+    |  - generate session ID        |                                   |
+    |                               |                                   |
+    |  2. InitOAuth2Session(id,     |                                   |
+    |     nonce, pkce_verifier)     |                                   |
+    |------------------------------>|                                   |
+    |                               |  3. Store session in DB           |
+    |                               |     (nonce, pkce_verifier,        |
+    |                               |      config_id)                   |
+    |                               |                                   |
+    |                    tiny URI   |                                   |
+    |<------------------------------|                                   |
+    |                               |                                   |
+    |  4. Open browser to           |                                   |
+    |     tiny URI                  |                                   |
+    |--------------.                |                                   |
+    |              |                |                                   |
+    |              v                |                                   |
+    |           Browser ----------->|                                   |
+    |                               |  5. Fetch OIDC discovery doc      |
+    |                               |-----------------------------.     |
+    |                               |                             |     |
+    |                               |                             v     |
+    |                               |  6. GET /.well-known/openid-configuration
+    |                               |-------------------------------------->|
+    |                               |     {authorization_endpoint,          |
+    |                               |      token_endpoint,                  |
+    |                               |      jwks_uri,                        |
+    |                               |      scopes_supported, ...}           |
+    |                               |<--------------------------------------|
+    |                               |                                   |
+    |                               |  7. Build auth URI:               |
+    |                               |     ?client_id=...                |
+    |                               |     &redirect_uri=...             |
+    |                               |     &scope=openid email profile   |
+    |                               |     &code_challenge=SHA256(verifier)
+    |                               |     &nonce=HASH(binding)          |
+    |                               |     &state=session_id             |
+    |                               |                                   |
+    |           Browser <-- 302 ----|                                   |
+    |              |                                                    |
+    |              |  8. User authenticates                             |
+    |              |----------------------------------------------->   |
+    |              |                                                |   |
+    |              |                                    Login page  |   |
+    |              |                                    Consent     |   |
+    |              |                                                |   |
+    |              |  9. Redirect to callback                       |   |
+    |              |     ?code=AUTH_CODE&state=session_id            |   |
+    |              |<----------------------------------------------|   |
+    |              |                |                                   |
+    |           Browser ----------->|                                   |
+    |                               |                                   |
+    |                               |  10. Exchange code for tokens     |
+    |                               |  POST token_endpoint              |
+    |                               |    grant_type=authorization_code  |
+    |                               |    code=AUTH_CODE                  |
+    |                               |    client_id=...                   |
+    |                               |    client_secret=... (if set)      |
+    |                               |    code_verifier=PKCE_VERIFIER     |
+    |                               |-------------------------------------->|
+    |                               |                                       |
+    |                               |     {access_token, id_token,          |
+    |                               |      refresh_token, expires_in}       |
+    |                               |<--------------------------------------|
+    |                               |                                   |
+    |                               |  11. Validate ID token (JWT)      |
+    |                               |  - Fetch JWKS from jwks_uri       |
+    |                               |  - Verify RS256 signature         |
+    |                               |  - Check aud == client_id         |
+    |                               |  - Check nonce matches            |
+    |                               |  - Extract: email, username,      |
+    |                               |    issuer, subject                |
+    |                               |                                   |
+    |                               |  12. Store tokens in DB           |
+    |                               |                                   |
+    |                               |  13. Enqueue token set to         |
+    |                               |      OAuth2 queue (wake poller)   |
+    |                               |                                   |
+    |  14. PollOAuth2Session        |                                   |
+    |      Completion()             |                                   |
+    |------------------------------>|                                   |
+    |                               |  15. Dequeue tokens               |
+    |                               |      Reserve username (if signup) |
+    |   tokens + username           |                                   |
+    |   reservation                 |                                   |
+    |<------------------------------|                                   |
+    |                               |                                   |
+    |  16. Validate ID token        |                                   |
+    |      (client-side check)      |                                   |
+    |  - Verify signature via JWKS  |                                   |
+    |  - Check nonce matches        |                                   |
+    |    binding from step 1        |                                   |
+    |                               |                                   |
+    |  17. Sign OAuth2 binding      |                                   |
+    |      with device key          |                                   |
+    |                               |                                   |
+    |  18. Signup(eldest_link,      |                                   |
+    |      sso_binding, username    |                                   |
+    |      reservation, ...)        |                                   |
+    |------------------------------>|                                   |
+    |                               |  19. Verify binding, create user  |
+    |          success              |                                   |
+    |<------------------------------|                                   |
+```
+
+## Security Mechanisms
+
+### PKCE (Proof Key for Code Exchange)
+
+Prevents authorization code interception.
+
+1. Client generates a random 20-byte **verifier**, base64url-encoded
+2. Client sends `SHA256(verifier)` as `code_challenge` in the auth request
+3. Server sends the original **verifier** in the token exchange POST
+4. IdP verifies that `SHA256(verifier) == code_challenge`
+
+PKCE is always used, regardless of whether a `client_secret` is configured.
+
+### Nonce Binding
+
+Binds the ID token to this specific FOKS session, preventing token replay/substitution.
+
+1. Client creates a **binding**: `{FQUser, TreeRoot, Rand[16]}`
+2. Hashes the binding to produce a **nonce**
+3. Nonce is sent in the auth request; the IdP embeds it in the ID token
+4. Both client and server verify the nonce in the returned ID token matches
+
+### Device Key Signature
+
+During signup, the client signs the `{IDToken, Binding}` tuple with its device key.
+This cryptographically proves that the device that initiated the OAuth2 flow is the same
+one completing signup.
+
+## IdP Compatibility
+
+Different IdPs have different behaviors:
+
+| Feature              | Standard OIDC           | Google                     |
+|----------------------|-------------------------|----------------------------|
+| Refresh tokens       | `offline_access` scope  | `access_type=offline` param|
+| Access token format  | Often JWT               | Opaque string              |
+| Username claim       | `preferred_username`    | Not provided (use email)   |
+
+The code handles these differences by:
+- Checking `scopes_supported` from the OIDC discovery document before requesting `offline_access`
+- Only validating the **ID token** as a JWT (access tokens may be opaque)
+- Falling back to the email local part when `preferred_username` is absent
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `lib/sso/oauth2.go` | OIDC discovery, ID token validation, PKCE, nonce hashing |
+| `server/shared/oauth2.go` | Server-side session management, token exchange, DB storage |
+| `server/shared/queue.go` | Queue-based async signaling (OAuth2Poke/OAuth2Wait) |
+| `server/engine/reg.go` | Registration RPCs (InitOAuth2Session, PollOAuth2SessionCompletion) |
+| `client/agent/signup.go` | Client-side flow orchestration |

--- a/lib/sso/oauth2.go
+++ b/lib/sso/oauth2.go
@@ -141,9 +141,14 @@ func MakeOAuth2Session(
 	if err != nil {
 		return nil, err
 	}
-	scopes := []string{"openid", "email", "profile", "offline_access"}
+	scopes := []string{"openid", "email", "profile"}
 
 	q := u.Query()
+	if instanceCfg.ScopeSupported("offline_access") {
+		scopes = append(scopes, "offline_access")
+	} else {
+		q.Set("access_type", "offline")
+	}
 	q.Set("client_id", ocfg.ClientID.String())
 	q.Set("redirect_uri", ocfg.RedirectURI.String())
 	q.Set("response_type", "code")
@@ -151,12 +156,8 @@ func MakeOAuth2Session(
 	q.Set("state", Base64URLEncode(ret.Binding.Rand[:]))
 	q.Set("nonce", ret.Nonce.String())
 
-	if ocfg.ClientSecret.IsZero() {
-		q.Set("code_challenge", ret.Verifier.String())
-		q.Set("code_challenge_method", "S256")
-	} else {
-		q.Set("client_secret", ocfg.ClientSecret.String())
-	}
+	q.Set("code_challenge", ret.Verifier.String())
+	q.Set("code_challenge_method", "S256")
 
 	u.RawQuery = q.Encode()
 	ret.AuthURI = proto.URLString(u.String())
@@ -171,15 +172,31 @@ type OAuth2IdPConfig struct {
 
 	isInit bool
 
-	ConfigURI   proto.URLString
-	AuthURI     proto.URLString
-	TokenURI    proto.URLString
-	JwksURI     proto.URLString
-	UserinfoURI proto.URLString
+	ConfigURI       proto.URLString
+	AuthURI         proto.URLString
+	TokenURI        proto.URLString
+	JwksURI         proto.URLString
+	UserinfoURI     proto.URLString
+	ScopesSupported []string // from OIDC discovery; nil means not specified
 
 	jkws map[OAuth2KeyID]*rsa.PublicKey
 
 	RefreshedAt time.Time // Should refresh every ~15 minutes or so (see Oauth2Configger.RefreshInterval
+}
+
+// ScopeSupported returns true if the given scope is in the IdP's scopes_supported list.
+// If the IdP did not advertise scopes_supported (nil), all scopes are assumed supported
+// per the OIDC spec.
+func (c *OAuth2IdPConfig) ScopeSupported(scope string) bool {
+	if c.ScopesSupported == nil {
+		return true
+	}
+	for _, s := range c.ScopesSupported {
+		if s == scope {
+			return true
+		}
+	}
+	return false
 }
 
 func newOAuth2Config(u proto.URLString) *OAuth2IdPConfig {
@@ -240,10 +257,11 @@ func (c *OAuth2IdPConfig) populate(ctx context.Context, g OAuth2GlobalContext) (
 	defer resp.Body.Close()
 
 	type config struct {
-		AuthURI     string `json:"authorization_endpoint"`
-		TokenURI    string `json:"token_endpoint"`
-		JwksURI     string `json:"jwks_uri"`
-		UserinfoURI string `json:"userinfo_endpoint"`
+		AuthURI         string   `json:"authorization_endpoint"`
+		TokenURI        string   `json:"token_endpoint"`
+		JwksURI         string   `json:"jwks_uri"`
+		UserinfoURI     string   `json:"userinfo_endpoint"`
+		ScopesSupported []string `json:"scopes_supported"`
 	}
 
 	var cfg config
@@ -259,6 +277,7 @@ func (c *OAuth2IdPConfig) populate(ctx context.Context, g OAuth2GlobalContext) (
 	c.TokenURI = proto.URLString(cfg.TokenURI)
 	c.JwksURI = proto.URLString(cfg.JwksURI)
 	c.UserinfoURI = proto.URLString(cfg.UserinfoURI)
+	c.ScopesSupported = cfg.ScopesSupported
 	c.RefreshedAt = g.Now()
 	c.isInit = true
 
@@ -412,12 +431,21 @@ func OAuth2CheckToken(
 	if ok {
 		ret.Subject = proto.OAuth2Subject(sub)
 	}
+
+	// If no preferred_username claim was provided, use the local part
+	// of the email as the username (e.g., Google doesn't include preferred_username in its ID tokens).
+	if ret.Username == "" && ret.Email != "" {
+		if parts := strings.SplitN(string(ret.Email), "@", 2); len(parts) == 2 {
+			ret.Username = proto.NameUtf8(parts[0])
+		}
+	}
 	return &ret, nil
 }
 
 // OAuth2CheckTokens takes the ID and access token returned from an OIDC flow and
 // checks them against the issuer's public key. It also sanity checks that the tokens
 // match the expected audience/clientID and that the nonce matches the one we generated.
+// The access token does not get checked, as it can be opaque, and not even a JWT.
 func OAuth2CheckTokens(
 	ctx context.Context,
 	g OAuth2GlobalContext,
@@ -430,24 +458,11 @@ func OAuth2CheckTokens(
 	error,
 ) {
 
-	checkOne := func(tok string, which string) (*proto.OAuth2ParsedIDToken, error) {
-		return OAuth2CheckToken(ctx, g, cfg, tok, which, audExpected, nonceExpected)
+	idtok, err := OAuth2CheckToken(ctx, g, cfg, toks.IdToken.String(), "ID", audExpected, nonceExpected)
+	if err != nil {
+		return nil, err
 	}
 
-	idtok, err := checkOne(toks.IdToken.String(), "ID")
-	if err != nil {
-		return nil, err
-	}
-	accesTok, err := checkOne(toks.AccessToken.String(), "access")
-	if err != nil {
-		return nil, err
-	}
-	if idtok.Issuer != accesTok.Issuer {
-		return nil, core.OAuth2TokenError{Which: "access", Err: core.HostMismatchError{}}
-	}
-	if idtok.Subject != accesTok.Subject {
-		return nil, core.OAuth2TokenError{Which: "access", Err: core.WrongUserError{}}
-	}
 	idtok.Raw = toks.IdToken
 	return idtok, nil
 }

--- a/server/shared/oauth2.go
+++ b/server/shared/oauth2.go
@@ -213,8 +213,7 @@ func (o *oauth2Session) makeAuthURI(m MetaContext, id proto.OAuth2SessionID) err
 	if err != nil {
 		return err
 	}
-	// Include "offline_access" to get a refresh token.
-	scopes := []string{"openid", "email", "profile", "offline_access"}
+	scopes := []string{"openid", "email", "profile"}
 	ids, err := id.StringErr()
 	if err != nil {
 		return err
@@ -225,18 +224,19 @@ func (o *oauth2Session) makeAuthURI(m MetaContext, id proto.OAuth2SessionID) err
 	}
 
 	q := u.Query()
+	if o.idpCfg.ScopeSupported("offline_access") {
+		scopes = append(scopes, "offline_access")
+	} else {
+		q.Set("access_type", "offline")
+	}
 	q.Set("client_id", o.cfg.ClientID.String())
 	q.Set("redirect_uri", o.cfg.RedirectURI.String())
 	q.Set("response_type", "code")
 	q.Set("scope", strings.Join(scopes, " "))
 	q.Set("state", ids)
 	q.Set("nonce", o.nonce.String())
-	if o.cfg.ClientSecret.IsZero() {
-		q.Set("code_challenge", chal.String())
-		q.Set("code_challenge_method", "S256")
-	} else {
-		q.Set("client_secret", o.cfg.ClientSecret.String())
-	}
+	q.Set("code_challenge", chal.String())
+	q.Set("code_challenge_method", "S256")
 	u.RawQuery = q.Encode()
 
 	o.authURI = proto.URLString(u.String())
@@ -566,9 +566,10 @@ func setOAuth2Config(
 	}
 	tag, err := db.Exec(
 		m.Ctx(),
-		`UPDATE sso_oauth2_config SET cancel_id=$1, mtime=NOW() WHERE short_host_id=$2`,
+		`UPDATE sso_oauth2_config SET cancel_id=$1, mtime=NOW() WHERE short_host_id=$2 AND cancel_id=$3`,
 		canc.ExportToDB(),
 		m.ShortHostID().ExportToDB(),
+		proto.NilCancelID(),
 	)
 	if err != nil {
 		return err

--- a/server/web/templates/vhost.templ
+++ b/server/web/templates/vhost.templ
@@ -425,7 +425,7 @@ templ VHostSSOFormFields(a *lib.AdminPageData, r *lib.VHostRow) {
 					type="text"
 					name="sso-oauth2-client-secret"
 					class="p-1 flex-1 border rounded-sm w-full text-sm"
-					placeholder="leave blank for PKCE"
+					placeholder="e.g, xZs8v3LhG9aB1n5Q0rT6u"
 					value={ r.Details.OAuth2SSOClientSecret() }
 				/>
 			</div>


### PR DESCRIPTION
sso: fix various google OAuth issues
- fix offline_access scope rejection for Google OAuth:
Google does not support offline_access as an OAuth2 scope and returns
a 400 invalid_scope error. Instead, Google requires access_type=offline
as a query parameter. Now we check the IdP's scopes_supported from the
OIDC discovery document and only include offline_access if advertised;
otherwise fall back to access_type=offline.

- other fixes:
  - always use PKCE
  - don't send client_secret in auth redirect
  - client secret is not optional in admin panel
  - fix updated logic when resetting the client secret in SSO admin portal
  - infer username if no preferred_username given

- close #244
- shipping in v0.1.7

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
