### PR TITLE
client: add key hide command and friends

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -8,7 +8,11 @@ changelog:
     date: TBD
     changes:
       - desc: add -v flag to 'foks key list' to show key IDs
-        closes: []
+        closes: ["#247"]
+      - desc: add 'foks key hide' to hide/unhide local profiles
+        closes: ["#247"]
+      - desc: add --hidden flag to 'foks key list' to show hidden profiles
+        closes: ["#247"]
   - version: 0.1.7
     urgency: low
     stable: true

--- a/client/agent/key.go
+++ b/client/agent/key.go
@@ -65,7 +65,7 @@ func (c *AgentConn) KeyRevoke(ctx context.Context, arg proto.EntityID) error {
 	return libclient.Revoke(m, au, arg)
 }
 
-func (c *AgentConn) KeyList(ctx context.Context) (lcl.KeyListRes, error) {
+func (c *AgentConn) KeyList(ctx context.Context, includeHidden bool) (lcl.KeyListRes, error) {
 
 	var ret lcl.KeyListRes
 	tmp, err := c.g.ActiveUserExport()
@@ -85,7 +85,9 @@ func (c *AgentConn) KeyList(ctx context.Context) (lcl.KeyListRes, error) {
 		return ret, err
 	}
 
-	allu, err := libclient.ReadAllUsersAndStatus(m)
+	allu, err := libclient.ReadAllUsersAndStatus(m, &libclient.ReadAllUsersOpts{
+		IncludeHidden: includeHidden,
+	})
 	if err != nil {
 		return ret, err
 	}

--- a/client/agent/user.go
+++ b/client/agent/user.go
@@ -400,4 +400,9 @@ func (c *AgentConn) RemoveKeyByInfo(ctx context.Context, info proto.UserInfo) er
 	return libclient.RemoveKeyByInfo(m, info)
 }
 
+func (c *AgentConn) ToggleDeviceHidden(ctx context.Context, arg lcl.ToggleDeviceHiddenArg) error {
+	m := c.MetaContext(ctx)
+	return libclient.SecretStoreToggleHidden(m, arg.Dev, arg.Hidden)
+}
+
 var _ lcl.UserInterface = (*AgentConn)(nil)

--- a/client/foks/cmd/key.go
+++ b/client/foks/cmd/key.go
@@ -86,6 +86,7 @@ type keyListOpts struct {
 	currentUserKeys bool
 	otherProfiles   bool
 	verbose         bool
+	showHidden      bool
 }
 
 func keyCmd(m libclient.MetaContext) *cobra.Command {
@@ -123,6 +124,7 @@ func keyCmd(m libclient.MetaContext) *cobra.Command {
 	list.Flags().BoolVar(&lsOpts.currentUserKeys, "current-user-keys", false, "show all the curent user's keys")
 	list.Flags().BoolVar(&lsOpts.otherProfiles, "other-profiles", false, "show all other profiles")
 	list.Flags().BoolVarP(&lsOpts.verbose, "verbose", "v", false, "show key IDs for all profiles")
+	list.Flags().BoolVar(&lsOpts.showHidden, "hidden", false, "show hidden profiles")
 	top.AddCommand(list)
 
 	revoke := &cobra.Command{
@@ -158,6 +160,19 @@ func keyCmd(m libclient.MetaContext) *cobra.Command {
 	useBotKey := botTokenUseCmd(m, "use-bot-token", []string{"use-bot"},
 		"This command is a synonym for `foks bot-token use`.")
 	top.AddCommand(useBotKey)
+
+	var hideShow bool
+	hide := &cobra.Command{
+		Use:          "hide <deviceID>",
+		Short:        "hide a profile from 'key list'",
+		Long:         "Hide a local profile so it doesn't appear in 'foks key list'. Use --show to unhide.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, arg []string) error {
+			return runHide(m, arg, !hideShow)
+		},
+	}
+	hide.Flags().BoolVar(&hideShow, "show", false, "unhide the profile instead")
+	top.AddCommand(hide)
 
 	// Add device commands as subcommands
 	dev := deviceCmd(m)
@@ -266,7 +281,7 @@ func runKeyList(m libclient.MetaContext, cmd *cobra.Command, arg []string, opts 
 		m,
 		&agent.StartupOpts{NeedUnlockedUser: true, NeedUser: true},
 		func(cli lcl.KeyClient) error {
-			ls, err := cli.KeyList(m.Ctx())
+			ls, err := cli.KeyList(m.Ctx(), opts.showHidden)
 			if err != nil {
 				return err
 			}
@@ -274,6 +289,30 @@ func runKeyList(m libclient.MetaContext, cmd *cobra.Command, arg []string, opts 
 				return JSONOutput(m, ls)
 			}
 			return runKeyListTable(m, ls, opts)
+		},
+	)
+}
+
+func runHide(m libclient.MetaContext, arg []string, hidden bool) error {
+	if len(arg) != 1 {
+		return ArgsError("expected exactly one argument, a device ID")
+	}
+	eid, err := proto.ImportEntityIDFromString(arg[0])
+	if err != nil {
+		return err
+	}
+	did, err := eid.ToDeviceID()
+	if err != nil {
+		return err
+	}
+	return quickStartLambda(
+		m,
+		&agent.StartupOpts{NeedUser: true},
+		func(cli lcl.UserClient) error {
+			return cli.ToggleDeviceHidden(m.Ctx(), lcl.ToggleDeviceHiddenArg{
+				Dev:    did,
+				Hidden: hidden,
+			})
 		},
 	)
 }

--- a/client/libclient/all_users.go
+++ b/client/libclient/all_users.go
@@ -113,19 +113,32 @@ func lookupDeviceName(
 // still can recover the users from the secret store file, and we try to do that here.
 
 type AllUserReader struct {
-	all        map[core.LocalUserIndex]proto.UserInfo
-	db         map[core.LocalUserIndex]proto.UserInfo
-	secrets    map[core.LocalUserIndex]proto.UserInfo
-	repairList []proto.UserInfo
-	order      []core.LocalUserIndex
-	active     *core.LocalUserIndex
+	all           map[core.LocalUserIndex]proto.UserInfo
+	db            map[core.LocalUserIndex]proto.UserInfo
+	secrets       map[core.LocalUserIndex]proto.UserInfo
+	hide          map[core.LocalUserIndex]bool
+	secretList    []lcl.FQUserRoleAndDeviceID
+	repairList    []proto.UserInfo
+	order         []core.LocalUserIndex
+	active        *core.LocalUserIndex
+	includeHidden bool
+}
+
+type ReadAllUsersOpts struct {
+	IncludeHidden bool
 }
 
 func NewAllUserLoader() *AllUserReader {
+	return NewAllUserLoaderWithOpts(ReadAllUsersOpts{})
+}
+
+func NewAllUserLoaderWithOpts(opts ReadAllUsersOpts) *AllUserReader {
 	return &AllUserReader{
-		all:     make(map[core.LocalUserIndex]proto.UserInfo),
-		db:      make(map[core.LocalUserIndex]proto.UserInfo),
-		secrets: make(map[core.LocalUserIndex]proto.UserInfo),
+		all:           make(map[core.LocalUserIndex]proto.UserInfo),
+		db:            make(map[core.LocalUserIndex]proto.UserInfo),
+		secrets:       make(map[core.LocalUserIndex]proto.UserInfo),
+		hide:          make(map[core.LocalUserIndex]bool),
+		includeHidden: opts.IncludeHidden,
 	}
 }
 
@@ -148,6 +161,10 @@ func (a *AllUserReader) loadFromDb(m MetaContext) error {
 		k, err := core.ImportLocalUserIndexFromInfo(u)
 		if err != nil {
 			return err
+		}
+
+		if a.hide[*k] && !a.includeHidden {
+			continue
 		}
 
 		if a.active != nil && a.active.Eq(*k) {
@@ -231,6 +248,21 @@ func (a *AllUserReader) loadFromSecrets(m MetaContext) error {
 	if err != nil {
 		return err
 	}
+	a.secretList = fquList
+	for _, fqu := range fquList {
+		k, err := core.NewLocalUserIndex(fqu.Fqur.Fqu, fqu.KeyID.EntityID())
+		if err != nil {
+			return err
+		}
+		if fqu.Hidden {
+			a.hide[*k] = true
+		}
+	}
+	return nil
+}
+
+func (a *AllUserReader) applySecrets(m MetaContext) error {
+	fquList := a.secretList
 
 	for _, fqu := range fquList {
 		k, err := core.NewLocalUserIndex(fqu.Fqur.Fqu, fqu.KeyID.EntityID())
@@ -239,6 +271,10 @@ func (a *AllUserReader) loadFromSecrets(m MetaContext) error {
 		}
 
 		if _, ok := a.all[*k]; ok {
+			continue
+		}
+
+		if fqu.Hidden && !a.includeHidden {
 			continue
 		}
 
@@ -251,7 +287,7 @@ func (a *AllUserReader) loadFromSecrets(m MetaContext) error {
 
 		err = fillHostInfo(m, &tmp)
 		if err != nil {
-			m.Warnw("AllUserLoader::loadFromSecrets", "fqu", fqu, "err", err)
+			m.Warnw("AllUserLoader::applySecrets", "fqu", fqu, "err", err)
 			continue
 		}
 
@@ -330,12 +366,17 @@ func (a *AllUserReader) Run(m MetaContext) error {
 		return err
 	}
 
+	err = a.loadFromSecrets(m)
+	if err != nil {
+		return err
+	}
+
 	err = a.loadFromDb(m)
 	if err != nil {
 		return err
 	}
 
-	err = a.loadFromSecrets(m)
+	err = a.applySecrets(m)
 	if err != nil {
 		return err
 	}
@@ -367,11 +408,17 @@ func ReadAllUsers(m MetaContext) ([]proto.UserInfo, error) {
 	return aul.Users(), nil
 }
 
-func ReadAllUsersAndStatus(m MetaContext) ([]proto.UserInfoAndStatus, error) {
-	tmp, err := ReadAllUsers(m)
+func ReadAllUsersAndStatus(m MetaContext, opts *ReadAllUsersOpts) ([]proto.UserInfoAndStatus, error) {
+	var o ReadAllUsersOpts
+	if opts != nil {
+		o = *opts
+	}
+	aul := NewAllUserLoaderWithOpts(o)
+	err := aul.Run(m)
 	if err != nil {
 		return nil, err
 	}
+	tmp := aul.Users()
 	res := core.Map(tmp, func(i proto.UserInfo) proto.UserInfoAndStatus {
 		return proto.UserInfoAndStatus{
 			Info: i,

--- a/client/libclient/secret_store.go
+++ b/client/libclient/secret_store.go
@@ -260,7 +260,10 @@ func (s *SecretStore) Get(
 	defer s.RUnlock()
 
 	if args.Opts.ByDeviceID {
-		ret, _ := s.lookupWithLockByDeviceID(args.Fqu, args.DeviceID)
+		ret, _, err := s.lookupWithLockByFQUAndDeviceID(args.Fqu, args.DeviceID)
+		if err != nil {
+			return nil, err
+		}
 		return ret, nil
 	}
 	ret, _, err := s.lookupWithLock(args.Fqu, args.Role, args.Opts.NoProvisional)
@@ -273,11 +276,33 @@ func (s *SecretStore) ListAll() ([]lcl.FQUserRoleAndDeviceID, error) {
 	var ret []lcl.FQUserRoleAndDeviceID
 	for _, k := range s.data.Keys {
 		ret = append(ret, lcl.FQUserRoleAndDeviceID{
-			Fqur:  k.Fqur,
-			KeyID: k.KeyID,
+			Fqur:   k.Fqur,
+			KeyID:  k.KeyID,
+			Hidden: k.Hidden,
 		})
 	}
 	return ret, nil
+}
+
+func (s *SecretStore) ToggleHidden(ctx context.Context, did proto.DeviceID, hidden bool) error {
+	s.Lock()
+	defer s.Unlock()
+	ent, i, err := s.lookupWithLockByDeviceID(did)
+	if err != nil {
+		return err
+	}
+	if ent == nil {
+		return core.UserNotFoundError{}
+	}
+	ent.Hidden = hidden
+	s.dirty = true
+	s.data.Keys[i] = *ent
+
+	err = s.saveWithLock(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *SecretStore) Delete(fqu proto.FQUser, role proto.Role, did proto.DeviceID) error {
@@ -395,25 +420,64 @@ func (s *SecretStore) FilterDeviceIDs(
 	return ret, nil
 }
 
-func (s *SecretStore) lookupWithLockByDeviceID(
+func (s *SecretStore) lookupWithLockByFQUAndDeviceID(
 	fqu proto.FQUser,
 	did proto.DeviceID,
-) (*lcl.LabeledSecretKeyBundle, int) {
-	if s.data == nil {
-		return nil, -1
-	}
-	for i, v := range s.data.Keys {
-		if v.KeyID.Eq(did) && v.Fqur.Fqu.Eq(fqu) {
-			return &v, i
-		}
-	}
-	return nil, -1
+) (
+	*lcl.LabeledSecretKeyBundle,
+	int,
+	error,
+) {
+	return s.lookupGeneric(
+		true,
+		func(row lcl.LabeledSecretKeyBundle) (bool, error) {
+			return row.Fqur.Fqu.Eq(fqu) && row.KeyID.Eq(did), nil
+		},
+	)
+}
+
+func (s *SecretStore) lookupWithLockByDeviceID(
+	devID proto.DeviceID,
+) (
+	*lcl.LabeledSecretKeyBundle,
+	int,
+	error,
+) {
+	return s.lookupGeneric(
+		false,
+		func(row lcl.LabeledSecretKeyBundle) (bool, error) {
+			return row.KeyID.Eq(devID), nil
+		},
+	)
 }
 
 func (s *SecretStore) lookupWithLock(
 	fqu proto.FQUser,
 	role proto.Role,
 	noProvsionalDevices bool,
+) (
+	*lcl.LabeledSecretKeyBundle,
+	int,
+	error,
+) {
+	return s.lookupGeneric(
+		false,
+		func(row lcl.LabeledSecretKeyBundle) (bool, error) {
+			roleEq, err := row.Fqur.Role.Eq(role)
+			if err != nil {
+				return false, err
+			}
+			if noProvsionalDevices && row.Provisional {
+				return false, nil
+			}
+			return roleEq && row.Fqur.Fqu.Eq(fqu), nil
+		},
+	)
+}
+
+func (s *SecretStore) lookupGeneric(
+	fwd bool,
+	predicate func(lcl.LabeledSecretKeyBundle) (bool, error),
 ) (
 	*lcl.LabeledSecretKeyBundle,
 	int,
@@ -426,19 +490,27 @@ func (s *SecretStore) lookupWithLock(
 	// iterate in reverse order so we get the must recent entry.
 	// if we ever failed to provision, and try again, the second entry will
 	// be the one that works, The first will be dead
-	for i := len(s.data.Keys) - 1; i >= 0; i-- {
+	var i, lim, inc int
+	if fwd {
+		i = 0
+		lim = len(s.data.Keys)
+		inc = 1
+	} else {
+		i = len(s.data.Keys) - 1
+		lim = -1
+		inc = -1
+	}
+
+	for i != lim {
 		v := s.data.Keys[i]
-		roleEq, err := v.Fqur.Role.Eq(role)
+		ok, err := predicate(v)
 		if err != nil {
 			return nil, -1, err
 		}
-		if !roleEq || !v.Fqur.Fqu.Eq(fqu) {
-			continue
+		if ok {
+			return &v, i, nil
 		}
-		if v.Provisional && noProvsionalDevices {
-			continue
-		}
-		return &v, i, nil
+		i += inc
 	}
 	return nil, -1, nil
 }
@@ -446,7 +518,10 @@ func (s *SecretStore) lookupWithLock(
 func (s *SecretStore) Put(row lcl.LabeledSecretKeyBundle) error {
 	s.Lock()
 	defer s.Unlock()
-	ex, _ := s.lookupWithLockByDeviceID(row.Fqur.Fqu, row.KeyID)
+	ex, _, err := s.lookupWithLockByFQUAndDeviceID(row.Fqur.Fqu, row.KeyID)
+	if err != nil {
+		return err
+	}
 	if ex != nil {
 		return core.SecretKeyExistsError{}
 	}
@@ -475,7 +550,10 @@ func (s *SecretStore) Update(row lcl.LabeledSecretKeyBundle) error {
 const CurrentSecretKeyRowMinorVersion = lcl.SecretKeyBundleMinorVersion(1)
 
 func (s *SecretStore) updateWithLock(row lcl.LabeledSecretKeyBundle) (func(), error) {
-	_, pos := s.lookupWithLockByDeviceID(row.Fqur.Fqu, row.KeyID)
+	_, pos, err := s.lookupWithLockByFQUAndDeviceID(row.Fqur.Fqu, row.KeyID)
+	if err != nil {
+		return nil, err
+	}
 	if pos < 0 {
 		return nil, core.KeyNotFoundError{Which: "secret devkey"}
 	}

--- a/client/libclient/secret_store_hilev.go
+++ b/client/libclient/secret_store_hilev.go
@@ -246,3 +246,12 @@ func makeSecretStoreBundle(
 		return nil, core.NotImplementedError{}
 	}
 }
+
+func SecretStoreToggleHidden(
+	m MetaContext,
+	did proto.DeviceID,
+	hidden bool,
+) error {
+	store := m.G().SecretStore()
+	return store.ToggleHidden(m.Ctx(), did, hidden)
+}

--- a/proto-src/lcl/key.snowp
+++ b/proto-src/lcl/key.snowp
@@ -16,6 +16,6 @@ protocol Key
     resHeader Header
     errors lib.Status @0xbaa02ef2 {
 
-    keyList @0 () -> KeyListRes;
+    keyList @0 ( includeHidden @0 : Bool ) -> KeyListRes;
     keyRevoke @1 ( eid @0 : lib.EntityID );
 }

--- a/proto-src/lcl/secret_key.snowp
+++ b/proto-src/lcl/secret_key.snowp
@@ -64,11 +64,13 @@ struct LabeledSecretKeyBundle {
     ctime @5 : lib.Time; // Creation time
     mtime @6 : lib.Time; // Modification time
     minorVersion @7 : SecretKeyBundleMinorVersion; // Incremented when necessary; local to the secretStore version above
+    hidden @8: Bool; // if we should hide this key (maybe because it's from a broken signup); added 2026.03.28 in v0.1.8
 }
 
 struct FQUserRoleAndDeviceID {
     fqur @0 : lib.FQUserAndRole;
     keyID @1 : lib.DeviceID;
+    hidden @2 : Bool;
 }
 
 // If storing data in the macOS keychain about a secret key, this is how to

--- a/proto-src/lcl/user.snowp
+++ b/proto-src/lcl/user.snowp
@@ -53,4 +53,8 @@ protocol User
 
     removeKey @14 ( key @0 : LocalUserIndexParsed );
     removeKeyByInfo @15 ( info @0 : lib.UserInfo );
+
+    // if we wrote down a local device to the local key ring, but signup crashed (let's say),
+    // we can hide that key so it doesn't spam up `foks key list`.
+    toggleDeviceHidden @16 ( dev @0 : lib.DeviceID, hidden @1 : Bool );
 }

--- a/proto/lcl/key.go
+++ b/proto/lcl/key.go
@@ -125,16 +125,27 @@ func (k *KeyListRes) Bytes() []byte { return nil }
 var KeyProtocolID rpc.ProtocolUniqueID = rpc.ProtocolUniqueID(0xbaa02ef2)
 
 type KeyListArg struct {
+	IncludeHidden bool
 }
 type KeyListArgInternal__ struct {
-	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	_struct       struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	IncludeHidden *bool
 }
 
 func (k KeyListArgInternal__) Import() KeyListArg {
-	return KeyListArg{}
+	return KeyListArg{
+		IncludeHidden: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(k.IncludeHidden),
+	}
 }
 func (k KeyListArg) Export() *KeyListArgInternal__ {
-	return &KeyListArgInternal__{}
+	return &KeyListArgInternal__{
+		IncludeHidden: &k.IncludeHidden,
+	}
 }
 func (k *KeyListArg) Encode(enc rpc.Encoder) error {
 	return enc.Encode(k.Export())
@@ -192,7 +203,7 @@ func (k *KeyRevokeArg) Decode(dec rpc.Decoder) error {
 func (k *KeyRevokeArg) Bytes() []byte { return nil }
 
 type KeyInterface interface {
-	KeyList(context.Context) (KeyListRes, error)
+	KeyList(context.Context, bool) (KeyListRes, error)
 	KeyRevoke(context.Context, lib.EntityID) error
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h Header) error
@@ -239,8 +250,10 @@ type KeyClient struct {
 	CheckResHeader func(context.Context, Header) error
 }
 
-func (c KeyClient) KeyList(ctx context.Context) (res KeyListRes, err error) {
-	var arg KeyListArg
+func (c KeyClient) KeyList(ctx context.Context, includeHidden bool) (res KeyListRes, err error) {
+	arg := KeyListArg{
+		IncludeHidden: includeHidden,
+	}
 	warg := &rpc.DataWrap[Header, *KeyListArgInternal__]{
 		Data: arg.Export(),
 	}
@@ -304,7 +317,8 @@ func KeyProtocol(i KeyInterface) rpc.ProtocolV2 {
 						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
 							return nil, err
 						}
-						tmp, err := i.KeyList(ctx)
+						typedArg := typedWrappedArg.Data
+						tmp, err := i.KeyList(ctx, (typedArg.Import()).IncludeHidden)
 						if err != nil {
 							return nil, err
 						}

--- a/proto/lcl/secret_key.go
+++ b/proto/lcl/secret_key.go
@@ -648,6 +648,7 @@ type LabeledSecretKeyBundle struct {
 	Ctime        lib.Time
 	Mtime        lib.Time
 	MinorVersion SecretKeyBundleMinorVersion
+	Hidden       bool
 }
 type LabeledSecretKeyBundleInternal__ struct {
 	_struct      struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -659,6 +660,7 @@ type LabeledSecretKeyBundleInternal__ struct {
 	Ctime        *lib.TimeInternal__
 	Mtime        *lib.TimeInternal__
 	MinorVersion *SecretKeyBundleMinorVersionInternal__
+	Hidden       *bool
 }
 
 func (l LabeledSecretKeyBundleInternal__) Import() LabeledSecretKeyBundle {
@@ -711,6 +713,12 @@ func (l LabeledSecretKeyBundleInternal__) Import() LabeledSecretKeyBundle {
 			}
 			return x.Import()
 		})(l.MinorVersion),
+		Hidden: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(l.Hidden),
 	}
 }
 func (l LabeledSecretKeyBundle) Export() *LabeledSecretKeyBundleInternal__ {
@@ -723,6 +731,7 @@ func (l LabeledSecretKeyBundle) Export() *LabeledSecretKeyBundleInternal__ {
 		Ctime:        l.Ctime.Export(),
 		Mtime:        l.Mtime.Export(),
 		MinorVersion: l.MinorVersion.Export(),
+		Hidden:       &l.Hidden,
 	}
 }
 func (l *LabeledSecretKeyBundle) Encode(enc rpc.Encoder) error {
@@ -742,13 +751,15 @@ func (l *LabeledSecretKeyBundle) Decode(dec rpc.Decoder) error {
 func (l *LabeledSecretKeyBundle) Bytes() []byte { return nil }
 
 type FQUserRoleAndDeviceID struct {
-	Fqur  lib.FQUserAndRole
-	KeyID lib.DeviceID
+	Fqur   lib.FQUserAndRole
+	KeyID  lib.DeviceID
+	Hidden bool
 }
 type FQUserRoleAndDeviceIDInternal__ struct {
 	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
 	Fqur    *lib.FQUserAndRoleInternal__
 	KeyID   *lib.DeviceIDInternal__
+	Hidden  *bool
 }
 
 func (f FQUserRoleAndDeviceIDInternal__) Import() FQUserRoleAndDeviceID {
@@ -765,12 +776,19 @@ func (f FQUserRoleAndDeviceIDInternal__) Import() FQUserRoleAndDeviceID {
 			}
 			return x.Import()
 		})(f.KeyID),
+		Hidden: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(f.Hidden),
 	}
 }
 func (f FQUserRoleAndDeviceID) Export() *FQUserRoleAndDeviceIDInternal__ {
 	return &FQUserRoleAndDeviceIDInternal__{
-		Fqur:  f.Fqur.Export(),
-		KeyID: f.KeyID.Export(),
+		Fqur:   f.Fqur.Export(),
+		KeyID:  f.KeyID.Export(),
+		Hidden: &f.Hidden,
 	}
 }
 func (f *FQUserRoleAndDeviceID) Encode(enc rpc.Encoder) error {

--- a/proto/lcl/user.go
+++ b/proto/lcl/user.go
@@ -715,6 +715,54 @@ func (r *RemoveKeyByInfoArg) Decode(dec rpc.Decoder) error {
 
 func (r *RemoveKeyByInfoArg) Bytes() []byte { return nil }
 
+type ToggleDeviceHiddenArg struct {
+	Dev    lib.DeviceID
+	Hidden bool
+}
+type ToggleDeviceHiddenArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Dev     *lib.DeviceIDInternal__
+	Hidden  *bool
+}
+
+func (t ToggleDeviceHiddenArgInternal__) Import() ToggleDeviceHiddenArg {
+	return ToggleDeviceHiddenArg{
+		Dev: (func(x *lib.DeviceIDInternal__) (ret lib.DeviceID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(t.Dev),
+		Hidden: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(t.Hidden),
+	}
+}
+func (t ToggleDeviceHiddenArg) Export() *ToggleDeviceHiddenArgInternal__ {
+	return &ToggleDeviceHiddenArgInternal__{
+		Dev:    t.Dev.Export(),
+		Hidden: &t.Hidden,
+	}
+}
+func (t *ToggleDeviceHiddenArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(t.Export())
+}
+
+func (t *ToggleDeviceHiddenArg) Decode(dec rpc.Decoder) error {
+	var tmp ToggleDeviceHiddenArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*t = tmp.Import()
+	return nil
+}
+
+func (t *ToggleDeviceHiddenArg) Bytes() []byte { return nil }
+
 type UserInterface interface {
 	Clear(context.Context) error
 	AgentStatus(context.Context) (AgentStatus, error)
@@ -732,6 +780,7 @@ type UserInterface interface {
 	LoginWaitForSsoLogin(context.Context, lib.UISessionID) (lib.SSOLoginRes, error)
 	RemoveKey(context.Context, LocalUserIndexParsed) error
 	RemoveKeyByInfo(context.Context, lib.UserInfo) error
+	ToggleDeviceHidden(context.Context, ToggleDeviceHiddenArg) error
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h Header) error
 	MakeResHeader() Header
@@ -1142,6 +1191,26 @@ func (c UserClient) RemoveKeyByInfo(ctx context.Context, info lib.UserInfo) (err
 	}
 	var tmp rpc.DataWrap[Header, interface{}]
 	err = c.Cli.Call2(ctx, rpc.NewMethodV2(UserProtocolID, 15, "User.removeKeyByInfo"), warg, &tmp, 0*time.Millisecond, userErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+func (c UserClient) ToggleDeviceHidden(ctx context.Context, arg ToggleDeviceHiddenArg) (err error) {
+	warg := &rpc.DataWrap[Header, *ToggleDeviceHiddenArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[Header, interface{}]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(UserProtocolID, 16, "User.toggleDeviceHidden"), warg, &tmp, 0*time.Millisecond, userErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
 	if err != nil {
 		return
 	}
@@ -1617,6 +1686,34 @@ func UserProtocol(i UserInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "removeKeyByInfo",
+			},
+			16: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[Header, *ToggleDeviceHiddenArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *ToggleDeviceHiddenArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[Header, *ToggleDeviceHiddenArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						err := i.ToggleDeviceHidden(ctx, (typedArg.Import()))
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[Header, interface{}]{
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "toggleDeviceHidden",
 			},
 		},
 		WrapError: UserMakeGenericErrorWrapper(i.ErrorWrapper()),

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -1672,6 +1672,8 @@ func (p PartyID) StringErr() (string, error)                  { return p.EntityI
 func (p PartyID) MarshalJSON() ([]byte, error)                { return marsh(p) }
 func (d DirentID) MarshalJSON() ([]byte, error)               { return marsh(d) }
 func (i KVNodeID) MarshalJSON() ([]byte, error)               { return marsh(i) }
+func (n NaclNonce) String() string                            { return B62Encode(n[:]) }
+func (n NaclNonce) MarshalJSON() ([]byte, error)              { return json.Marshal(n.String()) }
 
 func (d *DeviceID) UnmarshalJSON(data []byte) error {
 	return unmarshalJson(d, data, func(e EntityID) (DeviceID, error) { return e.ToDeviceID() })
@@ -1694,6 +1696,7 @@ func (k *KVNodeID) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *NaclNonce) UnmarshalJSON(dat []byte) error          { return UnmarshalJsonFixed((*n)[:], dat) }
 func (t *StdHash) UnmarshalJSON(dat []byte) error            { return UnmarshalJsonFixed((*t)[:], dat) }
 func (m *MerkleTreeRFOutput) UnmarshalJSON(dat []byte) error { return UnmarshalJsonFixed((*m)[:], dat) }
 func (m *MerkleRootHash) UnmarshalJSON(dat []byte) error     { return UnmarshalJsonFixed((*m)[:], dat) }


### PR DESCRIPTION
- Add 'foks key hide <deviceID>' command to hide local profiles from
  key list output; use --show to unhide
- Add --hidden flag to 'foks key list' to include hidden profiles
- Thread includeHidden through KeyList RPC, AllUserReader, and SecretStore

Closes #247

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
