### PR TITLE
chat(1a): local DB modifications

### DIFF
--- a/client/libclient/db.go
+++ b/client/libclient/db.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -209,6 +210,7 @@ type PutArg struct {
 	Val     core.Codecable
 	Counter *int64
 	Set     bool
+	Idx     *int64
 }
 
 func (g *GlobalContext) DbPut(ctx context.Context, which DbType, row PutArg) error {
@@ -529,6 +531,190 @@ func (d *DB) Get(
 	return ret, nil
 }
 
+type DBRange[
+	T any,
+	PT interface {
+		*T
+		core.Codecable
+	},
+] struct {
+	db    *DB
+	scope lcl.ScopeID
+	typ   lcl.DataType
+	key   proto.DbKey
+}
+
+func NewDBRange[
+	T any,
+	PT interface {
+		*T
+		core.Codecable
+	},
+](
+	m MetaContext,
+	d *DB,
+	scope Scoper,
+	typ lcl.DataType,
+	gkey any,
+) (*DBRange[T, PT], error) {
+	d.Lock()
+	defer d.Unlock()
+
+	key, err := core.NewDbKey(gkey)
+	if err != nil {
+		return nil, err
+	}
+
+	if scope == nil {
+		return nil, core.InternalError("scope is nil")
+	}
+	if typ == lcl.DataType_None {
+		return nil, core.InternalError("type is none")
+	}
+
+	scopeID, err := d.getScopeID(m.Ctx(), scope)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DBRange[T, PT]{
+		db:    d,
+		scope: scopeID,
+		typ:   typ,
+		key:   key,
+	}, nil
+}
+
+func (r *DBRange[T, TP]) Min(m MetaContext) (int64, error) {
+	return r.idxFunc(m, "MIN")
+}
+func (r *DBRange[T, TP]) Max(m MetaContext) (int64, error) {
+	return r.idxFunc(m, "MAX")
+}
+
+func (r *DBRange[T, TP]) Get(
+	m MetaContext,
+	start int64,
+	end int64,
+) (
+	[]T,
+	[]int64,
+	error,
+) {
+	r.db.Lock()
+	defer r.db.Unlock()
+
+	var lo, hi int64
+	var ord string
+
+	if start <= end {
+		lo = start
+		hi = end
+		ord = "ASC"
+	} else {
+		lo = end
+		hi = start
+		ord = "DESC"
+	}
+
+	q := `SELECT idx,val FROM ranged_data 
+	      WHERE scope_id=$1 AND typ=$2 AND key=$3
+		  AND idx >= $4 AND idx <= $5
+		  ORDER BY idx ` + ord
+	args := []any{int(r.scope), r.typ, r.key.ExportToDB(), lo, hi}
+	return r.get(m, q, args)
+}
+
+func (r *DBRange[T, TP]) GetNMax(
+	m MetaContext,
+	n int64,
+) (
+	[]T,
+	[]int64,
+	error,
+) {
+	q := `SELECT idx, val FROM ranged_data
+	WHERE scope_id=$1 AND typ=$2 AND key=$3
+	ORDER BY idx DESC LIMIT $4`
+	args := []any{int(r.scope), r.typ, r.key.ExportToDB(), n}
+	return r.get(m, q, args)
+}
+
+func (r *DBRange[T, TP]) get(
+	m MetaContext,
+	q string,
+	args []any,
+) (
+	[]T,
+	[]int64,
+	error,
+) {
+	var ret []T
+	var idxList []int64
+	rows, err := r.db.db.Query(q, args...)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var raw []byte
+		var idx int64
+		err = rows.Scan(&idx, &raw)
+		if err != nil {
+			return nil, nil, err
+		}
+		var tmp T
+		err = core.DecodeFromBytes(TP(&tmp), raw)
+		if err != nil {
+			return nil, nil, err
+		}
+		ret = append(ret, tmp)
+		idxList = append(idxList, idx)
+	}
+
+	q = `UPDATE ranged_data_gc_bit SET gc_bit=1 WHERE scope_id=$1 AND typ=$2 AND key=$3`
+	args = []any{r.scope, r.typ, r.key.ExportToDB()}
+
+	err = RetryTx(m, r.db.db, "DBRange.Get", func(m MetaContext, tx *sql.Tx) error {
+		_, err := tx.Exec(q, args...)
+		if err != nil {
+			return err
+		}
+		// Can't check rowsAffected() since it might noop if we're
+		// idempotent and the row already has gc_bit=1.
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ret, idxList, nil
+}
+
+func (r *DBRange[T, TP]) idxFunc(
+	m MetaContext,
+	f string,
+) (
+	int64,
+	error,
+) {
+	var zed int64
+	r.db.Lock()
+	defer r.db.Unlock()
+
+	q := fmt.Sprintf("SELECT %s(idx) FROM reanged data WHERE scope_id=$1 AND typ=$2 AND key=$3", f)
+	args := []any{int(r.scope), r.typ, r.key.ExportToDB()}
+
+	var ret int64
+	err := r.db.db.QueryRow(q, args...).Scan(&ret)
+	if err == sql.ErrNoRows {
+		return zed, core.RowNotFoundError{}
+	}
+	if err != nil {
+		return zed, err
+	}
+	return ret, nil
+}
+
 func (g *GlobalContext) DbPutTx(ctx context.Context, which DbType, rows []PutArg) error {
 	m := NewMetaContext(ctx, g)
 	db, err := g.Db(ctx, which)
@@ -653,6 +839,31 @@ func (d *DB) PutTx(m MetaContext, rows []PutArg) error {
 				`
 				args = []any{int(scopeIDs[i]), row.Typ.ExportToDB(), row.Counter, now}
 				checkRows = false
+
+			case row.Idx != nil:
+				if valRaw == nil {
+					return core.InternalError("nil value on insert")
+				}
+				key, err := core.NewDbKey(row.Key)
+				if err != nil {
+					return err
+				}
+				if scopeIDs[i] == 0 {
+					return core.InternalError("scopeID is 0")
+				}
+				rkey = key
+				q = `INSERT INTO ranged_data(scope_id, typ, key, idx, val, ctime, mtime)
+				     VALUES($1, $2, $3, $4, $5, $6, $6)
+				     ON CONFLICT(scope_id, typ, key, idx)
+					 DO UPDATE SET val=$5, mtime=$6`
+				args = []any{
+					int(scopeIDs[i]),
+					row.Typ.ExportToDB(),
+					key.ExportToDB(),
+					int(*row.Idx),
+					valRaw,
+					proto.Now(),
+				}
 
 			default:
 				if valRaw == nil {

--- a/client/librt/db.go
+++ b/client/librt/db.go
@@ -1,0 +1,165 @@
+package librt
+
+import (
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+func dbPutMsgs(
+	m MetaContext,
+	au *libclient.UserContext,
+	v []proto.RTMsgCachedWithSeq,
+) error {
+	if au == nil {
+		return core.NoActiveUserError{}
+	}
+	scope := au.FQParty()
+
+	args := make([]libclient.PutArg, 0, len(v))
+	for _, x := range v {
+		idx := int64(x.Seq)
+		// Store the whole RTMsgCached (noncer + wrapper + server-insert-time)
+		// under one key; dbGetMsgs decodes RTThreadMsgData back into RTMsgCached.
+		args = append(args,
+			libclient.PutArg{
+				Scope: &scope,
+				Typ:   lcl.DataType_RTThreadMsgData,
+				Key:   x.Cm.Md.Chid,
+				Val:   &x.Cm,
+				Idx:   &idx,
+			},
+		)
+	}
+
+	err := m.DbPutTx(
+		libclient.DbTypeSoft,
+		args,
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func dbPutMsgToOutbox(
+	m MetaContext,
+	au *libclient.UserContext,
+	row proto.RTMsgCached,
+) error {
+	if au == nil {
+		return core.NoActiveUserError{}
+	}
+	scope := au.FQParty()
+	sentAt := row.Md.Md.SendTime.ToInt64()
+	err := m.DbPut(
+		libclient.DbTypeSoft,
+		libclient.PutArg{
+			Scope: &scope,
+			Typ:   lcl.DataType_RTOutboxMsg,
+			Key:   row.Md.Chid,
+			Val:   &row,
+			Idx:   &sentAt,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func dbGetMsgsHelper(
+	m MetaContext,
+	au *libclient.UserContext,
+	chid proto.RTChannelID,
+	f func(rng *libclient.DBRange[proto.RTMsgCached, *proto.RTMsgCached]) (
+		[]proto.RTMsgCached,
+		[]int64,
+		error,
+	),
+) (
+	[]proto.RTMsgCachedWithSeq,
+	error,
+) {
+	db, err := m.G().Db(m.Ctx(), libclient.DbTypeSoft)
+	if err != nil {
+		return nil, err
+	}
+	scope := au.FQParty()
+	rng, err := libclient.NewDBRange[proto.RTMsgCached](
+		m.Base(),
+		db,
+		&scope,
+		lcl.DataType_RTThreadMsgData,
+		chid,
+	)
+	if err != nil {
+		return nil, err
+	}
+	msgs, idx, err := f(rng)
+	if err != nil {
+		return nil, err
+	}
+
+	// Now zip the indices back into the results, as they were returned
+	// in a parallel list.
+	ret := make([]proto.RTMsgCachedWithSeq, len(msgs))
+	for i, msg := range msgs {
+		ret[i] = proto.RTMsgCachedWithSeq{
+			Cm:  msg,
+			Seq: proto.RTMsgSeq(idx[i]),
+		}
+	}
+
+	return ret, nil
+}
+
+func dbGetMsgs(
+	m MetaContext,
+	au *libclient.UserContext,
+	chid proto.RTChannelID,
+	start proto.RTMsgSeq,
+	end proto.RTMsgSeq,
+) (
+	[]proto.RTMsgCachedWithSeq,
+	error,
+) {
+	return dbGetMsgsHelper(m, au, chid,
+		func(rng *libclient.DBRange[proto.RTMsgCached, *proto.RTMsgCached]) (
+			[]proto.RTMsgCached,
+			[]int64,
+			error,
+		) {
+			return rng.Get(
+				m.Base(),
+				start.Int64(),
+				end.Int64(),
+			)
+		},
+	)
+}
+
+func dbGetRecentMsgs(
+	m MetaContext,
+	au *libclient.UserContext,
+	chid proto.RTChannelID,
+	num uint,
+) (
+	[]proto.RTMsgCachedWithSeq,
+	error,
+) {
+	return dbGetMsgsHelper(m, au, chid,
+		func(rng *libclient.DBRange[proto.RTMsgCached, *proto.RTMsgCached]) (
+			[]proto.RTMsgCached,
+			[]int64,
+			error,
+		) {
+			return rng.GetNMax(
+				m.Base(),
+				int64(num),
+			)
+
+		},
+	)
+}

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -6,12 +6,14 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/lib/chains"
 	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/proto/lcl"
+	"github.com/foks-proj/go-foks/proto/lib"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
 )
@@ -51,6 +53,29 @@ type Minder struct {
 
 	localCliMu sync.Mutex
 	localCli   *rem.RealTimeClient
+
+	// Always-on instrumentation counters; read via Metrics(). Useful for tests
+	// and debugging (e.g. asserting a read was served entirely from cache).
+	serverThreadReads atomic.Int64
+	serverRecentReads atomic.Int64
+}
+
+// MinderMetrics is a snapshot of a Minder's instrumentation counters.
+type MinderMetrics struct {
+	// ServerThreadReads counts RtGetThread RPCs issued (bookended ranges and/or
+	// explicit seq fills). A read served entirely from the local cache does not
+	// increment this.
+	ServerThreadReads int64
+	// ServerRecentReads counts RtGetThreadRecents RPCs issued.
+	ServerRecentReads int64
+}
+
+// Metrics returns a snapshot of the Minder's instrumentation counters.
+func (d *Minder) Metrics() MinderMetrics {
+	return MinderMetrics{
+		ServerThreadReads: d.serverThreadReads.Load(),
+		ServerRecentReads: d.serverRecentReads.Load(),
+	}
 }
 
 func NewMinder(au *libclient.UserContext) *Minder {
@@ -683,6 +708,21 @@ func (d *Minder) SendWithTestHooks(
 		return nil, err
 	}
 	mw := proto.NewRTMsgWrapperWithEncrypted(*box)
+
+	msgCached := proto.RTMsgCached{
+		Md: noncer,
+		Mw: mw,
+	}
+
+	err = dbPutMsgToOutbox(
+		m,
+		d.au,
+		msgCached,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	res, err := cli.RtSend(m.Ctx(), rem.RTSendArg{
 		Md:   md,
 		Mw:   mw,
@@ -691,7 +731,37 @@ func (d *Minder) SendWithTestHooks(
 	if err != nil {
 		return nil, err
 	}
+
+	// The server assigns the insert time; record it so the cached copy matches
+	// what a server-fetched read would carry.
+	msgCached.Sit = res.InsertTime
+	msgCachedSeq := proto.RTMsgCachedWithSeq{
+		Cm:  msgCached,
+		Seq: res.Seq,
+	}
+
+	err = dbPutMsgs(m, d.au, []proto.RTMsgCachedWithSeq{msgCachedSeq})
+	if err != nil {
+		return nil, err
+	}
+
 	return &res, nil
+}
+
+func (d *Minder) openMessageWithRTMsg(
+	m MetaContext,
+	rtp *RTParty,
+	appID proto.RTAppID,
+	msg rem.RTMsg,
+	ch proto.RTChannelID,
+) (
+	[]byte,
+	*proto.RTMsgCached,
+	error,
+) {
+	return d.openMessage(m, rtp, appID,
+		msg.Md, msg.Mw, msg.Sender, msg.InsertTime, ch,
+	)
 }
 
 // openMessage decrypts a message body fetched from the server, using the key at
@@ -700,67 +770,212 @@ func (d *Minder) openMessage(
 	m MetaContext,
 	rtp *RTParty,
 	appID proto.RTAppID,
-	msg rem.RTMsg,
+	md proto.RTMsgMetadata,
+	mw proto.RTMsgWrapper,
+	sender *proto.PartyID,
+	serverInsertTime proto.Time,
 	ch proto.RTChannelID,
 ) (
 	[]byte,
+	*proto.RTMsgCached,
 	error,
 ) {
 	team := rtp.PLCNode().FQParty().Party
 	noncer := proto.RTMsgNoncer{
-		Md:    msg.Md,
+		Md:    md,
 		AppID: appID,
 		Team:  team,
 		Chid:  ch,
 	}
-	if msg.Sender != nil {
-		noncer.Sender = *msg.Sender
+	if sender != nil {
+		noncer.Sender = *sender
 	}
 	nn, err := cookNonce(&noncer)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	typ, err := msg.Mw.GetT()
+	typ, err := mw.GetT()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if typ != proto.MsgBodyType_Encrypted {
-		return nil, core.VersionNotSupportedError("only encrypted message bodies are supported")
+		return nil, nil, core.VersionNotSupportedError("only encrypted message bodies are supported")
 	}
-	box := msg.Mw.Encrypted()
+	box := mw.Encrypted()
 
 	kmgr, err := rtp.keysAtRoleGen(m, appID, box.Rg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var body proto.RTMsgBody
 	err = kmgr.OpenMsgWithNonce(&body, box.Ctext, nn)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	pt, err := body.GetT()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if pt != proto.RTMsgType_Basic {
-		return nil, core.VersionNotSupportedError("only basic messages are supported")
+		return nil, nil, core.VersionNotSupportedError("only basic messages are supported")
 	}
 	basic := body.Basic()
-	return basic.Bytes(), nil
+	cm := proto.RTMsgCached{
+		Md:  noncer,
+		Mw:  mw,
+		Sit: serverInsertTime,
+	}
+	return basic.Bytes(), &cm, nil
 }
 
-// GetThread fetches and decrypts a page of messages from the named channel.
+func merge(
+	left []ThreadMessage,
+	right []ThreadMessage,
+	inc int, // -1 for descending, 1 for ascending
+) []ThreadMessage {
+	ret := make([]ThreadMessage, len(left)+len(right))
+	var i, l, r int
+	for l < len(left) || r < len(right) {
+		if l == len(left) {
+			ret[i] = right[r]
+			r++
+		} else if r == len(right) {
+			ret[i] = left[l]
+			l++
+		} else {
+			leftLess := (left[l].Seq < right[r].Seq)
+			if (leftLess && inc > 0) || (!leftLess && inc < 0) {
+				ret[i] = left[l]
+				l++
+			} else {
+				ret[i] = right[r]
+				r++
+			}
+		}
+		i++
+	}
+	return ret
+
+}
+
+// findHoles returns the seqs missing from v, where v is a run of messages that
+// must be strictly monotonic (sorted, no duplicates) in either direction. A run
+// that isn't strictly monotonic is rejected as bad server data.
+func findHoles(
+	v []ThreadMessage,
+) (
+	[]proto.RTMsgSeq,
+	error,
+) {
+	if len(v) <= 1 {
+		return nil, nil
+	}
+
+	signMatch := func(a, b int) bool {
+		return (a < 0) == (b < 0)
+	}
+
+	start := int(v[0].Seq)
+	end := int(core.Last(v).Seq)
+	inc := 1
+	if end < start {
+		inc = -1
+	}
+
+	// Validate the run is strictly monotonic in `inc`'s direction (and that
+	// every seq is valid) up front, so the hole walk below can trust it. This
+	// catches duplicates (delta 0) and out-of-order seqs.
+	for i, msg := range v {
+		if !msg.Seq.IsValid() {
+			return nil, core.BadServerDataError("msg with invalid seqno")
+		}
+		if i == 0 {
+			continue
+		}
+		d := msg.Seq.Int() - v[i-1].Seq.Int()
+		if d == 0 || !signMatch(inc, d) {
+			return nil, core.BadServerDataError("non-monotonic thread msg sequence")
+		}
+	}
+
+	// Walk start..end inclusive; any index not present in v is a hole. v is
+	// monotonic, so a single forward cursor tracks the next present seq.
+	var ret []proto.RTMsgSeq
+	var ptr int
+	for i := start; i != end; i += inc {
+		if v[ptr].Seq.Int() == i {
+			ptr++
+		} else {
+			ret = append(ret, proto.RTMsgSeq(i))
+		}
+	}
+	return ret, nil
+}
+
+func (d *Minder) initReq(
+	m MetaContext,
+	team *proto.FQTeamParsed,
+	appID proto.RTAppID,
+	channelName proto.RTChannelName,
+	klass *proto.RTChannelClass,
+) (
+	*RTParty,
+	*lcl.RTChannelMetadataPlaintext,
+	*rem.RealTimeClient,
+	error,
+) {
+	if team == nil {
+		return nil, nil, nil, core.InternalError("team is required to read in Stage 1a")
+	}
+	rtp, err := d.base.GetParty(m.Base(), team)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	ch, err := d.resolveChannel(m, rtp, appID, channelName, klass)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	_, cli, err := d.clientLocal(m.Base(), d.au)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return rtp, ch, cli, nil
+}
+
+// if inc > 1, sort ascending
+// if inc < 1, sort descending
+func sortMsgs(v []ThreadMessage, inc int) error {
+	if inc == 0 {
+		return core.InternalError("bad sort direction")
+	}
+	slices.SortFunc(v,
+		func(a, b ThreadMessage) int {
+			return (a.Seq.Int() - b.Seq.Int()) * inc
+		},
+	)
+	return nil
+}
+
+// GetThreadBookened fetches and decrypts a page of messages from the named channel.
 // klass disambiguates when a name exists in more than one class; pass nil when
 // the name is unique.
-func (d *Minder) GetThread(
+//
+// The limits are given by inclusive bookends. The direction is infered from the
+// ordering of the bookends.
+//
+// Here is the overall algorithm:
+//   - fecth from local DB
+//   - fetch from server after the max (or min) message, and plug in any holes
+//   - check that prev pointers align with server sequencing.
+//   - cache any newly downloaded messages
+func (d *Minder) GetThreadBookended(
 	m MetaContext,
 	team *proto.FQTeamParsed,
 	appID proto.RTAppID,
 	channelName proto.RTChannelName,
 	klass *proto.RTChannelClass,
 	start proto.RTMsgSeq,
-	dir proto.RTThreadDir,
-	max uint64,
+	end proto.RTMsgSeq,
 ) (
 	[]ThreadMessage,
 	bool,
@@ -769,32 +984,279 @@ func (d *Minder) GetThread(
 	if team == nil {
 		return nil, false, core.InternalError("team is required to read in Stage 1a")
 	}
-	rtp, err := d.base.GetParty(m.Base(), team)
+	if start == end {
+		return nil, false, core.InternalError("no messages in range")
+	}
+
+	// Direction is implied by the ordering of the bookends; the request is
+	// authoritative. Cached rows come back in this same order (DBRange.Get
+	// orders by start vs end), so cached[0] is the `start` side throughout.
+	inc := 1
+	if end < start {
+		inc = -1
+	}
+
+	rtp, ch, cli, err := d.initReq(m, team, appID, channelName, klass)
 	if err != nil {
 		return nil, false, err
 	}
-	ch, err := d.resolveChannel(m, rtp, appID, channelName, klass)
+
+	cachedMsgsEnc, err := dbGetMsgs(
+		m, d.au,
+		ch.Id,
+		start,
+		end,
+	)
 	if err != nil {
 		return nil, false, err
 	}
-	_, cli, err := d.clientLocal(m.Base(), d.au)
+
+	cached, err := d.decodeMsgs(
+		m,
+		rtp,
+		appID,
+		ch.Id,
+		cachedMsgsEnc,
+	)
 	if err != nil {
 		return nil, false, err
 	}
-	page, err := cli.RtGetThread(m.Ctx(), proto.RTThreadQuery{
+	holes, err := findHoles(cached)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var bookends []rem.RTThreadRangeBookends
+	if len(cached) > 0 {
+
+		cachedStart := cached[0].Seq
+		cachedEnd := core.Last(cached).Seq
+
+		// We had everything in cache!
+		if len(holes) == 0 && start == cachedStart && end == cachedEnd {
+			return cached, false, nil
+		}
+
+		if start != cachedStart {
+			bookends = append(bookends,
+				rem.RTThreadRangeBookends{
+					Start: start,
+					End:   proto.RTMsgSeq(int(cachedStart) - inc),
+				},
+			)
+		}
+		if cachedEnd != end {
+			bookends = append(bookends,
+				rem.RTThreadRangeBookends{
+					Start: proto.RTMsgSeq(int(cachedEnd) + inc),
+					End:   end,
+				},
+			)
+		}
+	} else {
+		bookends = []rem.RTThreadRangeBookends{{Start: start, End: end}}
+		cached = []ThreadMessage{}
+	}
+
+	d.serverThreadReads.Add(1)
+	page, err := cli.RtGetThread(m.Ctx(), rem.RTThreadQuery{
 		ChannelID: ch.Id,
-		Start:     start,
-		Dir:       dir,
-		Max:       max,
+		Bookends:  bookends,
+		Seqs:      holes,
 	})
 	if err != nil {
 		return nil, false, err
 	}
-	out := make([]ThreadMessage, 0, len(page.Msgs))
-	for _, msg := range page.Msgs {
-		body, err := d.openMessage(m, rtp, appID, msg, ch.Id)
+
+	ret := cached
+	for _, r := range page.RangeMsgs {
+		tmp, err := d.decodeAndCacheMsgs(m, rtp, appID, ch.Id, r.Lst)
 		if err != nil {
 			return nil, false, err
+		}
+		ret = merge(ret, tmp, inc)
+	}
+
+	tmp, err := d.decodeAndCacheMsgs(m, rtp, appID, ch.Id, page.SeqMsgs)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// we have to sort these messages as they come back randomly from the server.
+	// since we are going to merge them just below
+	err = sortMsgs(tmp, inc)
+	if err != nil {
+		return nil, false, err
+	}
+
+	ret = merge(ret, tmp, inc)
+
+	// "final" means there's nothing more in the paging direction: we failed to
+	// reach the far (`end`) edge, so the thread ran out before it. After the sort
+	// Last(ret) is always the `end` side (smallest seq when descending, largest
+	// when ascending). A short read at the `start` side instead just means
+	// `start` overshot the live head, which isn't final. Empty => nothing in
+	// range, so final.
+	isFinal := len(ret) == 0 ||
+		(inc > 0 && core.Last(ret).Seq < end) ||
+		(inc < 0 && core.Last(ret).Seq > end)
+
+	return ret, isFinal, nil
+}
+
+// Get the num most recent messages that we don't already have.
+func (d *Minder) GetThreadRecentMsgs(
+	m MetaContext,
+	team *proto.FQTeamParsed,
+	appID proto.RTAppID,
+	channelName proto.RTChannelName,
+	klass *proto.RTChannelClass,
+	num uint,
+) (
+	[]ThreadMessage,
+	error,
+) {
+	if num == 0 {
+		num = 128
+	}
+	inc := -1
+	rtp, ch, cli, err := d.initReq(m, team, appID, channelName, klass)
+	if err != nil {
+		return nil, err
+	}
+
+	cachedMsgsEnc, err := dbGetRecentMsgs(
+		m,
+		d.au,
+		ch.Id,
+		num,
+	)
+	if err != nil {
+		return nil, err
+	}
+	cached, err := d.decodeMsgs(
+		m,
+		rtp,
+		appID,
+		ch.Id,
+		cachedMsgsEnc,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var stopAt proto.RTMsgSeq
+	if len(cached) > 0 {
+		stopAt = cached[0].Seq
+	}
+	d.serverRecentReads.Add(1)
+	fresh, err := cli.RtGetThreadRecents(
+		m.Ctx(),
+		rem.RtGetThreadRecentsArg{
+			Ch:     ch.Id,
+			StopAt: stopAt,
+			Lim:    uint64(num),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	freshPlain, err := d.decodeAndCacheMsgs(m, rtp, appID, ch.Id, fresh.Lst)
+	if err != nil {
+		return nil, err
+	}
+
+	// All of the fresh messages fill up the window, so can just return here.
+	if len(freshPlain) >= int(num) {
+		return freshPlain, nil
+	}
+
+	// in order, but with holes
+	combined := append(freshPlain, cached...)
+	holes, err := findHoles(combined)
+	if err != nil {
+		return nil, err
+	}
+	if len(holes) == 0 {
+		end := min(int(num), len(combined))
+		return combined[0:end], nil
+	}
+
+	d.serverThreadReads.Add(1)
+	fillers, err := cli.RtGetThread(
+		m.Ctx(),
+		rem.RTThreadQuery{
+			ChannelID: ch.Id,
+			Seqs:      holes,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	fillerPlain, err := d.decodeAndCacheMsgs(m, rtp, appID, ch.Id, fillers.SeqMsgs)
+	if err != nil {
+		return nil, err
+	}
+	// we have to sort these messages as they come back randomly from the server.
+	// since we are going to merge them just below
+	err = sortMsgs(fillerPlain, inc)
+	if err != nil {
+		return nil, err
+	}
+	ret := merge(combined, fillerPlain, inc)
+	// Trim to the requested window, matching the no-holes path above.
+	end := min(int(num), len(ret))
+	return ret[0:end], nil
+}
+
+func (d *Minder) decodeMsgs(
+	m MetaContext,
+	rtp *RTParty,
+	appID proto.RTAppID,
+	chid proto.RTChannelID,
+	msgs []lib.RTMsgCachedWithSeq,
+) (
+	[]ThreadMessage,
+	error,
+) {
+	out := make([]ThreadMessage, 0, len(msgs))
+	for _, msg := range msgs {
+		body, cm, err := d.openMessage(m, rtp, appID,
+			msg.Cm.Md.Md, msg.Cm.Mw, &msg.Cm.Md.Sender, msg.Cm.Sit, chid)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ThreadMessage{
+			Seq:                      msg.Seq,
+			Typ:                      cm.Md.Md.Typ,
+			Sender:                   &cm.Md.Sender,
+			SenderFurtherAttribution: cm.Md.Md.FurtherUserAttribution,
+			SentAtTime:               cm.Md.Md.SendTime,
+			InsertTime:               cm.Sit,
+			Body:                     body,
+		})
+	}
+	return out, nil
+}
+
+// decodeAndCacheMsgs decrypts each server message into a ThreadMessage for the
+// caller and writes the decrypted bodies into the local cache. Shared by
+// GetThread (paged range) and GetMsgs (arbitrary set of seqs).
+func (d *Minder) decodeAndCacheMsgs(
+	m MetaContext,
+	rtp *RTParty,
+	appID proto.RTAppID,
+	chid proto.RTChannelID,
+	msgs []rem.RTMsg,
+) (
+	[]ThreadMessage,
+	error,
+) {
+	out := make([]ThreadMessage, 0, len(msgs))
+	cachePuts := make([]proto.RTMsgCachedWithSeq, 0, len(msgs))
+	for _, msg := range msgs {
+		body, cm, err := d.openMessageWithRTMsg(m, rtp, appID, msg, chid)
+		if err != nil {
+			return nil, err
 		}
 		out = append(out, ThreadMessage{
 			Seq:                      msg.Seq,
@@ -805,6 +1267,58 @@ func (d *Minder) GetThread(
 			InsertTime:               msg.InsertTime,
 			Body:                     body,
 		})
+		cachePuts = append(cachePuts, proto.RTMsgCachedWithSeq{
+			Cm:  *cm,
+			Seq: msg.Seq,
+		})
 	}
-	return out, page.Final, nil
+	err := dbPutMsgs(m, d.au, cachePuts)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetMsgs fetches and decrypts an arbitrary set of messages from the named
+// channel by seq. Used to fill holes between locally-cached messages and a
+// paged GetThread fetch. Only messages that exist server-side are returned
+// (each carries its own Seq); requested seqs with no message are omitted, so
+// the result may be shorter than `seqs` and in unspecified order. klass
+// disambiguates when a name exists in more than one class; pass nil when the
+// name is unique.
+func (d *Minder) GetMsgs(
+	m MetaContext,
+	team *proto.FQTeamParsed,
+	appID proto.RTAppID,
+	channelName proto.RTChannelName,
+	klass *proto.RTChannelClass,
+	seqs []proto.RTMsgSeq,
+) (
+	[]ThreadMessage,
+	error,
+) {
+	if team == nil {
+		return nil, core.InternalError("team is required to read in Stage 1a")
+	}
+	rtp, err := d.base.GetParty(m.Base(), team)
+	if err != nil {
+		return nil, err
+	}
+	ch, err := d.resolveChannel(m, rtp, appID, channelName, klass)
+	if err != nil {
+		return nil, err
+	}
+	_, cli, err := d.clientLocal(m.Base(), d.au)
+	if err != nil {
+		return nil, err
+	}
+	d.serverThreadReads.Add(1)
+	page, err := cli.RtGetThread(m.Ctx(), rem.RTThreadQuery{
+		ChannelID: ch.Id,
+		Seqs:      seqs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return d.decodeAndCacheMsgs(m, rtp, appID, ch.Id, page.SeqMsgs)
 }

--- a/client/librt/minder_test.go
+++ b/client/librt/minder_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package librt
+
+import (
+	"testing"
+
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/stretchr/testify/require"
+)
+
+// threadMsgsFromSeqs builds a thread run carrying only seqs, which is all
+// findHoles inspects.
+func threadMsgsFromSeqs(seqs ...int) []ThreadMessage {
+	out := make([]ThreadMessage, len(seqs))
+	for i, s := range seqs {
+		out[i] = ThreadMessage{Seq: proto.RTMsgSeq(s)}
+	}
+	return out
+}
+
+func seqList(seqs ...int) []proto.RTMsgSeq {
+	out := make([]proto.RTMsgSeq, len(seqs))
+	for i, s := range seqs {
+		out[i] = proto.RTMsgSeq(s)
+	}
+	return out
+}
+
+func TestFindHoles(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    []ThreadMessage
+		holes []proto.RTMsgSeq
+		err   bool
+	}{
+		// Degenerate runs: nothing to find, never an error.
+		{name: "empty", in: nil},
+		{name: "single", in: threadMsgsFromSeqs(5)},
+
+		// Contiguous runs in both directions => no holes.
+		{name: "two_adjacent_asc", in: threadMsgsFromSeqs(5, 6)},
+		{name: "two_adjacent_desc", in: threadMsgsFromSeqs(6, 5)},
+		{name: "no_holes_asc", in: threadMsgsFromSeqs(5, 6, 7, 8)},
+		{name: "no_holes_desc", in: threadMsgsFromSeqs(8, 7, 6, 5)},
+
+		// Single hole, both directions. The desc case is the one the old
+		// implementation wrongly rejected as non-monotonic.
+		{name: "single_hole_asc", in: threadMsgsFromSeqs(6, 7, 9, 10), holes: seqList(8)},
+		{name: "single_hole_desc", in: threadMsgsFromSeqs(10, 9, 7, 6), holes: seqList(8)},
+
+		// Wide gaps spanning several missing seqs.
+		{name: "wide_gap_asc", in: threadMsgsFromSeqs(6, 10), holes: seqList(7, 8, 9)},
+		{name: "wide_gap_desc", in: threadMsgsFromSeqs(10, 6), holes: seqList(9, 8, 7)},
+
+		// Several disjoint holes; order of holes follows the run direction.
+		{name: "multiple_holes_asc", in: threadMsgsFromSeqs(5, 7, 8, 10), holes: seqList(6, 9)},
+		{name: "multiple_holes_desc", in: threadMsgsFromSeqs(10, 8, 7, 5), holes: seqList(9, 6)},
+
+		// Holes adjacent to the run's endpoints.
+		{name: "hole_after_start_desc", in: threadMsgsFromSeqs(11, 9, 8), holes: seqList(10)},
+		{name: "hole_before_end_asc", in: threadMsgsFromSeqs(5, 6, 8), holes: seqList(7)},
+
+		// Bad server data: out of order, or not strictly monotonic.
+		{name: "out_of_order", in: threadMsgsFromSeqs(10, 8, 9, 6), err: true},
+		{name: "duplicate_adjacent", in: threadMsgsFromSeqs(10, 10, 9), err: true},
+		{name: "duplicate_non_adjacent", in: threadMsgsFromSeqs(10, 9, 9, 8), err: true},
+
+		// Invalid (zero) seqs are rejected wherever they appear.
+		{name: "invalid_zero_seq_middle", in: threadMsgsFromSeqs(10, 0, 8), err: true},
+		{name: "invalid_zero_seq_first", in: threadMsgsFromSeqs(0, 8), err: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			holes, err := findHoles(tc.in)
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.holes, holes)
+		})
+	}
+}
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		name        string
+		left, right []int
+		inc         int
+		want        []int
+	}{
+		// Degenerate inputs.
+		{name: "both_empty", inc: 1},
+		{name: "left_empty_asc", right: []int{1, 2, 3}, inc: 1, want: []int{1, 2, 3}},
+		{name: "right_empty_asc", left: []int{1, 2, 3}, inc: 1, want: []int{1, 2, 3}},
+		{name: "left_empty_desc", right: []int{3, 2, 1}, inc: -1, want: []int{3, 2, 1}},
+		{name: "right_empty_desc", left: []int{3, 2, 1}, inc: -1, want: []int{3, 2, 1}},
+
+		// One element on each side.
+		{name: "single_each_asc", left: []int{1}, right: []int{2}, inc: 1, want: []int{1, 2}},
+		{name: "single_each_desc", left: []int{2}, right: []int{1}, inc: -1, want: []int{2, 1}},
+
+		// Fully interleaved, both directions.
+		{name: "interleave_asc", left: []int{1, 3, 5}, right: []int{2, 4, 6}, inc: 1, want: []int{1, 2, 3, 4, 5, 6}},
+		{name: "interleave_desc", left: []int{6, 4, 2}, right: []int{5, 3, 1}, inc: -1, want: []int{6, 5, 4, 3, 2, 1}},
+
+		// Disjoint ranges -- result is the same regardless of which side is lower.
+		{name: "disjoint_left_low_asc", left: []int{1, 2}, right: []int{3, 4}, inc: 1, want: []int{1, 2, 3, 4}},
+		{name: "disjoint_left_high_asc", left: []int{3, 4}, right: []int{1, 2}, inc: 1, want: []int{1, 2, 3, 4}},
+		{name: "disjoint_desc", left: []int{4, 3}, right: []int{2, 1}, inc: -1, want: []int{4, 3, 2, 1}},
+
+		// Uneven lengths: one side drains after the other is exhausted.
+		{name: "uneven_lengths_asc", left: []int{1, 5}, right: []int{2, 3, 4, 6, 7}, inc: 1, want: []int{1, 2, 3, 4, 5, 6, 7}},
+
+		// merge does not dedup: equal seqs from both sides are both kept.
+		{name: "duplicates_kept_asc", left: []int{1, 2}, right: []int{2, 3}, inc: 1, want: []int{1, 2, 2, 3}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := merge(threadMsgsFromSeqs(tc.left...), threadMsgsFromSeqs(tc.right...), tc.inc)
+			require.Equal(t, threadMsgsFromSeqs(tc.want...), got)
+			// No dedup: total length is always the sum of inputs.
+			require.Len(t, got, len(tc.left)+len(tc.right))
+		})
+	}
+}
+
+// TestMergeCopiesPayload checks that merge carries the whole message (not just
+// the Seq it keys on) into the result, in the right interleaved positions.
+func TestMergeCopiesPayload(t *testing.T) {
+	mk := func(seq int, body string) ThreadMessage {
+		return ThreadMessage{Seq: proto.RTMsgSeq(seq), Body: []byte(body)}
+	}
+	left := []ThreadMessage{mk(1, "one"), mk(3, "three")}
+	right := []ThreadMessage{mk(2, "two"), mk(4, "four")}
+	want := []ThreadMessage{mk(1, "one"), mk(2, "two"), mk(3, "three"), mk(4, "four")}
+	require.Equal(t, want, merge(left, right, 1))
+}

--- a/client/sql/soft.sql
+++ b/client/sql/soft.sql
@@ -47,4 +47,32 @@ CREATE TABLE IF NOT EXISTS scoped_counters (
 
 CREATE INDEX IF NOT EXISTS scoped_data_ctime_idx ON scoped_data(ctime);
 
+/*
+ * We can select a number of rows in a selected numerical range,
+ * using the same other key components as above.
+ */
+CREATE TABLE IF NOT EXISTS ranged_data (
+    scope_id INTEGER NOT NULL,
+    typ INTEGER NOT NULL,
+    key BLOB NOT NULL,
+    idx INTEGER NOT NULL,
+    val BLOB, 
+    ctime INTEGER NOT NULL,
+    mtime INTEGER NOT NULL,
+    PRIMARY KEY(scope_id, typ, key, idx),
+    FOREIGN KEY(scope_id) REFERENCES scope(id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS ranged_data_gc_bit (
+    scope_id INTEGER NOT NULL,
+    typ INTEGER NOT NULL,
+    key BLOB NOT NULL,
+    gc_bit INTEGER NOT NULL DEFAULT 0,
+    ctime INTEGER NOT NULL,
+    mtime INTEGER NOT NULL,
+    PRIMARY KEY(scope_id, typ, key),
+    FOREIGN KEY(scope_id) REFERENCES scope(id)
+) STRICT;
+
+
 INSERT OR IGNORE INTO scope (id, label) VALUES (0, X'00')

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -191,11 +191,12 @@ func TestRTMinderSendAndGetThread(t *testing.T) {
 		lastSeq = res.Seq
 	}
 
-	// Read them all back; they should decrypt and come in seq order.
-	msgs, final, err := minder.GetThread(mb, fqt, proto.RTAppID_Chat, "foo",
-		nil, 0, proto.RTThreadDir_Forward, 0)
+	// Read them all back; they should decrypt and come in seq order. We reached
+	// the far edge (end == lastSeq) exactly, so this is not a "final" short read.
+	msgs, final, err := minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat, "foo",
+		nil, 1, lastSeq)
 	require.NoError(t, err)
-	require.True(t, final)
+	require.False(t, final)
 	require.Len(t, msgs, len(bodies))
 	for i, b := range bodies {
 		require.Equal(t, proto.RTMsgSeq(i+1), msgs[i].Seq)
@@ -205,11 +206,12 @@ func TestRTMinderSendAndGetThread(t *testing.T) {
 		require.Equal(t, bluey.uid.ToPartyID(), *msgs[i].Sender)
 	}
 
-	// Reading from a later seq should yield only the tail.
-	msgs, final, err = minder.GetThread(mb, fqt, proto.RTAppID_Chat, "foo",
-		nil, 2, proto.RTThreadDir_Forward, 0)
+	// Reading a later sub-range should yield only the tail (served from cache,
+	// since the read above populated it).
+	msgs, final, err = minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat, "foo",
+		nil, 2, lastSeq)
 	require.NoError(t, err)
-	require.True(t, final)
+	require.False(t, final)
 	require.Len(t, msgs, 2)
 	require.Equal(t, proto.RTMsgSeq(2), msgs[0].Seq)
 	require.Equal(t, "second message", string(msgs[0].Body))
@@ -217,6 +219,192 @@ func TestRTMinderSendAndGetThread(t *testing.T) {
 	// Sending to a non-existent channel fails.
 	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat, "nosuchchannel", nil, []byte("hi"))
 	require.Error(t, err)
+}
+
+// TestRTMinderGetMsgsBySeq exercises rtGetMsgs: fetching an arbitrary,
+// non-contiguous set of messages by seq, the way a client fills holes between
+// its local cache and a paged fetch. Seqs that don't exist are silently
+// dropped, so the result is found-only and not necessarily in request order.
+func TestRTMinderGetMsgsBySeq(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+	tm := tew.makeTeamForOwner(t, bluey)
+
+	mb := librt.NewMetaContext(tew.NewClientMetaContextWithEracer(t, bluey))
+	minder := librt.NewMinder(mb.G().ActiveUser())
+	fqt := tm.ToFQTeamParsed(t)
+
+	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "foo", "the foo channel", proto.RolePairOpt{})
+	require.NoError(t, err)
+
+	bodies := []string{"one", "two", "three", "four", "five"}
+	for _, b := range bodies {
+		_, err := minder.Send(mb, fqt, proto.RTAppID_Chat, "foo", nil, []byte(b))
+		require.NoError(t, err)
+	}
+
+	// Ask for a non-contiguous subset (2 and 4) plus a seq that doesn't exist
+	// (99). We should get exactly seqs 2 and 4 back, each decrypting correctly;
+	// the missing seq is simply absent.
+	msgs, err := minder.GetMsgs(mb, fqt, proto.RTAppID_Chat, "foo", nil,
+		[]proto.RTMsgSeq{2, 4, 99})
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	bySeq := make(map[proto.RTMsgSeq]string, len(msgs))
+	for _, msg := range msgs {
+		require.Equal(t, proto.RTMsgType_Basic, msg.Typ)
+		require.NotNil(t, msg.Sender)
+		require.Equal(t, bluey.uid.ToPartyID(), *msg.Sender)
+		bySeq[msg.Seq] = string(msg.Body)
+	}
+	require.Equal(t, "two", bySeq[2])
+	require.Equal(t, "four", bySeq[4])
+
+	// An empty request yields nothing, not an error.
+	msgs, err = minder.GetMsgs(mb, fqt, proto.RTAppID_Chat, "foo", nil, nil)
+	require.NoError(t, err)
+	require.Len(t, msgs, 0)
+
+	// Requesting only missing seqs yields an empty result.
+	msgs, err = minder.GetMsgs(mb, fqt, proto.RTAppID_Chat, "foo", nil,
+		[]proto.RTMsgSeq{100, 101})
+	require.NoError(t, err)
+	require.Len(t, msgs, 0)
+}
+
+// TestRTMinderGetThreadBookendedHoleFilling exercises the partial-cache path of
+// GetThreadBookended: the local cache holds a sparse, non-contiguous subset, so
+// a bookended read must fetch the leading range, the trailing range, and the
+// interior hole(s) from the server and merge them back with the cached run into
+// one ordered thread. The empty-cache and full-cache-hit branches are covered
+// too (first vs. second read). Both paging directions are checked, since the
+// merge / bookend / sort math differs by direction.
+func TestRTMinderGetThreadBookendedHoleFilling(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t) // sender / team owner
+	coco := tew.NewTestUser(t)  // receiver / ordinary member
+	tew.DirectDoubleMerklePokeInTest(t)
+	tm := tew.makeTeamForOwner(t, bluey)
+	tm.makeChanges(
+		t, tew.MetaContext(), bluey,
+		[]proto.MemberRole{coco.toMemberRole(t, proto.DefaultRole, tm.hepks)}, nil,
+	)
+
+	mb := librt.NewMetaContext(tew.NewClientMetaContextWithEracer(t, bluey))
+	sender := librt.NewMinder(mb.G().ActiveUser())
+	mc := librt.NewMetaContext(tew.NewClientMetaContextWithEracer(t, coco))
+	receiver := librt.NewMinder(mc.G().ActiveUser())
+	fqt := tm.ToFQTeamParsed(t)
+
+	const n = 7
+
+	// setup: bluey creates a member-readable channel and sends n messages (seqs
+	// 1..n). coco is a *separate* client with her own local cache; she primes it
+	// with a non-contiguous subset {3,5}, leaving an interior hole at 4 and
+	// nothing cached outside [3,5]. Because the sender and receiver are different
+	// users, any sender-side caching never touches coco's cache, so the holes the
+	// bookended read must fill are exactly the ones set up here.
+	setup := func(ch proto.RTChannelName) {
+		_, err := sender.MakeChannel(mb, fqt, proto.RTAppID_Chat, ch, "hole-filling",
+			proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.DefaultRole})
+		require.NoError(t, err)
+		for i := 1; i <= n; i++ {
+			res, err := sender.Send(mb, fqt, proto.RTAppID_Chat, ch, nil, []byte(fmt.Sprintf("msg-%d", i)))
+			require.NoError(t, err)
+			require.Equal(t, proto.RTMsgSeq(i), res.Seq)
+		}
+		primed, err := receiver.GetMsgs(mc, fqt, proto.RTAppID_Chat, ch, nil,
+			[]proto.RTMsgSeq{3, 5})
+		require.NoError(t, err)
+		require.Len(t, primed, 2)
+	}
+
+	check := func(t *testing.T, msgs []librt.ThreadMessage, wantSeqs ...int) {
+		require.Len(t, msgs, len(wantSeqs))
+		for i, s := range wantSeqs {
+			require.Equal(t, proto.RTMsgSeq(s), msgs[i].Seq)
+			require.Equal(t, fmt.Sprintf("msg-%d", s), string(msgs[i].Body))
+		}
+	}
+
+	t.Run("ascending", func(t *testing.T) {
+		setup("asc")
+
+		// coco's cache holds {3,5}. The server must supply leading [1,2], trailing
+		// [6,7], and the hole at 4; all of it merges into one ascending run.
+		msgs, final, err := receiver.GetThreadBookended(mc, fqt, proto.RTAppID_Chat, "asc",
+			nil, 1, n)
+		require.NoError(t, err)
+		require.False(t, final) // reached end (== n) exactly
+		check(t, msgs, 1, 2, 3, 4, 5, 6, 7)
+
+		// The read above cached everything, so the second read is a pure cache
+		// hit (no holes, no bookends).
+		msgs, _, err = receiver.GetThreadBookended(mc, fqt, proto.RTAppID_Chat, "asc",
+			nil, 1, n)
+		require.NoError(t, err)
+		check(t, msgs, 1, 2, 3, 4, 5, 6, 7)
+	})
+
+	t.Run("descending", func(t *testing.T) {
+		setup("desc")
+
+		// Same sparse cache {3,5}, but walk 7..1: leading bookend [7,6], trailing
+		// [2,1], hole 4, merged newest-first.
+		msgs, final, err := receiver.GetThreadBookended(mc, fqt, proto.RTAppID_Chat, "desc",
+			nil, n, 1)
+		require.NoError(t, err)
+		require.False(t, final) // reached end (== 1) exactly
+		check(t, msgs, 7, 6, 5, 4, 3, 2, 1)
+	})
+}
+
+// TestRTMinderSenderReadsAreCacheHits confirms that because Send populates the
+// sender's own read cache, the sender reading back exactly what it just sent is
+// served entirely from cache -- no server round-trip. It uses the Minder's
+// instrumentation counters to assert that (and a contrast read past the cached
+// range to prove the counter actually tracks round-trips).
+func TestRTMinderSenderReadsAreCacheHits(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+	tm := tew.makeTeamForOwner(t, bluey)
+
+	mb := librt.NewMetaContext(tew.NewClientMetaContextWithEracer(t, bluey))
+	minder := librt.NewMinder(mb.G().ActiveUser())
+	fqt := tm.ToFQTeamParsed(t)
+
+	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "foo", "sender cache", proto.RolePairOpt{})
+	require.NoError(t, err)
+
+	const n = 5
+	for i := 1; i <= n; i++ {
+		res, err := minder.Send(mb, fqt, proto.RTAppID_Chat, "foo", nil, []byte(fmt.Sprintf("msg-%d", i)))
+		require.NoError(t, err)
+		require.Equal(t, proto.RTMsgSeq(i), res.Seq)
+	}
+
+	// Reading back the full range it just sent is a pure cache hit.
+	before := minder.Metrics()
+	msgs, final, err := minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat, "foo", nil, 1, n)
+	require.NoError(t, err)
+	require.False(t, final)
+	require.Len(t, msgs, n)
+	for i := 0; i < n; i++ {
+		require.Equal(t, proto.RTMsgSeq(i+1), msgs[i].Seq)
+		require.Equal(t, fmt.Sprintf("msg-%d", i+1), string(msgs[i].Body))
+	}
+	require.Equal(t, before.ServerThreadReads, minder.Metrics().ServerThreadReads,
+		"fully-cached read must not issue a server RtGetThread")
+
+	// Contrast: asking past the cached range forces a (trailing) server fetch, so
+	// the counter must advance by exactly one -- proving it tracks round-trips.
+	before = minder.Metrics()
+	_, _, err = minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat, "foo", nil, 1, n+1)
+	require.NoError(t, err)
+	require.Equal(t, before.ServerThreadReads+1, minder.Metrics().ServerThreadReads,
+		"a read past the cached range must issue exactly one server RtGetThread")
 }
 
 // TestRTSendReadPermissions exercises the server-side authorization machinery
@@ -279,8 +467,8 @@ func TestRTSendReadPermissions(t *testing.T) {
 	// --- read permission ---
 
 	// coco CAN read the admin-writable (but member-readable) channel.
-	msgs, _, err := minderCoco.GetThread(mc, fqt, proto.RTAppID_Chat, "announce",
-		nil, 0, proto.RTThreadDir_Forward, 0)
+	msgs, err := minderCoco.GetThreadRecentMsgs(mc, fqt, proto.RTAppID_Chat, "announce",
+		nil, 0)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	require.Equal(t, "official notice", string(msgs[0].Body))
@@ -293,8 +481,8 @@ func TestRTSendReadPermissions(t *testing.T) {
 	}
 
 	// ...and reading its thread fails: she can't resolve a channel she can't see.
-	_, _, err = minderCoco.GetThread(mc, fqt, proto.RTAppID_Chat, "brass",
-		nil, 0, proto.RTThreadDir_Forward, 0)
+	_, err = minderCoco.GetThreadRecentMsgs(mc, fqt, proto.RTAppID_Chat, "brass",
+		nil, 0)
 	require.Equal(t, core.RTNotFoundError("channel 'brass'"), err)
 }
 
@@ -328,8 +516,8 @@ func TestRTSendEncryptionRole(t *testing.T) {
 	require.Equal(t, core.BadArgsError("message must be encrypted at the channel's read role"), err)
 
 	// The rejected message was not persisted: only the one good message remains.
-	msgs, _, err := minder.GetThread(mb, fqt, proto.RTAppID_Chat, "general",
-		nil, 0, proto.RTThreadDir_Forward, 0)
+	msgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, "general",
+		nil, 0)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	require.Equal(t, "hi", string(msgs[0].Body))
@@ -362,8 +550,7 @@ func TestRTChannelDisambiguation(t *testing.T) {
 	// Addressing by name alone can't choose between them.
 	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat, "general", nil, []byte("hi"))
 	require.Equal(t, core.RTAmbiguousChannelError{Name: "general"}, err)
-	_, _, err = minder.GetThread(mb, fqt, proto.RTAppID_Chat, "general", nil,
-		0, proto.RTThreadDir_Forward, 0)
+	_, err = minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, "general", nil, 0)
 	require.Equal(t, core.RTAmbiguousChannelError{Name: "general"}, err)
 
 	// A class disambiguates, and each channel keeps its own thread.
@@ -372,14 +559,12 @@ func TestRTChannelDisambiguation(t *testing.T) {
 	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat, "general", &bottom, []byte("bottom msg"))
 	require.NoError(t, err)
 
-	adminMsgs, _, err := minder.GetThread(mb, fqt, proto.RTAppID_Chat, "general", &admin,
-		0, proto.RTThreadDir_Forward, 0)
+	adminMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, "general", &admin, 0)
 	require.NoError(t, err)
 	require.Len(t, adminMsgs, 1)
 	require.Equal(t, "admin msg", string(adminMsgs[0].Body))
 
-	bottomMsgs, _, err := minder.GetThread(mb, fqt, proto.RTAppID_Chat, "general", &bottom,
-		0, proto.RTThreadDir_Forward, 0)
+	bottomMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, "general", &bottom, 0)
 	require.NoError(t, err)
 	require.Len(t, bottomMsgs, 1)
 	require.Equal(t, "bottom msg", string(bottomMsgs[0].Body))

--- a/proto-src/lcl/db.snowp
+++ b/proto-src/lcl/db.snowp
@@ -33,6 +33,9 @@ enum DataType {
     KVNSName @71;
     KVSymlink @72;
     KVGitRefSet @73;
+
+    RTThreadMsgData @97;
+    RTOutboxMsg @98;
 }
 
 typedef ScopeLabel = Blob;

--- a/proto-src/lib/realtime.snowp
+++ b/proto-src/lib/realtime.snowp
@@ -169,17 +169,23 @@ enum RTThreadDir {
     Backward @1;  // decreasing seq (newer -> older)
 }
 
-struct RTThreadQuery {
-    channelID @0 : RTChannelID;
-    start @1 : RTMsgSeq;         // inclusive; 0 = from start (forward) or head (backward)
-    dir @2 : RTThreadDir;
-    max @3 : Uint;               // max messages this page; server may return fewer
-}
-
 // Subscribe long-poll: server returns when inbox advances past `since` OR the
 // timeout elapses. Cheap stand-in for true server-push until Stage 2c wires up
 // Redis pub/sub and a callback protocol.
 struct RTInboxPollRes {
     bumped @0 : Bool;                  // false if returned due to timeout
     inboxVersion @1 : RTInboxVersion;  // current head (== since if !bumped)
+}
+
+// RTMsgCached does know what its sequence is, but we index by seqno,
+// so we don't need to store it here.
+struct RTMsgCached {
+    md @0 : RTMsgNoncer;
+    mw @1 : RTMsgWrapper;
+    sit @2 : Time; // server-insert-time 
+}
+
+struct RTMsgCachedWithSeq {
+    cm @0 : RTMsgCached;
+    seq @1 : RTMsgSeq; // server-assigned sequence number
 }

--- a/proto-src/rem/realtime.snowp
+++ b/proto-src/rem/realtime.snowp
@@ -106,11 +106,32 @@ struct RTInboxDelta {
     channels @2 : List(RTInboxChannel);
 }
 
+// Contiguous-range portion of a thread query. Direction is implied.
+struct RTThreadRangeBookends {
+    start @0 : lib.RTMsgSeq;         // inclusive; cannot be 0
+    end @1 : lib.RTMsgSeq;           // inclusive; cannot be 0
+}
+
+struct RTThreadQuery {
+    channelID @0 : lib.RTChannelID;
+    bookends @1 : List(RTThreadRangeBookends);  // nil = skip the range query
+    seqs @2 : List(lib.RTMsgSeq);               // empty = skip the seq query
+}
+
+// Sequential set of messages
+struct RTMsgList {
+    lst @0 : List(RTMsg);
+}
+
 struct RTThreadPage {
-    msgs @0 : List(RTMsg);
-    // True if this page reaches the natural endpoint of the requested range.
-    // Client paginates by re-requesting from msgs[last].seq+1 (or -1).
-    final @1 : Bool;
+    // Result of the range query; empty if no range was requested. The client
+    // paginates by re-requesting from rangeMsgs[last].seq+1 (or -1).
+    // We can ask for one or more ranges, hence List of Lists.
+    rangeMsgs @0 : List(RTMsgList);
+    // Result of the seq query: found-only, in no particular order, each carrying
+    // its own seq so the caller can slot it back into the right hole. Seqs with
+    // no matching message are simply absent. Empty if no seqs were requested.
+    seqMsgs @1 : List(RTMsg);
 }
 
 protocol RealTime
@@ -149,7 +170,7 @@ protocol RealTime
 
     // Fetch a page of messages from a channel. User auth only.
     rtGetThread @4 (
-        q @0 : lib.RTThreadQuery
+        q @0 : RTThreadQuery
     ) -> RTThreadPage;
 
     // Get the current inbox head for this user+app (cheap no-op sync).
@@ -177,5 +198,14 @@ protocol RealTime
     rtSelectVHost @9 (
         host @0 : lib.HostID
     ) : RTSelectVhost;
+
+    // Get all the recent messages, starting with most recent, and stopping
+    // at stopAt (which can be 0). Only give back lim messages at most.
+    // Will be sent back in descending order.
+    rtGetThreadRecents @10 (
+        ch @0 : lib.RTChannelID,
+        stopAt @1 : lib.RTMsgSeq,
+        lim @2 : Uint
+    ) -> RTMsgList;
 
 }

--- a/proto/lcl/db.go
+++ b/proto/lcl/db.go
@@ -73,6 +73,8 @@ const (
 	DataType_KVNSName             DataType = 71
 	DataType_KVSymlink            DataType = 72
 	DataType_KVGitRefSet          DataType = 73
+	DataType_RTThreadMsgData      DataType = 97
+	DataType_RTOutboxMsg          DataType = 98
 )
 
 var DataTypeMap = map[string]DataType{
@@ -100,6 +102,8 @@ var DataTypeMap = map[string]DataType{
 	"KVNSName":             71,
 	"KVSymlink":            72,
 	"KVGitRefSet":          73,
+	"RTThreadMsgData":      97,
+	"RTOutboxMsg":          98,
 }
 var DataTypeRevMap = map[DataType]string{
 	0:  "None",
@@ -126,6 +130,8 @@ var DataTypeRevMap = map[DataType]string{
 	71: "KVNSName",
 	72: "KVSymlink",
 	73: "KVGitRefSet",
+	97: "RTThreadMsgData",
+	98: "RTOutboxMsg",
 }
 
 type DataTypeInternal__ DataType

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -721,6 +721,10 @@ func (t Time) ToSecondsFloat() float64 {
 	return float64(t) / 1000.0
 }
 
+func (t Time) ToInt64() int64 {
+	return int64(t)
+}
+
 func Today() Date {
 	n := time.Now()
 	return Date{
@@ -5240,4 +5244,45 @@ func (r *RTMsgID) ImportFromBytes(b []byte) error {
 	}
 	copy((*r)[:], b[:])
 	return nil
+}
+
+func (d RTThreadDir) IsAscending() bool {
+	return d == RTThreadDir_Forward
+}
+
+func (d RTThreadDir) Inc() int {
+	ret := 1
+	if d == RTThreadDir_Backward {
+		ret = -1
+	}
+	return ret
+}
+
+func (d RTThreadDir) IsOrdered(a, b RTMsgSeq) bool {
+	switch d {
+	case RTThreadDir_Forward:
+		return a < b
+	case RTThreadDir_Backward:
+		return a > b
+	default:
+		return false
+	}
+}
+
+func (r RTMsgSeq) Int() int {
+	return int(r)
+}
+
+func (d RTThreadDir) Jump(start RTMsgSeq, i int) RTMsgSeq {
+	end := int(start) + i*d.Inc()
+	if end < 0 {
+		end = 0
+	}
+	return RTMsgSeq(end)
+}
+
+var RTMsgSeqFirst = RTMsgSeq(1)
+
+func (r RTChannelIDShort) Int64() int64 {
+	return int64(r)
 }

--- a/proto/lib/realtime.go
+++ b/proto/lib/realtime.go
@@ -1649,72 +1649,6 @@ func (r RTThreadDir) Export() *RTThreadDirInternal__ {
 	return ((*RTThreadDirInternal__)(&r))
 }
 
-type RTThreadQuery struct {
-	ChannelID RTChannelID
-	Start     RTMsgSeq
-	Dir       RTThreadDir
-	Max       uint64
-}
-type RTThreadQueryInternal__ struct {
-	_struct   struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
-	ChannelID *RTChannelIDInternal__
-	Start     *RTMsgSeqInternal__
-	Dir       *RTThreadDirInternal__
-	Max       *uint64
-}
-
-func (r RTThreadQueryInternal__) Import() RTThreadQuery {
-	return RTThreadQuery{
-		ChannelID: (func(x *RTChannelIDInternal__) (ret RTChannelID) {
-			if x == nil {
-				return ret
-			}
-			return x.Import()
-		})(r.ChannelID),
-		Start: (func(x *RTMsgSeqInternal__) (ret RTMsgSeq) {
-			if x == nil {
-				return ret
-			}
-			return x.Import()
-		})(r.Start),
-		Dir: (func(x *RTThreadDirInternal__) (ret RTThreadDir) {
-			if x == nil {
-				return ret
-			}
-			return x.Import()
-		})(r.Dir),
-		Max: (func(x *uint64) (ret uint64) {
-			if x == nil {
-				return ret
-			}
-			return *x
-		})(r.Max),
-	}
-}
-func (r RTThreadQuery) Export() *RTThreadQueryInternal__ {
-	return &RTThreadQueryInternal__{
-		ChannelID: r.ChannelID.Export(),
-		Start:     r.Start.Export(),
-		Dir:       r.Dir.Export(),
-		Max:       &r.Max,
-	}
-}
-func (r *RTThreadQuery) Encode(enc rpc.Encoder) error {
-	return enc.Encode(r.Export())
-}
-
-func (r *RTThreadQuery) Decode(dec rpc.Decoder) error {
-	var tmp RTThreadQueryInternal__
-	err := dec.Decode(&tmp)
-	if err != nil {
-		return err
-	}
-	*r = tmp.Import()
-	return nil
-}
-
-func (r *RTThreadQuery) Bytes() []byte { return nil }
-
 type RTInboxPollRes struct {
 	Bumped       bool
 	InboxVersion RTInboxVersion
@@ -1762,6 +1696,111 @@ func (r *RTInboxPollRes) Decode(dec rpc.Decoder) error {
 }
 
 func (r *RTInboxPollRes) Bytes() []byte { return nil }
+
+type RTMsgCached struct {
+	Md  RTMsgNoncer
+	Mw  RTMsgWrapper
+	Sit Time
+}
+type RTMsgCachedInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Md      *RTMsgNoncerInternal__
+	Mw      *RTMsgWrapperInternal__
+	Sit     *TimeInternal__
+}
+
+func (r RTMsgCachedInternal__) Import() RTMsgCached {
+	return RTMsgCached{
+		Md: (func(x *RTMsgNoncerInternal__) (ret RTMsgNoncer) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Md),
+		Mw: (func(x *RTMsgWrapperInternal__) (ret RTMsgWrapper) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Mw),
+		Sit: (func(x *TimeInternal__) (ret Time) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Sit),
+	}
+}
+func (r RTMsgCached) Export() *RTMsgCachedInternal__ {
+	return &RTMsgCachedInternal__{
+		Md:  r.Md.Export(),
+		Mw:  r.Mw.Export(),
+		Sit: r.Sit.Export(),
+	}
+}
+func (r *RTMsgCached) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTMsgCached) Decode(dec rpc.Decoder) error {
+	var tmp RTMsgCachedInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTMsgCached) Bytes() []byte { return nil }
+
+type RTMsgCachedWithSeq struct {
+	Cm  RTMsgCached
+	Seq RTMsgSeq
+}
+type RTMsgCachedWithSeqInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Cm      *RTMsgCachedInternal__
+	Seq     *RTMsgSeqInternal__
+}
+
+func (r RTMsgCachedWithSeqInternal__) Import() RTMsgCachedWithSeq {
+	return RTMsgCachedWithSeq{
+		Cm: (func(x *RTMsgCachedInternal__) (ret RTMsgCached) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Cm),
+		Seq: (func(x *RTMsgSeqInternal__) (ret RTMsgSeq) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Seq),
+	}
+}
+func (r RTMsgCachedWithSeq) Export() *RTMsgCachedWithSeqInternal__ {
+	return &RTMsgCachedWithSeqInternal__{
+		Cm:  r.Cm.Export(),
+		Seq: r.Seq.Export(),
+	}
+}
+func (r *RTMsgCachedWithSeq) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTMsgCachedWithSeq) Decode(dec rpc.Decoder) error {
+	var tmp RTMsgCachedWithSeqInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTMsgCachedWithSeq) Bytes() []byte { return nil }
 
 func init() {
 	rpc.AddUnique(RTKeyDerivationTypeUniqueID)

--- a/proto/rem/realtime.go
+++ b/proto/rem/realtime.go
@@ -911,19 +911,164 @@ func (r *RTInboxDelta) Decode(dec rpc.Decoder) error {
 
 func (r *RTInboxDelta) Bytes() []byte { return nil }
 
-type RTThreadPage struct {
-	Msgs  []RTMsg
-	Final bool
+type RTThreadRangeBookends struct {
+	Start lib.RTMsgSeq
+	End   lib.RTMsgSeq
 }
-type RTThreadPageInternal__ struct {
+type RTThreadRangeBookendsInternal__ struct {
 	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
-	Msgs    *[](*RTMsgInternal__)
-	Final   *bool
+	Start   *lib.RTMsgSeqInternal__
+	End     *lib.RTMsgSeqInternal__
 }
 
-func (r RTThreadPageInternal__) Import() RTThreadPage {
-	return RTThreadPage{
-		Msgs: (func(x *[](*RTMsgInternal__)) (ret []RTMsg) {
+func (r RTThreadRangeBookendsInternal__) Import() RTThreadRangeBookends {
+	return RTThreadRangeBookends{
+		Start: (func(x *lib.RTMsgSeqInternal__) (ret lib.RTMsgSeq) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Start),
+		End: (func(x *lib.RTMsgSeqInternal__) (ret lib.RTMsgSeq) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.End),
+	}
+}
+func (r RTThreadRangeBookends) Export() *RTThreadRangeBookendsInternal__ {
+	return &RTThreadRangeBookendsInternal__{
+		Start: r.Start.Export(),
+		End:   r.End.Export(),
+	}
+}
+func (r *RTThreadRangeBookends) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTThreadRangeBookends) Decode(dec rpc.Decoder) error {
+	var tmp RTThreadRangeBookendsInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTThreadRangeBookends) Bytes() []byte { return nil }
+
+type RTThreadQuery struct {
+	ChannelID lib.RTChannelID
+	Bookends  []RTThreadRangeBookends
+	Seqs      []lib.RTMsgSeq
+}
+type RTThreadQueryInternal__ struct {
+	_struct   struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	ChannelID *lib.RTChannelIDInternal__
+	Bookends  *[](*RTThreadRangeBookendsInternal__)
+	Seqs      *[](*lib.RTMsgSeqInternal__)
+}
+
+func (r RTThreadQueryInternal__) Import() RTThreadQuery {
+	return RTThreadQuery{
+		ChannelID: (func(x *lib.RTChannelIDInternal__) (ret lib.RTChannelID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.ChannelID),
+		Bookends: (func(x *[](*RTThreadRangeBookendsInternal__)) (ret []RTThreadRangeBookends) {
+			if x == nil || len(*x) == 0 {
+				return nil
+			}
+			ret = make([]RTThreadRangeBookends, len(*x))
+			for k, v := range *x {
+				if v == nil {
+					continue
+				}
+				ret[k] = (func(x *RTThreadRangeBookendsInternal__) (ret RTThreadRangeBookends) {
+					if x == nil {
+						return ret
+					}
+					return x.Import()
+				})(v)
+			}
+			return ret
+		})(r.Bookends),
+		Seqs: (func(x *[](*lib.RTMsgSeqInternal__)) (ret []lib.RTMsgSeq) {
+			if x == nil || len(*x) == 0 {
+				return nil
+			}
+			ret = make([]lib.RTMsgSeq, len(*x))
+			for k, v := range *x {
+				if v == nil {
+					continue
+				}
+				ret[k] = (func(x *lib.RTMsgSeqInternal__) (ret lib.RTMsgSeq) {
+					if x == nil {
+						return ret
+					}
+					return x.Import()
+				})(v)
+			}
+			return ret
+		})(r.Seqs),
+	}
+}
+func (r RTThreadQuery) Export() *RTThreadQueryInternal__ {
+	return &RTThreadQueryInternal__{
+		ChannelID: r.ChannelID.Export(),
+		Bookends: (func(x []RTThreadRangeBookends) *[](*RTThreadRangeBookendsInternal__) {
+			if len(x) == 0 {
+				return nil
+			}
+			ret := make([](*RTThreadRangeBookendsInternal__), len(x))
+			for k, v := range x {
+				ret[k] = v.Export()
+			}
+			return &ret
+		})(r.Bookends),
+		Seqs: (func(x []lib.RTMsgSeq) *[](*lib.RTMsgSeqInternal__) {
+			if len(x) == 0 {
+				return nil
+			}
+			ret := make([](*lib.RTMsgSeqInternal__), len(x))
+			for k, v := range x {
+				ret[k] = v.Export()
+			}
+			return &ret
+		})(r.Seqs),
+	}
+}
+func (r *RTThreadQuery) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTThreadQuery) Decode(dec rpc.Decoder) error {
+	var tmp RTThreadQueryInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTThreadQuery) Bytes() []byte { return nil }
+
+type RTMsgList struct {
+	Lst []RTMsg
+}
+type RTMsgListInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Lst     *[](*RTMsgInternal__)
+}
+
+func (r RTMsgListInternal__) Import() RTMsgList {
+	return RTMsgList{
+		Lst: (func(x *[](*RTMsgInternal__)) (ret []RTMsg) {
 			if x == nil || len(*x) == 0 {
 				return nil
 			}
@@ -940,18 +1085,12 @@ func (r RTThreadPageInternal__) Import() RTThreadPage {
 				})(v)
 			}
 			return ret
-		})(r.Msgs),
-		Final: (func(x *bool) (ret bool) {
-			if x == nil {
-				return ret
-			}
-			return *x
-		})(r.Final),
+		})(r.Lst),
 	}
 }
-func (r RTThreadPage) Export() *RTThreadPageInternal__ {
-	return &RTThreadPageInternal__{
-		Msgs: (func(x []RTMsg) *[](*RTMsgInternal__) {
+func (r RTMsgList) Export() *RTMsgListInternal__ {
+	return &RTMsgListInternal__{
+		Lst: (func(x []RTMsg) *[](*RTMsgInternal__) {
 			if len(x) == 0 {
 				return nil
 			}
@@ -960,8 +1099,97 @@ func (r RTThreadPage) Export() *RTThreadPageInternal__ {
 				ret[k] = v.Export()
 			}
 			return &ret
-		})(r.Msgs),
-		Final: &r.Final,
+		})(r.Lst),
+	}
+}
+func (r *RTMsgList) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTMsgList) Decode(dec rpc.Decoder) error {
+	var tmp RTMsgListInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTMsgList) Bytes() []byte { return nil }
+
+type RTThreadPage struct {
+	RangeMsgs []RTMsgList
+	SeqMsgs   []RTMsg
+}
+type RTThreadPageInternal__ struct {
+	_struct   struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	RangeMsgs *[](*RTMsgListInternal__)
+	SeqMsgs   *[](*RTMsgInternal__)
+}
+
+func (r RTThreadPageInternal__) Import() RTThreadPage {
+	return RTThreadPage{
+		RangeMsgs: (func(x *[](*RTMsgListInternal__)) (ret []RTMsgList) {
+			if x == nil || len(*x) == 0 {
+				return nil
+			}
+			ret = make([]RTMsgList, len(*x))
+			for k, v := range *x {
+				if v == nil {
+					continue
+				}
+				ret[k] = (func(x *RTMsgListInternal__) (ret RTMsgList) {
+					if x == nil {
+						return ret
+					}
+					return x.Import()
+				})(v)
+			}
+			return ret
+		})(r.RangeMsgs),
+		SeqMsgs: (func(x *[](*RTMsgInternal__)) (ret []RTMsg) {
+			if x == nil || len(*x) == 0 {
+				return nil
+			}
+			ret = make([]RTMsg, len(*x))
+			for k, v := range *x {
+				if v == nil {
+					continue
+				}
+				ret[k] = (func(x *RTMsgInternal__) (ret RTMsg) {
+					if x == nil {
+						return ret
+					}
+					return x.Import()
+				})(v)
+			}
+			return ret
+		})(r.SeqMsgs),
+	}
+}
+func (r RTThreadPage) Export() *RTThreadPageInternal__ {
+	return &RTThreadPageInternal__{
+		RangeMsgs: (func(x []RTMsgList) *[](*RTMsgListInternal__) {
+			if len(x) == 0 {
+				return nil
+			}
+			ret := make([](*RTMsgListInternal__), len(x))
+			for k, v := range x {
+				ret[k] = v.Export()
+			}
+			return &ret
+		})(r.RangeMsgs),
+		SeqMsgs: (func(x []RTMsg) *[](*RTMsgInternal__) {
+			if len(x) == 0 {
+				return nil
+			}
+			ret := make([](*RTMsgInternal__), len(x))
+			for k, v := range x {
+				ret[k] = v.Export()
+			}
+			return &ret
+		})(r.SeqMsgs),
 	}
 }
 func (r *RTThreadPage) Encode(enc rpc.Encoder) error {
@@ -1157,16 +1385,16 @@ func (r *RtSendArg) Decode(dec rpc.Decoder) error {
 func (r *RtSendArg) Bytes() []byte { return nil }
 
 type RtGetThreadArg struct {
-	Q lib.RTThreadQuery
+	Q RTThreadQuery
 }
 type RtGetThreadArgInternal__ struct {
 	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
-	Q       *lib.RTThreadQueryInternal__
+	Q       *RTThreadQueryInternal__
 }
 
 func (r RtGetThreadArgInternal__) Import() RtGetThreadArg {
 	return RtGetThreadArg{
-		Q: (func(x *lib.RTThreadQueryInternal__) (ret lib.RTThreadQuery) {
+		Q: (func(x *RTThreadQueryInternal__) (ret RTThreadQuery) {
 			if x == nil {
 				return ret
 			}
@@ -1390,17 +1618,75 @@ func (r *RTSelectVhost) Decode(dec rpc.Decoder) error {
 
 func (r *RTSelectVhost) Bytes() []byte { return nil }
 
+type RtGetThreadRecentsArg struct {
+	Ch     lib.RTChannelID
+	StopAt lib.RTMsgSeq
+	Lim    uint64
+}
+type RtGetThreadRecentsArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Ch      *lib.RTChannelIDInternal__
+	StopAt  *lib.RTMsgSeqInternal__
+	Lim     *uint64
+}
+
+func (r RtGetThreadRecentsArgInternal__) Import() RtGetThreadRecentsArg {
+	return RtGetThreadRecentsArg{
+		Ch: (func(x *lib.RTChannelIDInternal__) (ret lib.RTChannelID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Ch),
+		StopAt: (func(x *lib.RTMsgSeqInternal__) (ret lib.RTMsgSeq) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.StopAt),
+		Lim: (func(x *uint64) (ret uint64) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.Lim),
+	}
+}
+func (r RtGetThreadRecentsArg) Export() *RtGetThreadRecentsArgInternal__ {
+	return &RtGetThreadRecentsArgInternal__{
+		Ch:     r.Ch.Export(),
+		StopAt: r.StopAt.Export(),
+		Lim:    &r.Lim,
+	}
+}
+func (r *RtGetThreadRecentsArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RtGetThreadRecentsArg) Decode(dec rpc.Decoder) error {
+	var tmp RtGetThreadRecentsArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RtGetThreadRecentsArg) Bytes() []byte { return nil }
+
 type RealTimeInterface interface {
 	RtNewChannel(context.Context, RtNewChannelArg) error
 	RtGetChannel(context.Context, lib.RTChannelID) (RTChannelMetadata, error)
 	RtListAllChannelsForTeam(context.Context, RtListAllChannelsForTeamArg) (RTChannelSet, error)
 	RtSend(context.Context, RTSendArg) (RTSendRes, error)
-	RtGetThread(context.Context, lib.RTThreadQuery) (RTThreadPage, error)
+	RtGetThread(context.Context, RTThreadQuery) (RTThreadPage, error)
 	RtGetInboxVersion(context.Context, RTInboxKey) (lib.RTInboxVersion, error)
 	RtGetChangedThreads(context.Context, RTGetChangedThreadsArg) (RTInboxDelta, error)
 	RtReadThrough(context.Context, RTReadThroughArg) error
 	RtPollInbox(context.Context, RTPollInboxArg) (lib.RTInboxPollRes, error)
 	RtSelectVHost(context.Context, lib.HostID) error
+	RtGetThreadRecents(context.Context, RtGetThreadRecentsArg) (RTMsgList, error)
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h lib.Header) error
 	MakeResHeader() lib.Header
@@ -1535,7 +1821,7 @@ func (c RealTimeClient) RtSend(ctx context.Context, rtarg RTSendArg) (res RTSend
 	res = tmp.Data.Import()
 	return
 }
-func (c RealTimeClient) RtGetThread(ctx context.Context, q lib.RTThreadQuery) (res RTThreadPage, err error) {
+func (c RealTimeClient) RtGetThread(ctx context.Context, q RTThreadQuery) (res RTThreadPage, err error) {
 	arg := RtGetThreadArg{
 		Q: q,
 	}
@@ -1675,6 +1961,27 @@ func (c RealTimeClient) RtSelectVHost(ctx context.Context, host lib.HostID) (err
 			return
 		}
 	}
+	return
+}
+func (c RealTimeClient) RtGetThreadRecents(ctx context.Context, arg RtGetThreadRecentsArg) (res RTMsgList, err error) {
+	warg := &rpc.DataWrap[lib.Header, *RtGetThreadRecentsArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[lib.Header, RTMsgListInternal__]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(RealTimeProtocolID, 10, "RealTime.rtGetThreadRecents"), warg, &tmp, 0*time.Millisecond, realTimeErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	res = tmp.Data.Import()
 	return
 }
 func RealTimeProtocol(i RealTimeInterface) rpc.ProtocolV2 {
@@ -1968,6 +2275,35 @@ func RealTimeProtocol(i RealTimeInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "rtSelectVHost",
+			},
+			10: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[lib.Header, *RtGetThreadRecentsArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[lib.Header, *RtGetThreadRecentsArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[lib.Header, *RtGetThreadRecentsArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						tmp, err := i.RtGetThreadRecents(ctx, (typedArg.Import()))
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[lib.Header, *RTMsgListInternal__]{
+							Data:   tmp.Export(),
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "rtGetThreadRecents",
 			},
 		},
 		WrapError: RealTimeMakeGenericErrorWrapper(i.ErrorWrapper()),

--- a/server/realtime/messages.go
+++ b/server/realtime/messages.go
@@ -1,6 +1,7 @@
 package realtime
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/foks-proj/go-foks/lib/core"
@@ -8,11 +9,13 @@ import (
 	"github.com/foks-proj/go-foks/proto/rem"
 	"github.com/foks-proj/go-foks/server/shared"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // defaultThreadPage bounds a single rtGetThread page when the client doesn't
 // ask for a specific size (max=0).
 const defaultThreadPage = 100
+const maxThreadPage = 1000
 
 // messageSender sends one message into a channel. All work happens inside a
 // single realtime-DB transaction; we lock the channels row up front with
@@ -345,69 +348,21 @@ func loadChannelForRead(
 	return team, readRole, nil
 }
 
-// readThread pulls one page of messages from messages_enc, joining
-// channel_parties to recover sender attribution.
-func readThread(
-	m shared.MetaContext,
-	db shared.Querier,
-	q proto.RTThreadQuery,
-) (
-	[]rem.RTMsg,
-	error,
-) {
-	max := q.Max
-	if max == 0 || max > defaultThreadPage {
-		max = defaultThreadPage
-	}
-	channelID := int64(q.ChannelID.Short())
+// threadMsgSelect is the column list + sender-attribution join shared by every
+// message read (range fetch and by-seq fetch). Callers append their own WHERE /
+// ORDER BY / LIMIT clause; $1/$2 are reserved for short_host_id/channel_id.
+const threadMsgSelect = `SELECT me.seq, me.msg_id, me.typ, me.msg_box, me.ptk_gen,
+              me.role_type, me.viz_level, me.sent_at_time, me.insert_time,
+              me.prev_msg_id, me.prev_seq,
+              cp.party_id, cp.uid
+       FROM messages_enc me
+       JOIN channel_parties cp ON
+           cp.short_host_id = me.short_host_id
+           AND cp.channel_id = me.channel_id
+           AND cp.party_no = me.sender_no`
 
-	// Forward = ascending seq from `start` (inclusive); Backward = descending
-	// seq from `start` (or the head when start==0).
-	var sql string
-	switch q.Dir {
-	case proto.RTThreadDir_Backward:
-		sql = `SELECT me.seq, me.msg_id, me.typ, me.msg_box, me.ptk_gen,
-		              me.role_type, me.viz_level, me.sent_at_time, me.insert_time,
-		              me.prev_msg_id, me.prev_seq,
-		              cp.party_id, cp.uid
-		       FROM messages_enc me
-		       JOIN channel_parties cp ON
-		           cp.short_host_id = me.short_host_id
-		           AND cp.channel_id = me.channel_id
-		           AND cp.party_no = me.sender_no
-		       WHERE me.short_host_id=$1 AND me.channel_id=$2
-		         AND ($3 = 0 OR me.seq <= $3)
-		       ORDER BY me.seq DESC
-		       LIMIT $4`
-	default:
-		sql = `SELECT me.seq, me.msg_id, me.typ, me.msg_box, me.ptk_gen,
-		              me.role_type, me.viz_level, me.sent_at_time, me.insert_time,
-		              me.prev_msg_id, me.prev_seq,
-		              cp.party_id, cp.uid
-		       FROM messages_enc me
-		       JOIN channel_parties cp ON
-		           cp.short_host_id = me.short_host_id
-		           AND cp.channel_id = me.channel_id
-		           AND cp.party_no = me.sender_no
-		       WHERE me.short_host_id=$1 AND me.channel_id=$2
-		         AND me.seq >= $3
-		       ORDER BY me.seq ASC
-		       LIMIT $4`
-	}
-
-	rows, err := db.Query(
-		m.Ctx(),
-		sql,
-		m.ShortHostID(),
-		channelID,
-		int64(q.Start),
-		int64(max),
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
+// scanThreadMsgs decodes rows produced by a threadMsgSelect query into RTMsgs.
+func scanThreadMsgs(rows pgx.Rows) ([]rem.RTMsg, error) {
 	var ret []rem.RTMsg
 	for rows.Next() {
 		var (
@@ -422,7 +377,7 @@ func readThread(
 			prevSeq              int64
 			partyIDRaw, uidRaw   []byte
 		)
-		err = rows.Scan(
+		err := rows.Scan(
 			&seq, &msgIDRaw, &typRaw, &msgBoxRaw, &ptkGen,
 			&roleType, &vizLevel, &sentAtTime, &insertTm,
 			&prevMsgIDRaw, &prevSeq,
@@ -491,60 +446,258 @@ func readThread(
 		}
 		ret = append(ret, msg)
 	}
-	if err = rows.Err(); err != nil {
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	return ret, nil
 }
 
-// GetThread fetches a page of messages from a channel, after checking that the
-// authenticated user (m.UID()) is authorized to read it.
+// cappedThreadMax clamps a client-requested range size to defaultThreadPage,
+// treating 0 (unspecified) as "use the default".
+func cappedThreadMax(max uint64) uint64 {
+	if max == 0 || max > defaultThreadPage {
+		return defaultThreadPage
+	}
+	return max
+}
+
+func readThreadRecents(
+	m shared.MetaContext,
+	db shared.Querier,
+	channelID proto.RTChannelID,
+	stopAt proto.RTMsgSeq,
+	lim uint64,
+) (
+	[]rem.RTMsg,
+	error,
+) {
+	lim = cappedThreadMax(lim)
+	q := threadMsgSelect +
+		` WHERE me.short_host_id=$1 AND me.channel_id=$2
+	  AND me.seq > $3
+	  ORDER BY me.seq DESC LIMIT $4`
+	args := []any{m.ShortHostID(), channelID.Short().Int64(),
+		stopAt.Int64(),
+		lim,
+	}
+	rows, err := db.Query(
+		m.Ctx(),
+		q,
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanThreadMsgs(rows)
+}
+
+// readThread pulls one contiguous page of messages from messages_enc, joining
+// channel_parties to recover sender attribution.
+func readThreadBookends(
+	m shared.MetaContext,
+	db shared.Querier,
+	channelID proto.RTChannelID,
+	bookends rem.RTThreadRangeBookends,
+) (
+	[]rem.RTMsg,
+	error,
+) {
+
+	q := threadMsgSelect + " WHERE me.short_host_id=$1 AND me.channel_id=$2 "
+	args := []any{m.ShortHostID(), channelID.Short().Int64()}
+
+	var order string
+	var bottom, top proto.RTMsgSeq
+	if bookends.Start < bookends.End {
+		bottom = bookends.Start
+		top = bookends.End
+		order = "ASC"
+	} else {
+		bottom = bookends.End
+		top = bookends.Start
+		order = "DESC"
+	}
+	if top-bottom > maxThreadPage {
+		return nil, core.BadArgsError("message fetch range too wide")
+	}
+	args = append(args, bottom.Int64(), top.Int64())
+	q += fmt.Sprintf(" AND me.seq >= $3 AND me.seq <= $4 ORDER BY me.seq %s", order)
+
+	rows, err := db.Query(
+		m.Ctx(),
+		q,
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanThreadMsgs(rows)
+}
+
+// readMsgsBySeq fetches the messages whose seq is in `seqs`. Seqs with no
+// matching message are simply absent from the result; order is unspecified
+// (each RTMsg carries its own seq, so the caller can slot it back into place).
+func readMsgsBySeq(
+	m shared.MetaContext,
+	db shared.Querier,
+	channelID proto.RTChannelID,
+	seqs []proto.RTMsgSeq,
+) (
+	[]rem.RTMsg,
+	error,
+) {
+	if len(seqs) == 0 {
+		return nil, nil
+	}
+	v := make([]int64, len(seqs))
+	for i, s := range seqs {
+		v[i] = int64(s)
+	}
+	rows, err := db.Query(
+		m.Ctx(),
+		threadMsgSelect+`
+		       WHERE me.short_host_id=$1 AND me.channel_id=$2
+		         AND me.seq = ANY($3)`,
+		m.ShortHostID(),
+		channelID.Short().Int64(),
+		v,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanThreadMsgs(rows)
+}
+
+// maxMsgsBySeq bounds the seq-list portion of a single rtGetThread request, so
+// a client can't ask for an unbounded set of seqs in one round trip.
+const maxMsgsBySeq = 4096
+
+func GetThreadRecents(
+	m shared.MetaContext,
+	arg rem.RtGetThreadRecentsArg,
+) (
+	*rem.RTMsgList,
+	error,
+) {
+	channelID := arg.Ch
+	var retp *rem.RTMsgList
+	err := getThreadGeneric(
+		m,
+		channelID,
+		func(
+			rtdb *pgxpool.Conn,
+		) error {
+			msgs, err := readThreadRecents(m, rtdb, channelID, arg.StopAt, arg.Lim)
+			if err != nil {
+				return err
+			}
+			ret := rem.RTMsgList{
+				Lst: msgs,
+			}
+			retp = &ret
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return retp, nil
+}
+
+// GetThread answers a thread query after checking that the authenticated user
+// (m.UID()) is authorized to read the channel. A query may carry a contiguous
+// range, an explicit set of seqs (to fill holes between cached and
+// remote-fetched ranges), or both; the two are answered into separate result
+// lists. Seq lookups are found-only: missing seqs are silently omitted.
 func GetThread(
 	m shared.MetaContext,
-	q proto.RTThreadQuery,
+	q rem.RTThreadQuery,
 ) (
 	*rem.RTThreadPage,
 	error,
 ) {
-	rtdb, err := m.Db(shared.DbTypeRealTime)
+	channelID := q.ChannelID
+	var retp *rem.RTThreadPage
+
+	err := getThreadGeneric(
+		m,
+		channelID,
+		func(
+			rtdb *pgxpool.Conn,
+		) error {
+			if len(q.Seqs) > maxMsgsBySeq {
+				return core.BadArgsError("too many seqs requested")
+			}
+
+			ret := rem.RTThreadPage{}
+
+			for _, rng := range q.Bookends {
+				msgs, err := readThreadBookends(m, rtdb, channelID, rng)
+				if err != nil {
+					return err
+				}
+				ret.RangeMsgs = append(ret.RangeMsgs, rem.RTMsgList{Lst: msgs})
+			}
+
+			if len(q.Seqs) > 0 {
+				msgs, err := readMsgsBySeq(m, rtdb, channelID, q.Seqs)
+				if err != nil {
+					return err
+				}
+				ret.SeqMsgs = msgs
+			}
+			retp = &ret
+			return nil
+		},
+	)
 	if err != nil {
 		return nil, err
+	}
+	return retp, nil
+}
+
+func getThreadGeneric(
+	m shared.MetaContext,
+	chid proto.RTChannelID,
+	fn func(rtdb *pgxpool.Conn) error,
+) error {
+
+	rtdb, err := m.Db(shared.DbTypeRealTime)
+	if err != nil {
+		return err
 	}
 	defer rtdb.Release()
 	userdb, err := m.Db(shared.DbTypeUsers)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer userdb.Release()
 
-	team, readRole, err := loadChannelForRead(m, rtdb, int64(q.ChannelID.Short()))
+	team, readRole, err := loadChannelForRead(m, rtdb, chid.Short().Int64())
 	if err != nil {
-		return nil, err
+		return err
 	}
 	role, err := AuthorizeUserForTeam(m, userdb, team)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	readRoleKey, err := core.ImportRole(readRole)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if role.LessThan(*readRoleKey) {
-		return nil, core.PermissionError("user role too low to read channel")
+		return core.PermissionError("user role too low to read channel")
 	}
 
-	max := q.Max
-	if max == 0 || max > defaultThreadPage {
-		max = defaultThreadPage
-	}
-	msgs, err := readThread(m, rtdb, q)
+	err = fn(rtdb)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	ret := rem.RTThreadPage{
-		Msgs: msgs,
-		// A short page means we reached the end of the requested range.
-		Final: uint64(len(msgs)) < max,
-	}
-	return &ret, nil
+	return nil
 }

--- a/server/realtime/server.go
+++ b/server/realtime/server.go
@@ -82,7 +82,7 @@ func (c *ClientConn) RtSend(ctx context.Context, arg rem.RTSendArg) (res rem.RTS
 	}
 	return *ret, nil
 }
-func (c *ClientConn) RtGetThread(ctx context.Context, arg proto.RTThreadQuery) (res rem.RTThreadPage, err error) {
+func (c *ClientConn) RtGetThread(ctx context.Context, arg rem.RTThreadQuery) (res rem.RTThreadPage, err error) {
 	m := shared.NewMetaContextConn(ctx, c)
 	ret, err := GetThread(m, arg)
 	if err != nil {
@@ -104,6 +104,20 @@ func (c *ClientConn) RtPollInbox(ctx context.Context, arg rem.RTPollInboxArg) (r
 }
 func (c *ClientConn) RtSelectVHost(ctx context.Context, arg proto.HostID) error {
 	return core.NotImplementedError{}
+}
+func (c *ClientConn) RtGetThreadRecents(
+	ctx context.Context,
+	arg rem.RtGetThreadRecentsArg,
+) (
+	res rem.RTMsgList,
+	err error,
+) {
+	m := shared.NewMetaContextConn(ctx, c)
+	ret, err := GetThreadRecents(m, arg)
+	if err != nil {
+		return res, err
+	}
+	return *ret, nil
 }
 
 var _ shared.RPCServer = (*Server)(nil)


### PR DESCRIPTION
Add a local message cache so a thread can be served from disk first, with
only the missing pieces fetched from the server and merged in.

Local DB / cache
- New `ranged_data` table (plus a gc-bit sidecar) in soft.sql, keyed by
  (scope, typ, key, idx). Rows can be selected by a simple integer lo/hi
  range, which backs both thread and inbox fetches.
- `DBRange` helper in libclient for typed ranged get/put: Get over [lo,hi]
  and GetNMax for the most-recent N.
- Reads, the outbox, and sends all write through this layer. A sent message
  is now cached locally on send, so the sender can read its own thread back
  without a server round-trip.

RPC surface (proto-src)
- Reworked rtGetThread. RTThreadQuery now carries a list of inclusive
  [start,end] "bookend" ranges and a list of explicit seqs, answered into
  separate result lists (rangeMsgs / seqMsgs) in one RTThreadPage. A client
  can fetch contiguous ranges and fill arbitrary holes in a single call.
- Added rtGetThreadRecents: a most-recent-first page that stops at a given
  seq, for the common "open the channel" path.
- RTMsgCached gains a server-insert-time (sit) field so a cached message
  carries the same insert time a server fetch would.

Client read paths (minder.go)
- GetThreadBookended reads [start,end] from cache, computes the holes and
  edges still missing, fetches only those, and merges. Direction is implied
  by the ordering of the bookends.
- GetThreadRecentMsgs and GetMsgs (arbitrary seqs) build on the same merge.
- Helpers findHoles (gap detection over a monotonic run) and merge (two
  sorted runs), both unit-tested.
- Minder exposes always-on instrumentation counters via Metrics() for server
  read RPCs, used to assert cache hits in tests.

Bug fixes
- The DBRange constructor never stored its `typ`, so every ranged read queried
  typ=0 and matched nothing: the cache was effectively write-only and all
  reads silently fell through to the server. Store the typ.
- Retired the metadata/body split in the cache. The write stored only the
  noncer under one data type while the read expected a whole RTMsgCached, so
  cached rows could never be reconstructed; now the full RTMsgCached is stored
  under a single key. (The split may have been a premature optimization.)

Tests
- Unit tests for findHoles and merge.
- Integration tests for bookended hole-filling (separate sender/receiver) and
  sender-side cache hits (asserted via the new metrics); the existing
  send/read, permission, encryption-role, and disambiguation suites were
  updated to the new API.

TODO
- prev-pointer / ordering checks when replaying a thread.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
