### PR TITLE
test: fix agent socket race in waitForSocket

### DIFF
--- a/integration-tests/cli/base_test.go
+++ b/integration-tests/cli/base_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strings"
 	"testing"
@@ -463,11 +464,15 @@ func (a *testAgent) waitForSocket(t *testing.T) {
 	}, "ctl", "socket")
 	sock := tui.TrimmedString()
 
-	// Now poll for it, shoudln't take long
+	// Poll until the agent is actually accepting connections, not just until
+	// the socket file exists. A stale socket file from a previous agent run
+	// can satisfy os.Stat before the new listener is up, leading to a flaky
+	// "failed to connect to agent" on the next CLI invocation.
 	wait := time.Millisecond * 1
 	for i := 0; i < 20; i++ {
-		_, err := os.Stat(sock)
+		conn, err := net.DialTimeout("unix", sock, 50*time.Millisecond)
 		if err == nil {
+			_ = conn.Close()
 			return
 		}
 		time.Sleep(wait)
@@ -475,7 +480,7 @@ func (a *testAgent) waitForSocket(t *testing.T) {
 			wait *= 2
 		}
 	}
-	t.Fatal("socket not found")
+	t.Fatal("agent socket not reachable")
 }
 
 func (a *testAgent) stop(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #260. Fixes the `TestPassphraseSetViaKex` flake (and the same-shape `TestRevokeThreeWayWithPassphraseRotation` flake observed in an earlier run) that surfaces once CI starts running on `ubuntu-latest`.

The race is in `waitForSocket` (`integration-tests/cli/base_test.go`). It used `os.Stat` to decide when a freshly started agent was ready, so a stale socket file left behind by the previous agent could satisfy it before the new listener actually existed — the next CLI invocation would then dial into nothing and fail with `failed to connect to agent at path ...`.

The fix: poll with `net.DialTimeout("unix", sock, 50ms)` instead of `os.Stat`. A stale unlinked file no longer fools us; if no one is listening the dial fails fast with `ECONNREFUSED` and we keep polling. Same total wait budget (~1.4 s).

## Notes

- Did not also `os.Remove(sock)` in `stop()` — the dial-based wait is sufficient on its own. Happy to add it for belt-and-suspenders.

## Test plan

- [x] CI passes on this PR
- [x] No regression in tests that don't stop+restart the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
