### PR TITLE
server: normalize all DB timestamps to UTC

### DIFF
--- a/server/shared/db_config.go
+++ b/server/shared/db_config.go
@@ -45,6 +45,11 @@ func (d DbConfigJSON) ToString() string {
 	if !d.NoTLS {
 		pairs = append(pairs, "sslmode=verify-full")
 	}
+	// Pin every session to UTC. All time.Time values are written UTC (see
+	// GlobalContext.Now), and TIMESTAMP/TIMESTAMPTZ columns rely on this so the
+	// stored wall-clock digits are unambiguously UTC regardless of the server's
+	// timezone GUC or the host's local zone.
+	pairs = append(pairs, "timezone=UTC")
 	// Tune this way down to expose leaks and recurives db acquires
 	pairs = append(pairs, "pool_max_conns=100")
 	ret := strings.Join(pairs, " ")

--- a/server/shared/globals.go
+++ b/server/shared/globals.go
@@ -223,9 +223,9 @@ func (g *GlobalContext) Now() time.Time {
 	g.RLock()
 	defer g.RUnlock()
 	if g.clock == nil {
-		return time.Now()
+		return time.Now().UTC()
 	}
-	return g.clock.Now()
+	return g.clock.Now().UTC()
 }
 
 func (g *GlobalContext) HostIDMap() *HostIDMap {

--- a/server/shared/payments.go
+++ b/server/shared/payments.go
@@ -613,7 +613,7 @@ func editStripeSubscriptionTx(
 
 	switch op {
 	case PlanEditOpCancel:
-		args = append(args, true, time.Now())
+		args = append(args, true, m.Now())
 	case PlanEditOpResume:
 		args = append(args, false, nil)
 	case PlanEditOpRageQuit:
@@ -621,7 +621,7 @@ func editStripeSubscriptionTx(
 		if err != nil {
 			return err
 		}
-		args = append(args, cid.ExportToDB(), time.Now())
+		args = append(args, cid.ExportToDB(), m.Now())
 	default:
 		return core.InternalError("unknown plan edit op")
 
@@ -887,7 +887,7 @@ func LoadAndUpdatePlanForUser(
 	// Might have failed if stripe gave us a bad reply, but err on the side of
 	// giving the user a plan.
 	if cpe.IsZero() {
-		cpe = time.Now().Add(time.Duration(24*30) * time.Hour)
+		cpe = m.Now().Add(time.Duration(24*30) * time.Hour)
 		m.Warnw("recordPlan", "uid", uid, "action", "default-cpe", "cpe", cpe)
 	}
 


### PR DESCRIPTION
## Summary

Prerequisite cleanup before migrating Postgres `TIMESTAMP` columns to `TIMESTAMPTZ`. Guarantees that every `time.Time` written to the DB — and every pooled connection's session — is unambiguously UTC, so the eventual `ALTER COLUMN ... TYPE TIMESTAMPTZ USING <col> AT TIME ZONE 'UTC'` is correct for all existing rows.

- `globals.go`: `GlobalContext.Now()` (and therefore `MetaContext.Now()`) now always returns UTC, on both the real-clock and injected-test-clock paths. This is the root fix — all `m.Now()` call sites inherit it.
- `payments.go`: switch the remaining raw `time.Now()` call sites to `m.Now()` (the `cpe` fallback flows into the `paid_through` column; the two `editStripeSubscriptionTx` sites feed `pending_cancel_time`/`cancel_time`).
- `db_config.go`: pin `timezone=UTC` in the connection string built by `DbConfigJSON.ToString()`, the single chokepoint for both the main DBs and the KV shards. Sent as a pgx startup `RuntimeParam` (no per-connection round-trip). Belt-and-suspenders against an operator overriding the server's `timezone` GUC.

### Context

These are safe no-ops in the current `FROM scratch` container deploy, which already runs UTC (Go's `time.Local` falls back to UTC with no tzdata, and Postgres defaults the session to UTC). They close latent hygiene gaps that would silently corrupt timestamps if the server ever ran outside that environment, and unblock the `TIMESTAMPTZ` migration.

## Test plan

- [x] `go build ./server/...` clean
- [x] `go vet ./server/shared/` clean
- [x] Verified pgx parses `timezone=UTC` into `ConnConfig.RuntimeParams` (throwaway test)
- [ ] Confirm against a live PG that sessions report `SHOW timezone` = `UTC`

🤖 Generated with [Claude Code](https://claude.com/claude-code)