### PR TITLE
chat(1a): CLI for send/read, sender-name resolution, and read-role gating

### DIFF
--- a/client/agent/rt.go
+++ b/client/agent/rt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/foks-proj/go-foks/client/librt"
+	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 )
@@ -36,7 +37,22 @@ func (c *AgentConn) ClientRTMakeChannel(
 	if err != nil {
 		return zed, err
 	}
-	chid, err := minder.MakeChannel(m, arg.Cfg.Team, arg.Cfg.AppID, arg.Cfg.Channel, arg.Desc, arg.Cfg.Roles)
+	t, err := arg.Cfg.Channel.GetT()
+	if err != nil {
+		return zed, err
+	}
+	if t != lcl.RTChannelSpecifierType_Name {
+		return zed, core.BadArgsError("expected a channel name")
+	}
+	nm := arg.Cfg.Channel.Name().Name
+	chid, err := minder.MakeChannel(
+		m,
+		arg.Cfg.Team,
+		arg.Cfg.AppID,
+		nm,
+		arg.Desc,
+		arg.Cfg.Roles,
+	)
 	if err != nil {
 		return zed, err
 	}
@@ -60,6 +76,44 @@ func (c *AgentConn) ClientRTListChannelsForTeam(
 		return zed, err
 	}
 	return *lst, nil
+}
+
+func (c *AgentConn) ClientRTSend(
+	ctx context.Context,
+	arg lcl.ClientRTSendArg,
+) (
+	proto.RTMsgSeq,
+	error,
+) {
+	var zed proto.RTMsgSeq
+	m, minder, err := c.rtInit(ctx, arg.Cfg)
+	if err != nil {
+		return zed, err
+	}
+	res, err := minder.Send(m, arg.Cfg.Team, arg.Cfg.AppID, arg.Cfg.Channel, arg.Body)
+	if err != nil {
+		return zed, err
+	}
+	return res.Seq, nil
+}
+
+func (c *AgentConn) ClientRTGetThread(
+	ctx context.Context,
+	arg lcl.ClientRTGetThreadArg,
+) (
+	lcl.RTThreadView,
+	error,
+) {
+	var zed lcl.RTThreadView
+	m, minder, err := c.rtInit(ctx, arg.Cfg)
+	if err != nil {
+		return zed, err
+	}
+	view, err := minder.GetThreadView(m, arg.Cfg.Team, arg.Cfg.AppID, arg.Cfg.Channel, arg.Before, uint(arg.Num))
+	if err != nil {
+		return zed, err
+	}
+	return *view, nil
 }
 
 var _ lcl.RealTimeInterface = (*AgentConn)(nil)

--- a/client/foks/cmd/rt.go
+++ b/client/foks/cmd/rt.go
@@ -12,6 +12,79 @@ type quickRTOpts struct {
 	SupportReadRole  bool
 	SupportWriteRole bool
 	NoSupportTeam    bool
+	SupportChannel   bool
+}
+
+func parseChannelSpecifier(
+	nameOrId string,
+	klass string,
+) (
+	*lcl.RTChannelSpecifier,
+	error,
+) {
+	none := lcl.NewRTChannelSpecifierDefault(lcl.RTChannelSpecifierType_None)
+	if nameOrId == "" && klass == "" {
+		return &none, nil
+	}
+	cc := proto.RTChannelClass_None
+	if len(klass) > 0 {
+		switch klass {
+		case "a", "admin":
+			cc = proto.RTChannelClass_Admin
+		case "d", "default", "bottom":
+			cc = proto.RTChannelClass_Bottom
+		default:
+			return nil, core.BadArgsError("bad channel class")
+		}
+	}
+
+	var ret *lcl.RTChannelSpecifier
+	var chid *proto.RTChannelID
+	var cn proto.RTChannelName
+
+	if len(nameOrId) > 0 {
+		if nameOrId[0] != '#' {
+			var rtid proto.RTID
+			err := rtid.ImportFromString(nameOrId)
+			if err == nil {
+				chid = rtid.RTChannelID()
+			}
+		} else {
+			nameOrId = nameOrId[1:]
+		}
+		if chid == nil && len(nameOrId) > 0 {
+			if proto.RTChannelName(nameOrId).Eq(proto.RTGeneralChannel) {
+				nameOrId = ""
+			} else {
+				err := cn.ParseFrom(nameOrId)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	switch {
+	case chid != nil:
+		if cc != proto.RTChannelClass_None {
+			return nil, core.BadArgsError(
+				"cannot specify channel ID and class together",
+			)
+		}
+		tmp := lcl.NewRTChannelSpecifierWithId(*chid)
+		ret = &tmp
+	case !cn.IsEmpty() || cc != proto.RTChannelClass_None:
+		tmp := lcl.NewRTChannelSpecifierWithName(
+			lcl.RTChannelNameAndClass{
+				Name:  cn,
+				Klass: cc,
+			},
+		)
+		ret = &tmp
+	default:
+		ret = &none
+	}
+
+	return ret, nil
 }
 
 func quickRTCmd(
@@ -29,7 +102,7 @@ func quickRTCmd(
 		long = short
 	}
 	var teamStr string
-	var rrs, wrs string
+	var rrs, wrs, chs, chcs string
 	var rr, wr *proto.Role
 	run := func(cmd *cobra.Command, arg []string) error {
 		var fqt *proto.FQTeamParsed
@@ -56,10 +129,18 @@ func quickRTCmd(
 				return err
 			}
 		}
+		chsp, err := parseChannelSpecifier(
+			chs,
+			chcs,
+		)
+		if err != nil {
+			return err
+		}
 		cfg := lcl.RTConfig{
-			Team:  fqt,
-			Roles: proto.RolePairOpt{Read: rr, Write: wr},
-			AppID: proto.RTAppID_Chat,
+			Team:    fqt,
+			Roles:   proto.RolePairOpt{Read: rr, Write: wr},
+			AppID:   proto.RTAppID_Chat,
+			Channel: *chsp,
 		}
 		return quickStartLambda(m, &kvOpts, func(cli lcl.RealTimeClient) error {
 			err := fn(arg, cfg, cli)
@@ -87,6 +168,10 @@ func quickRTCmd(
 	if opts.SupportWriteRole {
 		cmd.Flags().StringVarP(&wrs, "write-role", "w", "", "write role to create as (default depends on subcommand)")
 	}
+	if opts.SupportChannel {
+		cmd.Flags().StringVar(&chs, "channel", "", "specify channel name (with '#') or channel ID (#general by default)")
+		cmd.Flags().StringVar(&chcs, "channel-class", "", "disambiguate with channel class (can be \"a\"/\"admin\" or \"d\"/\"default\")")
+	}
 	if setup != nil {
 		setup(cmd)
 	}
@@ -100,16 +185,25 @@ func rtNewChannel(m libclient.MetaContext, top *cobra.Command) {
 		"new-channel", []string{"new"},
 		"create a new channel",
 		"create a new channel for a team or DM-style ad-hoc team",
-		quickRTOpts{},
+		quickRTOpts{SupportReadRole: true, SupportWriteRole: true},
 		func(cmd *cobra.Command) {
 			cmd.Flags().StringVar(&desc, "description", "", "channel description")
 			cmd.Flags().StringVar(&nm, "name", "", "channel name")
 		},
 		func(args []string, cfg lcl.RTConfig, cli lcl.RealTimeClient) error {
+			if len(args) != 0 {
+				return ArgsError("no args; specify channel name with --name")
+			}
 			if cfg.Team == nil {
 				return ArgsError("must provide a --team for chat stage 1a")
 			}
-			err := cfg.Channel.ParseFrom(nm)
+			// '#' is a display convention, not part of the name; let users
+			// pass "#bar" and parse the rest as the channel name.
+			if len(nm) > 0 && nm[0] == '#' {
+				nm = nm[1:]
+			}
+			var ch proto.RTChannelName
+			err := ch.ParseFrom(nm)
 			if err != nil {
 				return err
 			}
@@ -118,9 +212,14 @@ func rtNewChannel(m libclient.MetaContext, top *cobra.Command) {
 			if err != nil {
 				return err
 			}
-			if !cd.IsEmpty() && cfg.Channel.IsEmpty() {
+			if !cd.IsEmpty() && ch.IsEmpty() {
 				return ArgsError("can only specify a description if not the default channel")
 			}
+			cfg.Channel = lcl.NewRTChannelSpecifierWithName(
+				lcl.RTChannelNameAndClass{
+					Name: ch,
+				},
+			)
 			ret, err := cli.ClientRTMakeChannel(m.Ctx(),
 				lcl.ClientRTMakeChannelArg{
 					Cfg:  cfg,
@@ -167,6 +266,110 @@ func rtListChannels(m libclient.MetaContext, top *cobra.Command) {
 	)
 }
 
+func rtSend(m libclient.MetaContext, top *cobra.Command) {
+	quickRTCmd(
+		m, top,
+		"send", []string{"s"},
+		"send a message to a channel",
+		"send a basic text message to a team channel; the message is the single positional argument",
+		quickRTOpts{
+			SupportChannel: true,
+		},
+		nil,
+		func(args []string, cfg lcl.RTConfig, cli lcl.RealTimeClient) error {
+			if cfg.Team == nil {
+				return ArgsError("must provide a --team for chat stage 1a")
+			}
+			if len(args) != 1 {
+				return ArgsError("must provide exactly one message argument (quote it)")
+			}
+			seq, err := cli.ClientRTSend(m.Ctx(),
+				lcl.ClientRTSendArg{
+					Cfg:  cfg,
+					Body: []byte(args[0]),
+				},
+			)
+			if err != nil {
+				return err
+			}
+			if m.G().Cfg().JSONOutput() {
+				return JSONOutput(m, seq)
+			}
+			m.G().UIs().Terminal.Printf("sent message #%d\n", seq)
+			return nil
+		},
+	)
+}
+
+func rtRead(m libclient.MetaContext, top *cobra.Command) {
+	var num uint
+	var before uint64
+	quickRTCmd(
+		m, top,
+		"read", []string{"thread", "get-thread", "r"},
+		"read a page of messages from a channel",
+		"fetch and decrypt a page of messages from a team channel, resolving sender "+
+			"names. By default reads the most recent page; use --before to page back "+
+			"through older messages.",
+		quickRTOpts{
+			SupportChannel: true,
+		},
+		func(cmd *cobra.Command) {
+			cmd.Flags().UintVarP(&num, "num", "n", 0, "max number of messages in the page (0 = default)")
+			cmd.Flags().Uint64Var(&before, "before", 0, "page messages older than this seq # (0 = most recent)")
+		},
+		func(args []string, cfg lcl.RTConfig, cli lcl.RealTimeClient) error {
+			if cfg.Team == nil {
+				return ArgsError("must provide a --team")
+			}
+			thread, err := cli.ClientRTGetThread(m.Ctx(),
+				lcl.ClientRTGetThreadArg{
+					Cfg:    cfg,
+					Num:    uint64(num),
+					Before: proto.RTMsgSeq(before),
+				},
+			)
+			if err != nil {
+				return err
+			}
+			if m.G().Cfg().JSONOutput() {
+				return JSONOutput(m, thread)
+			}
+			return outputRTThread(m, thread)
+		},
+	)
+}
+
+// outputRTThread prints a thread oldest-first (the page comes back newest-first,
+// so we iterate in reverse for chronological reading order) and, unless we've
+// reached the start of the thread, prints how to page back to the previous page.
+func outputRTThread(m libclient.MetaContext, thread lcl.RTThreadView) error {
+	t := m.G().UIs().Terminal
+	for i := len(thread.Msgs) - 1; i >= 0; i-- {
+		msg := thread.Msgs[i]
+		sender := "<system>"
+		switch {
+		case msg.SenderName != nil:
+			sender = string(*msg.SenderName)
+		case msg.Sender != nil:
+			if s, err := msg.Sender.StringErr(); err == nil {
+				sender = s
+			}
+		}
+		when := msg.SentAtTime.Import().Local().Format("2006-01-02 15:04:05")
+		t.Printf("#%d  %s  %s\n      %s\n", msg.Seq, when, sender, string(msg.Body))
+	}
+	switch {
+	case thread.AtBeginning:
+		t.Printf("(beginning of thread)\n")
+	case len(thread.Msgs) > 0:
+		// Oldest message in this page is the last one printed; page back from it.
+		oldest := thread.Msgs[len(thread.Msgs)-1].Seq
+		t.Printf("(older messages above; rerun with --before %d)\n", oldest)
+	}
+	return nil
+}
+
 func rtCmd(m libclient.MetaContext) *cobra.Command {
 	top := &cobra.Command{
 		Use:     "rt",
@@ -179,6 +382,8 @@ func rtCmd(m libclient.MetaContext) *cobra.Command {
 	}
 	rtNewChannel(m, top)
 	rtListChannels(m, top)
+	rtSend(m, top)
+	rtRead(m, top)
 	return top
 }
 

--- a/client/foks/cmd/tables.go
+++ b/client/foks/cmd/tables.go
@@ -142,7 +142,7 @@ func outputTable(
 	}
 	t.SetStyle(table.StyleLight)
 	dat := t.Render()
-	_, err := m.G().UIs().Terminal.OutputStream().Write([]byte(dat))
+	_, err := m.G().UIs().Terminal.OutputStream().Write([]byte(dat + "\n"))
 	return err
 
 }
@@ -696,10 +696,7 @@ func outputTeamListMembershipsTable(
 // displayRTChannelName renders a channel name for the console; the default
 // (empty) channel is shown as "#general".
 func displayRTChannelName(n proto.RTChannelName) string {
-	if n.IsEmpty() {
-		return "#general"
-	}
-	return "#" + string(n)
+	return n.DecorateToString()
 }
 
 type rtChannelRow struct {

--- a/client/librt/const.go
+++ b/client/librt/const.go
@@ -1,0 +1,1 @@
+package librt

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -3,6 +3,7 @@ package librt
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"slices"
 	"strings"
 	"sync"
@@ -61,7 +62,33 @@ type Minder struct {
 
 	msgIDCache *LRU[proto.RTMsgID, proto.RTMsgSeq]
 
+	// usernameCache memoizes UID -> display-name resolutions (each a full user
+	// chain load), which would otherwise be issued per message-sender on every
+	// thread read. Entries expire after a jittered ~6h TTL; see usernameCacheTTL.
+	usernameMu    sync.Mutex
+	usernameCache map[proto.UID]usernameCacheEntry
+
 	testHooks *MinderTestHooks
+}
+
+type usernameCacheEntry struct {
+	name      proto.NameUtf8
+	expiresAt time.Time
+}
+
+const (
+	// usernameCacheTTLBase is the central lifetime of a cached UID->name entry;
+	// usernameCacheTTLJitter is the random spread added on top so a burst of
+	// entries cached together don't all expire at once and stampede the server.
+	usernameCacheTTLBase   = 6 * time.Hour
+	usernameCacheTTLJitter = 2 * time.Hour
+)
+
+// jitteredUsernameTTL returns a lifetime uniformly in
+// [base - jitter/2, base + jitter/2), centered on base (~6h).
+func jitteredUsernameTTL() time.Duration {
+	return usernameCacheTTLBase - usernameCacheTTLJitter/2 +
+		time.Duration(rand.Int63n(int64(usernameCacheTTLJitter)))
 }
 
 // MinderTestHooks lets tests perturb a Minder. A nil Minder.testHooks, or a nil
@@ -113,8 +140,9 @@ func NewMinder(au *libclient.UserContext) *Minder {
 		panic("nil active user")
 	}
 	ret := &Minder{
-		au:         au,
-		msgIDCache: NewLRU[proto.RTMsgID, proto.RTMsgSeq](10_000),
+		au:            au,
+		msgIDCache:    NewLRU[proto.RTMsgID, proto.RTMsgSeq](10_000),
+		usernameCache: make(map[proto.UID]usernameCacheEntry),
 	}
 	ret.base = libclient.NewBaseMinder(
 		au,
@@ -154,6 +182,9 @@ func (d *Minder) MakeChannelWithTestHooks(
 	*proto.RTChannelID,
 	error,
 ) {
+	if nm.Eq(proto.RTGeneralChannel) {
+		return nil, core.RTGenericError("cannot make channel named #general")
+	}
 	sleepDur := time.Millisecond
 	numTries := 5
 	for i := range numTries {
@@ -208,7 +239,7 @@ func (d *Minder) makeChannelOneAttempt(
 	}
 	chMap := make(map[chKey]struct{})
 	for _, chmd := range chlst.Channels {
-		chMap[chKey{name: chmd.Name, klass: chmd.Klass}] = struct{}{}
+		chMap[chKey{name: chmd.Name.Normalize(), klass: chmd.Klass}] = struct{}{}
 	}
 
 	// A note on roles, which are tricky. If no roles were specified, we use
@@ -247,7 +278,10 @@ func (d *Minder) makeChannelOneAttempt(
 		nameRole = proto.AdminRole
 	}
 
-	if _, found := chMap[chKey{name: nm, klass: newChClass}]; found {
+	if _, found := chMap[chKey{
+		name:  nm.Normalize(),
+		klass: newChClass,
+	}]; found {
 		return nil, core.RTChannelExistsError{}
 	}
 	nameKeySeq, err := rtp.PLCNode().SKM().PrivateKeysForRole(m.Base(), nameRole)
@@ -383,6 +417,14 @@ func (r *RTParty) keysAtRoleGen(
 	if err != nil {
 		return nil, err
 	}
+	// PrivateKeysForRole returns (nil, nil) when we hold no private keys for the
+	// role, i.e. we aren't a member at or above the channel's role. Without those
+	// keys we can decrypt neither the channel name/description nor its messages,
+	// so this is a read-permission failure -- not an internal error or a panic on
+	// the nil sequence below.
+	if seq == nil {
+		return nil, core.PermissionError("no read access to channel at this role")
+	}
 	key := seq.At(rg.Gen)
 	if key == nil {
 		return nil, core.KeyNotFoundError{Which: "SKM at role/gen in chat"}
@@ -490,6 +532,7 @@ func (k *Minder) decryptChannelMetadata(
 	ret.Roles = chmdenc.Roles
 	ret.Klass = chmdenc.Klass
 	ret.UpdatedAt = chmdenc.UpdatedAt
+	ret.Unreadable = chmdenc.Unreadable
 
 	return &ret, nil
 }
@@ -510,6 +553,15 @@ func (k *Minder) ListAllChannelsForTeam(
 	if err != nil {
 		return nil, err
 	}
+	// Drop channels the server flagged as unreadable for us (role below the read
+	// role). They're returned so name-collision detection in MakeChannel can see
+	// them, but they have no decryptable content, so we hide them from the inbox.
+	ret.Channels = slices.DeleteFunc(
+		ret.Channels,
+		func(c lcl.RTChannelMetadataPlaintext) bool {
+			return c.Unreadable
+		},
+	)
 	slices.SortFunc(
 		ret.Channels,
 		func(a lcl.RTChannelMetadataPlaintext, b lcl.RTChannelMetadataPlaintext) int {
@@ -589,8 +641,7 @@ func (d *Minder) resolveChannel(
 	m MetaContext,
 	rtp *RTParty,
 	appID proto.RTAppID,
-	name proto.RTChannelName,
-	klass *proto.RTChannelClass,
+	spc lcl.RTChannelSpecifier,
 ) (
 	*lcl.RTChannelMetadataPlaintext,
 	error,
@@ -599,23 +650,57 @@ func (d *Minder) resolveChannel(
 	if err != nil {
 		return nil, err
 	}
+
+	t, err := spc.GetT()
+	if err != nil {
+		return nil, err
+	}
+
+	var searchID *proto.RTChannelID
+	var searchName proto.RTChannelName
+	var searchClass proto.RTChannelClass
+
+	switch t {
+	case lcl.RTChannelSpecifierType_None:
+		/* noop */
+	case lcl.RTChannelSpecifierType_Name:
+		searchName = spc.Name().Name
+		searchClass = spc.Name().Klass
+	case lcl.RTChannelSpecifierType_ID:
+		tmp := spc.Id()
+		searchID = &tmp
+	default:
+		return nil, core.InternalError("unexpected channel specifier type")
+	}
+
 	var found *lcl.RTChannelMetadataPlaintext
 	for i := range lst.Channels {
 		ch := &lst.Channels[i]
-		if ch.Name != name {
+
+		// If specified by channel, then first match wins
+		if searchID != nil {
+			if searchID.Eq(ch.Id) {
+				return ch, nil
+			}
 			continue
 		}
-		if klass != nil && ch.Klass != *klass {
+
+		if !ch.Name.Eq(searchName) {
+			continue
+		}
+		if searchClass != proto.RTChannelClass_None && ch.Klass != searchClass {
 			continue
 		}
 		if found != nil {
 			// Only reachable when klass==nil; a (name, class) pair is unique.
-			return nil, core.RTAmbiguousChannelError{Name: string(name)}
+			return nil, core.RTAmbiguousChannelError{Name: searchName}
 		}
 		found = ch
 	}
 	if found == nil {
-		return nil, core.RTNotFoundError(fmt.Sprintf("channel '%s'", string(name)))
+		return nil, core.RTNotFoundError(
+			fmt.Sprintf("channel '%s'", spc.String()),
+		)
 	}
 	return found, nil
 }
@@ -676,14 +761,13 @@ func (d *Minder) Send(
 	m MetaContext,
 	team *proto.FQTeamParsed,
 	appID proto.RTAppID,
-	channelName proto.RTChannelName,
-	klass *proto.RTChannelClass,
+	channel lcl.RTChannelSpecifier,
 	body []byte,
 ) (
 	*rem.RTSendRes,
 	error,
 ) {
-	return d.SendWithTestHooks(m, team, appID, channelName, klass, body, nil)
+	return d.SendWithTestHooks(m, team, appID, channel, body, nil)
 }
 
 func (d *Minder) cacheMsgID(
@@ -702,8 +786,7 @@ func (d *Minder) SendWithTestHooks(
 	m MetaContext,
 	team *proto.FQTeamParsed,
 	appID proto.RTAppID,
-	channelName proto.RTChannelName,
-	klass *proto.RTChannelClass,
+	channel lcl.RTChannelSpecifier,
 	body []byte,
 	test *SendTestHooks,
 ) (
@@ -717,7 +800,7 @@ func (d *Minder) SendWithTestHooks(
 	if err != nil {
 		return nil, err
 	}
-	ch, err := d.resolveChannel(m, rtp, appID, channelName, klass)
+	ch, err := d.resolveChannel(m, rtp, appID, channel)
 	if err != nil {
 		return nil, err
 	}
@@ -983,8 +1066,7 @@ func (d *Minder) initReq(
 	m MetaContext,
 	team *proto.FQTeamParsed,
 	appID proto.RTAppID,
-	channelName proto.RTChannelName,
-	klass *proto.RTChannelClass,
+	channel lcl.RTChannelSpecifier,
 ) (
 	*RTParty,
 	*lcl.RTChannelMetadataPlaintext,
@@ -998,7 +1080,7 @@ func (d *Minder) initReq(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	ch, err := d.resolveChannel(m, rtp, appID, channelName, klass)
+	ch, err := d.resolveChannel(m, rtp, appID, channel)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1007,6 +1089,109 @@ func (d *Minder) initReq(
 		return nil, nil, nil, err
 	}
 	return rtp, ch, cli, nil
+}
+
+// TeamViewToken returns the team's view bearer token, used for AsLocalTeam user
+// loads. The agent uses it to resolve message-sender UIDs to usernames: in
+// closed viewership mode, co-members can only load each other mediated through
+// the shared team, not directly. Returns nil if the team carries no view token
+// (e.g. it was loaded as self/owner); callers should treat name resolution as
+// best-effort and tolerate a nil token.
+func (d *Minder) TeamViewToken(
+	m MetaContext,
+	team *proto.FQTeamParsed,
+) (
+	*rem.TeamVOBearerToken,
+	error,
+) {
+	if team == nil {
+		return nil, core.InternalError("team is required")
+	}
+	rtp, err := d.base.GetParty(m.Base(), team)
+	if err != nil {
+		return nil, err
+	}
+	return rtp.PLCNode().ViewTok(), nil
+}
+
+// usernameCacheGet returns a cached, unexpired display name for uid, if any.
+func (d *Minder) usernameCacheGet(m MetaContext, uid proto.UID) (proto.NameUtf8, bool) {
+	d.usernameMu.Lock()
+	defer d.usernameMu.Unlock()
+	ent, ok := d.usernameCache[uid]
+	if !ok {
+		return "", false
+	}
+	if !m.G().Now().Before(ent.expiresAt) {
+		delete(d.usernameCache, uid)
+		return "", false
+	}
+	return ent.name, true
+}
+
+// usernameCacheSet records uid -> name with a fresh jittered TTL.
+func (d *Minder) usernameCacheSet(m MetaContext, uid proto.UID, nm proto.NameUtf8) {
+	d.usernameMu.Lock()
+	defer d.usernameMu.Unlock()
+	d.usernameCache[uid] = usernameCacheEntry{
+		name:      nm,
+		expiresAt: m.G().Now().Add(jitteredUsernameTTL()),
+	}
+}
+
+// ResolveSenderNames maps each distinct user-sender UID in msgs to its display
+// name. Resolutions are memoized (see usernameCache) since each cache miss is a
+// full user-chain load; in closed viewership mode the load is mediated through
+// the shared team, so a team view bearer token (tok) is presented. Best-effort:
+// a sender that can't be loaded is omitted from the result rather than failing.
+func (d *Minder) ResolveSenderNames(
+	m MetaContext,
+	tok *rem.TeamVOBearerToken,
+	msgs []ThreadMessage,
+) map[proto.UID]proto.NameUtf8 {
+	ret := make(map[proto.UID]proto.NameUtf8)
+	for i := range msgs {
+		sender := msgs[i].Sender
+		if sender == nil || !sender.IsUser() {
+			continue
+		}
+		uid, err := sender.UID()
+		if err != nil {
+			continue
+		}
+		if _, ok := ret[uid]; ok {
+			continue
+		}
+		if nm, ok := d.resolveSenderName(m, tok, uid); ok {
+			ret[uid] = nm
+		}
+	}
+	return ret
+}
+
+// resolveSenderName returns the display name for a single sender UID -- from the
+// cache if present, otherwise via a (team-mediated) user-chain load whose result
+// is then cached. Returns false if the user can't be loaded.
+func (d *Minder) resolveSenderName(
+	m MetaContext,
+	tok *rem.TeamVOBearerToken,
+	uid proto.UID,
+) (proto.NameUtf8, bool) {
+	if nm, ok := d.usernameCacheGet(m, uid); ok {
+		return nm, true
+	}
+	uw, err := libclient.LoadUser(m.Base(), libclient.LoadUserArg{
+		Uid:               uid,
+		LoadMode:          libclient.LoadModeOthers,
+		TeamVOBearerToken: tok,
+	})
+	if err != nil {
+		m.Warnw("resolveSenderName", "uid", uid, "err", err)
+		return "", false
+	}
+	nm := uw.Name()
+	d.usernameCacheSet(m, uid, nm)
+	return nm, true
 }
 
 // if inc > 1, sort ascending
@@ -1049,8 +1234,7 @@ func (d *Minder) GetThreadBookended(
 	m MetaContext,
 	team *proto.FQTeamParsed,
 	appID proto.RTAppID,
-	channelName proto.RTChannelName,
-	klass *proto.RTChannelClass,
+	channel lcl.RTChannelSpecifier,
 	start proto.RTMsgSeq,
 	end proto.RTMsgSeq,
 ) (
@@ -1061,21 +1245,20 @@ func (d *Minder) GetThreadBookended(
 	if team == nil {
 		return nil, false, core.InternalError("team is required to read in Stage 1a")
 	}
-	if start == end {
-		return nil, false, core.InternalError("no messages in range")
-	}
 
 	sess := newMsgSession()
 
 	// Direction is implied by the ordering of the bookends; the request is
 	// authoritative. Cached rows come back in this same order (DBRange.Get
 	// orders by start vs end), so cached[0] is the `start` side throughout.
+	// Bookends are inclusive, so start==end is a well-defined single-message
+	// request; direction is moot there, and ascending (the default) is fine.
 	inc := 1
 	if end < start {
 		inc = -1
 	}
 
-	rtp, ch, cli, err := d.initReq(m, team, appID, channelName, klass)
+	rtp, ch, cli, err := d.initReq(m, team, appID, channel)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1190,13 +1373,128 @@ func (d *Minder) GetThreadBookended(
 	return ret, isFinal, nil
 }
 
+// GetThreadPage fetches up to num messages, newest-first, ending just before the
+// cursor `before` (exclusive). With before==0 it returns the most recent page
+// (the live head). It also reports atBeginning: true when the page reaches seq 1,
+// i.e. there are no older messages to page back to. To walk backwards through a
+// thread, pass the oldest seq of the previous page as the next `before`.
+func (d *Minder) GetThreadPage(
+	m MetaContext,
+	team *proto.FQTeamParsed,
+	appID proto.RTAppID,
+	channel lcl.RTChannelSpecifier,
+	before proto.RTMsgSeq,
+	num uint,
+) (
+	[]ThreadMessage,
+	bool,
+	error,
+) {
+	if num == 0 {
+		num = 128
+	}
+
+	// before==0: start from the live head.
+	if before == 0 {
+		msgs, err := d.GetThreadRecentMsgs(m, team, appID, channel, num)
+		if err != nil {
+			return nil, false, err
+		}
+		atBeginning := len(msgs) == 0 || core.Last(msgs).Seq <= 1
+		return msgs, atBeginning, nil
+	}
+
+	// Page backwards, newest-first, over the inclusive seq window [lo, hi].
+	// `before` is exclusive, so the window's top is hi = before-1. Bookends are
+	// inclusive, so [lo, hi] holds exactly hi-lo+1 messages; with seqs contiguous
+	// from 1 we size it to `num` (lo = hi-num+1, clamped at 1) and know we're at
+	// the beginning once the window reaches seq 1.
+	hi := int(before) - 1
+	if hi < 1 {
+		return nil, true, nil
+	}
+	lo := hi - int(num) + 1
+	if lo < 1 {
+		lo = 1
+	}
+	atBeginning := lo <= 1
+
+	// Inclusive bookends: start=hi (newest), end=lo (oldest) ⇒ descending page.
+	// hi==lo (a single trailing message) is fine -- bookends are inclusive.
+	msgs, _, err := d.GetThreadBookended(m, team, appID, channel,
+		proto.RTMsgSeq(hi), proto.RTMsgSeq(lo))
+	if err != nil {
+		return nil, false, err
+	}
+	return msgs, atBeginning, nil
+}
+
+// GetThreadView fetches a page (see GetThreadPage) and returns it as a decrypted,
+// app-layer RTThreadView: message bodies plus sender display names resolved from
+// their UIDs. Name resolution is team-mediated (closed viewership only lets
+// co-members load each other through the shared team) and best-effort -- a sender
+// that can't be loaded simply has a nil name rather than failing the read.
+func (d *Minder) GetThreadView(
+	m MetaContext,
+	team *proto.FQTeamParsed,
+	appID proto.RTAppID,
+	channel lcl.RTChannelSpecifier,
+	before proto.RTMsgSeq,
+	num uint,
+) (
+	*lcl.RTThreadView,
+	error,
+) {
+	msgs, atBeginning, err := d.GetThreadPage(m, team, appID, channel, before, num)
+	if err != nil {
+		return nil, err
+	}
+	tok, err := d.TeamViewToken(m, team)
+	if err != nil {
+		return nil, err
+	}
+	names := d.ResolveSenderNames(m, tok, msgs)
+
+	ret := lcl.RTThreadView{AtBeginning: atBeginning}
+	for i := range msgs {
+		ret.Msgs = append(ret.Msgs, threadMessageToView(&msgs[i], names))
+	}
+	return &ret, nil
+}
+
+// threadMessageToView converts a decrypted ThreadMessage to the app-layer
+// RTMsgView, attaching the sender's display name from names if resolved.
+func threadMessageToView(
+	msg *ThreadMessage,
+	names map[proto.UID]proto.NameUtf8,
+) lcl.RTMsgView {
+	ret := lcl.RTMsgView{
+		Seq:        msg.Seq,
+		MsgID:      msg.MsgID,
+		PrevID:     msg.PrevID,
+		PrevSeq:    msg.PrevSeq,
+		Typ:        msg.Typ,
+		Sender:     msg.Sender,
+		SentAtTime: msg.SentAtTime,
+		InsertTime: msg.InsertTime,
+		Body:       msg.Body,
+	}
+	if msg.Sender != nil && msg.Sender.IsUser() {
+		if uid, err := msg.Sender.UID(); err == nil {
+			if nm, ok := names[uid]; ok {
+				ret.SenderName = &nm
+			}
+		}
+	}
+	return ret
+}
+
 // Get the num most recent messages that we don't already have.
 func (d *Minder) GetThreadRecentMsgs(
 	m MetaContext,
 	team *proto.FQTeamParsed,
 	appID proto.RTAppID,
-	channelName proto.RTChannelName,
-	klass *proto.RTChannelClass,
+	channel lcl.RTChannelSpecifier,
 	num uint,
 ) (
 	[]ThreadMessage,
@@ -1206,7 +1504,7 @@ func (d *Minder) GetThreadRecentMsgs(
 		num = 128
 	}
 	inc := -1
-	rtp, ch, cli, err := d.initReq(m, team, appID, channelName, klass)
+	rtp, ch, cli, err := d.initReq(m, team, appID, channel)
 	if err != nil {
 		return nil, err
 	}
@@ -1460,8 +1758,7 @@ func (d *Minder) GetMsgs(
 	m MetaContext,
 	team *proto.FQTeamParsed,
 	appID proto.RTAppID,
-	channelName proto.RTChannelName,
-	klass *proto.RTChannelClass,
+	channel lcl.RTChannelSpecifier,
 	seqs []proto.RTMsgSeq,
 ) (
 	[]ThreadMessage,
@@ -1475,7 +1772,7 @@ func (d *Minder) GetMsgs(
 	if err != nil {
 		return nil, err
 	}
-	ch, err := d.resolveChannel(m, rtp, appID, channelName, klass)
+	ch, err := d.resolveChannel(m, rtp, appID, channel)
 	if err != nil {
 		return nil, err
 	}

--- a/integration-tests/cli/rt_test.go
+++ b/integration-tests/cli/rt_test.go
@@ -4,11 +4,13 @@
 package cli
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/team"
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/stretchr/testify/require"
@@ -69,4 +71,422 @@ func TestRTChannelMakeAndList(t *testing.T) {
 	require.Contains(t, out, "#general")
 	require.Contains(t, out, "#foo")
 	require.Contains(t, out, "#hotels")
+}
+
+// TestRTSendAndRead exercises the `rt send` / `rt read` CLI for a single user:
+// send a few messages into a channel, read them back (newest-first), and check
+// that the agent resolved the sender's UID to a username (the sender here is the
+// reader themselves, loaded via the team).
+func TestRTSendAndRead(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	b := bob.agent
+	defer b.stop(t)
+
+	merklePoke(t)
+	merklePoke(t)
+
+	tm := "t-" + strings.ToLower(fsRandomString(t, 8))
+	var teamRes lcl.TeamCreateRes
+	b.runCmdToJSON(t, &teamRes, "team", "create", tm)
+	merklePoke(t)
+
+	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "foo", "--description", "the foo channel")
+
+	bodies := []string{"hello world", "second message", "a third one"}
+	for _, body := range bodies {
+		b.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "foo", body)
+	}
+
+	var thread lcl.RTThreadView
+	b.runCmdToJSON(t, &thread, "rt", "read", "-t", tm, "--channel", "foo")
+	require.Len(t, thread.Msgs, len(bodies))
+
+	// GetThreadRecentMsgs returns newest-first.
+	for i, body := range bodies {
+		msg := thread.Msgs[len(bodies)-1-i]
+		require.Equal(t, body, string(msg.Body))
+		require.Equal(t, proto.RTMsgType_Basic, msg.Typ)
+		require.NotNil(t, msg.Sender)
+		require.NotNil(t, msg.SenderName)
+		require.Equal(t, bob.username, *msg.SenderName)
+	}
+
+	// Sending to a non-existent channel should fail.
+	err := b.runCmdErr(nil, "rt", "send", "-t", tm, "--channel", "nope", "lost message")
+	require.Error(t, err)
+}
+
+// TestRTSendAndReadCrossMember verifies sender-name resolution across two
+// distinct members of a (closed-viewership) team: each reads the other's
+// message and sees the other's username, which only works if the agent loads
+// the sender mediated through the shared team (AsLocalTeam), since closed
+// viewership forbids direct peer user loads.
+func TestRTSendAndReadCrossMember(t *testing.T) {
+	x := newTestAgent(t)
+	x.runAgent(t)
+	defer x.stop(t)
+
+	stopper := runMerkleActivePoker(t)
+	defer stopper()
+
+	newUserWithAgentAtVHost(t, x, 0)
+	merklePoke(t)
+	merklePoke(t)
+	xName := getActiveUser(t, x).Info.Username.NameUtf8
+
+	tm := "t-" + strings.ToLower(fsRandomString(t, 8))
+	var teamRes lcl.TeamCreateRes
+	x.runCmdToJSON(t, &teamRes, "team", "create", tm)
+	merklePoke(t)
+
+	// Create a member-readable channel (read/write at the default member role)
+	// so an ordinary member can read and write it.
+	x.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "foo", "--description", "the foo channel",
+		"--read-role", "m/0", "--write-role", "m/0")
+
+	// Invite a second user y and admit them as an ordinary member.
+	var invite proto.TeamInvite
+	x.runCmdToJSON(t, &invite, "team", "invite", tm)
+	inviteStr, err := team.ExportTeamInvite(invite)
+	require.NoError(t, err)
+
+	y := newTestAgent(t)
+	y.runAgent(t)
+	defer y.stop(t)
+	newUserWithAgentAtVHost(t, y, 0)
+	merklePoke(t)
+	merklePoke(t)
+	yName := getActiveUser(t, y).Info.Username.NameUtf8
+
+	y.runCmd(t, nil, "team", "accept", inviteStr)
+	var inb lcl.TeamInbox
+	x.runCmdToJSON(t, &inb, "team", "inbox", tm)
+	require.Equal(t, 1, len(inb.Rows))
+	x.runCmd(t, nil, "team", "admit", tm, string(inb.Rows[0].Tok.String())+"/m/0")
+	merklePoke(t)
+
+	// x sends; y reads and should see x's name.
+	x.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "foo", "hello from x")
+
+	var thread lcl.RTThreadView
+	y.runCmdToJSON(t, &thread, "rt", "read", "-t", tm, "--channel", "foo")
+	require.Len(t, thread.Msgs, 1)
+	require.Equal(t, "hello from x", string(thread.Msgs[0].Body))
+	require.NotNil(t, thread.Msgs[0].SenderName)
+	require.Equal(t, xName, *thread.Msgs[0].SenderName)
+
+	// y sends; x reads and should see both messages with names resolved for
+	// each distinct sender.
+	y.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "foo", "hello back from y")
+
+	x.runCmdToJSON(t, &thread, "rt", "read", "-t", tm, "--channel", "foo")
+	require.Len(t, thread.Msgs, 2)
+	// newest-first
+	require.Equal(t, "hello back from y", string(thread.Msgs[0].Body))
+	require.NotNil(t, thread.Msgs[0].SenderName)
+	require.Equal(t, yName, *thread.Msgs[0].SenderName)
+	require.Equal(t, "hello from x", string(thread.Msgs[1].Body))
+	require.NotNil(t, thread.Msgs[1].SenderName)
+	require.Equal(t, xName, *thread.Msgs[1].SenderName)
+}
+
+// TestRTChannelGeneralNameReserved checks that the "general" name is reserved
+// for the default (empty-name) channel and can't be claimed explicitly. The
+// minder rejects it case-insensitively; a leading '#' is stripped by the CLI
+// before the check, so "#general" is rejected the same way.
+func TestRTChannelGeneralNameReserved(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	b := bob.agent
+	defer b.stop(t)
+
+	merklePoke(t)
+	merklePoke(t)
+
+	tm := "t-" + strings.ToLower(fsRandomString(t, 8))
+	var teamRes lcl.TeamCreateRes
+	b.runCmdToJSON(t, &teamRes, "team", "create", tm)
+	merklePoke(t)
+
+	// "general", "General" (case-folded), and "#general" ('#' stripped) are all
+	// rejected as the reserved default-channel name.
+	for _, nm := range []string{"general", "General", "#general"} {
+		err := b.runCmdErr(nil, "rt", "new-channel", "-t", tm, "--name", nm)
+		require.Error(t, err, "name %q", nm)
+		require.Equal(t, core.RTGenericError("cannot make channel named #general"), err, "name %q", nm)
+	}
+
+	// None of the rejected attempts created anything.
+	var set lcl.RTChannelSetForTeam
+	b.runCmdToJSON(t, &set, "rt", "list-channels", "-t", tm)
+	require.Len(t, set.Channels, 0)
+}
+
+// TestRTChannelNameNoHashPrefix verifies the '#' is purely a display
+// convention. The CLI strips a leading '#' from --name, so "#foo" creates a
+// channel stored as "foo"; the text renderer then re-adds exactly one '#',
+// yielding "#foo" and never "##foo".
+func TestRTChannelNameNoHashPrefix(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	b := bob.agent
+	defer b.stop(t)
+
+	merklePoke(t)
+	merklePoke(t)
+
+	tm := "t-" + strings.ToLower(fsRandomString(t, 8))
+	var teamRes lcl.TeamCreateRes
+	b.runCmdToJSON(t, &teamRes, "team", "create", tm)
+	merklePoke(t)
+
+	// Create with a leading '#'; the '#' is stripped before parsing.
+	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "#foo")
+
+	// The stored name is "foo", with no leading '#'.
+	var set lcl.RTChannelSetForTeam
+	b.runCmdToJSON(t, &set, "rt", "list-channels", "-t", tm)
+	require.Len(t, set.Channels, 1)
+	require.Equal(t, proto.RTChannelName("foo"), set.Channels[0].Name)
+
+	// The text renderer adds exactly one '#': "#foo", never "##foo".
+	var terminalUI terminalUI
+	uis := libclient.UIs{
+		Terminal: &terminalUI,
+	}
+	err := b.runCmdErrWithUIs(uis, "rt", "list-channels", "-t", tm)
+	require.NoError(t, err)
+	out := terminalUI.String()
+	require.Contains(t, out, "#foo")
+	require.NotContains(t, out, "##foo")
+
+	// Re-creating it without the '#' collides with the stripped original.
+	err = b.runCmdErr(nil, "rt", "new-channel", "-t", tm, "--name", "foo")
+	require.Error(t, err)
+	require.Equal(t, core.RTChannelExistsError{}, err)
+}
+
+// TestRTChannelNameCaseFoldCollision verifies channel names are case-folded:
+// "bar" and "Bar" both normalize to "bar", so within the same class the second
+// create collides with the first.
+func TestRTChannelNameCaseFoldCollision(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	b := bob.agent
+	defer b.stop(t)
+
+	merklePoke(t)
+	merklePoke(t)
+
+	tm := "t-" + strings.ToLower(fsRandomString(t, 8))
+	var teamRes lcl.TeamCreateRes
+	b.runCmdToJSON(t, &teamRes, "team", "create", tm)
+	merklePoke(t)
+
+	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "bar")
+
+	// "Bar" normalizes to "bar" -- same name, same (admin) class -> collision.
+	err := b.runCmdErr(nil, "rt", "new-channel", "-t", tm, "--name", "Bar")
+	require.Error(t, err)
+	require.Equal(t, core.RTChannelExistsError{}, err)
+
+	// Only the one channel exists, stored lowercased.
+	var set lcl.RTChannelSetForTeam
+	b.runCmdToJSON(t, &set, "rt", "list-channels", "-t", tm)
+	require.Len(t, set.Channels, 1)
+	require.Equal(t, proto.RTChannelName("bar"), set.Channels[0].Name)
+}
+
+// TestRTChannelClassFlag exercises the --channel-class flag on `rt send` / `rt
+// read`. A name may live in two classes at once (an admin "dup" and a
+// bottom/member "dup"); without a class the name is ambiguous, and the flag
+// ("a"/"admin" vs "d"/"default"/"bottom") picks one. An unknown class is a
+// bad-args error.
+func TestRTChannelClassFlag(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	b := bob.agent
+	defer b.stop(t)
+
+	merklePoke(t)
+	merklePoke(t)
+
+	tm := "t-" + strings.ToLower(fsRandomString(t, 8))
+	var teamRes lcl.TeamCreateRes
+	b.runCmdToJSON(t, &teamRes, "team", "create", tm)
+	merklePoke(t)
+
+	// "dup" in two classes: no roles -> admin class; member roles -> bottom class.
+	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "dup")
+	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "dup",
+		"--read-role", "m/0", "--write-role", "m/0")
+
+	var set lcl.RTChannelSetForTeam
+	b.runCmdToJSON(t, &set, "rt", "list-channels", "-t", tm)
+	require.Len(t, set.Channels, 2)
+
+	// Addressing "dup" with no class is ambiguous.
+	err := b.runCmdErr(nil, "rt", "send", "-t", tm, "--channel", "dup", "no class")
+	require.Error(t, err)
+	require.Equal(t, core.RTAmbiguousChannelError{Name: "dup"}, err)
+
+	// The flag disambiguates: short and long forms of each class.
+	b.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "dup", "--channel-class", "a", "to admin")
+	b.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "dup", "--channel-class", "d", "to bottom")
+
+	// Each class's channel holds only its own message.
+	var adminThread lcl.RTThreadView
+	b.runCmdToJSON(t, &adminThread, "rt", "read", "-t", tm, "--channel", "dup", "--channel-class", "admin")
+	require.Len(t, adminThread.Msgs, 1)
+	require.Equal(t, "to admin", string(adminThread.Msgs[0].Body))
+
+	var bottomThread lcl.RTThreadView
+	b.runCmdToJSON(t, &bottomThread, "rt", "read", "-t", tm, "--channel", "dup", "--channel-class", "bottom")
+	require.Len(t, bottomThread.Msgs, 1)
+	require.Equal(t, "to bottom", string(bottomThread.Msgs[0].Body))
+
+	// An unrecognized class is a bad-args error.
+	err = b.runCmdErr(nil, "rt", "send", "-t", tm, "--channel", "dup", "--channel-class", "bogus", "nope")
+	require.Error(t, err)
+	require.Equal(t, core.BadArgsError("bad channel class"), err)
+}
+
+// TestRTReadPaging walks backwards through a thread with `rt read --before`,
+// checking page contents, the atBeginning flag, and the single-message window at
+// the very top (which exercises GetThreadBookended's inclusive start==end path).
+func TestRTReadPaging(t *testing.T) {
+	bob := makeBobAndHisAgent(t)
+	b := bob.agent
+	defer b.stop(t)
+
+	merklePoke(t)
+	merklePoke(t)
+
+	tm := "t-" + strings.ToLower(fsRandomString(t, 8))
+	var teamRes lcl.TeamCreateRes
+	b.runCmdToJSON(t, &teamRes, "team", "create", tm)
+	merklePoke(t)
+
+	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "foo", "--description", "the foo channel")
+
+	const n = 5
+	for i := 1; i <= n; i++ {
+		b.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "foo", fmt.Sprintf("msg-%d", i))
+	}
+
+	// Pages come back newest-first.
+	read := func(num uint, before int) lcl.RTThreadView {
+		var page lcl.RTThreadView
+		b.runCmdToJSON(t, &page, "rt", "read", "-t", tm, "--channel", "foo",
+			"-n", fmt.Sprintf("%d", num), "--before", fmt.Sprintf("%d", before))
+		return page
+	}
+	requireSeqs := func(page lcl.RTThreadView, seqs ...int) {
+		require.Len(t, page.Msgs, len(seqs))
+		for i, s := range seqs {
+			require.Equal(t, proto.RTMsgSeq(s), page.Msgs[i].Seq)
+		}
+	}
+
+	// Most recent page of 2 -> seqs 5,4; more remains above.
+	page := read(2, 0)
+	requireSeqs(page, 5, 4)
+	require.False(t, page.AtBeginning)
+
+	// Page back before seq 4 -> seqs 3,2; still more above.
+	page = read(2, 4)
+	requireSeqs(page, 3, 2)
+	require.False(t, page.AtBeginning)
+
+	// Page back before seq 2 -> only seq 1 (single-message window), at beginning.
+	page = read(2, 2)
+	requireSeqs(page, 1)
+	require.True(t, page.AtBeginning)
+
+	// Nothing before seq 1.
+	page = read(2, 1)
+	requireSeqs(page)
+	require.True(t, page.AtBeginning)
+}
+
+// TestRTUnreadableChannelHiddenFromInbox checks the server's read-role gating of
+// the channel list within the member tier. A bottom-class channel is sealed at
+// member viz 5; a member at viz 0 still receives it (the class gate admits all
+// members to bottom-class channels) but is below the read role, so its
+// description/last-message are withheld and it's flagged unreadable and hidden
+// from the inbox. Its name is still returned, though, so client-side collision
+// detection reserves it -- the lower member can't create a same-named channel.
+//
+// The team only has a key at viz 5 because a member actually sits there: an
+// unoccupied viz level has no provisioned key (see lib/team keyAtLevel), so we
+// admit z at m/5 before sealing the channel to it.
+func TestRTUnreadableChannelHiddenFromInbox(t *testing.T) {
+	x := newTestAgent(t)
+	x.runAgent(t)
+	defer x.stop(t)
+
+	stopper := runMerkleActivePoker(t)
+	defer stopper()
+
+	newUserWithAgentAtVHost(t, x, 0)
+	merklePoke(t)
+	merklePoke(t)
+
+	tm := "t-" + strings.ToLower(fsRandomString(t, 8))
+	var teamRes lcl.TeamCreateRes
+	x.runCmdToJSON(t, &teamRes, "team", "create", tm)
+	merklePoke(t)
+
+	var invite proto.TeamInvite
+	x.runCmdToJSON(t, &invite, "team", "invite", tm)
+	inviteStr, err := team.ExportTeamInvite(invite)
+	require.NoError(t, err)
+
+	// admit brings up a fresh user/agent, accepts the (multi-use) invite, and has
+	// x admit them at the given role string (e.g. "m/5").
+	admit := func(role string) *testAgent {
+		u := newTestAgent(t)
+		u.runAgent(t)
+		newUserWithAgentAtVHost(t, u, 0)
+		merklePoke(t)
+		merklePoke(t)
+		u.runCmd(t, nil, "team", "accept", inviteStr)
+		var inb lcl.TeamInbox
+		x.runCmdToJSON(t, &inb, "team", "inbox", tm)
+		require.Equal(t, 1, len(inb.Rows))
+		x.runCmd(t, nil, "team", "admit", tm, string(inb.Rows[0].Tok.String())+"/"+role)
+		merklePoke(t)
+		return u
+	}
+
+	// z sits at member viz 5; admitting them provisions the team's m/5 key, which
+	// we then seal the channel to.
+	z := admit("m/5")
+	defer z.stop(t)
+
+	// A bottom-class channel readable only at member viz 5.
+	x.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "secret",
+		"--description", "eyes only", "--read-role", "m/5", "--write-role", "m/5")
+
+	// y sits at viz 0, below the channel's read role.
+	y := admit("m/0")
+	defer y.stop(t)
+
+	// x (owner) and z (m/5) are at or above the read role and see the channel.
+	var xset lcl.RTChannelSetForTeam
+	x.runCmdToJSON(t, &xset, "rt", "list-channels", "-t", tm)
+	require.Len(t, xset.Channels, 1)
+	require.Equal(t, proto.RTChannelName("secret"), xset.Channels[0].Name)
+
+	var zset lcl.RTChannelSetForTeam
+	z.runCmdToJSON(t, &zset, "rt", "list-channels", "-t", tm)
+	require.Len(t, zset.Channels, 1)
+	require.Equal(t, proto.RTChannelName("secret"), zset.Channels[0].Name)
+
+	// y (m/0, below the read role) does not see it in the inbox.
+	var yset lcl.RTChannelSetForTeam
+	y.runCmdToJSON(t, &yset, "rt", "list-channels", "-t", tm)
+	require.Len(t, yset.Channels, 0)
+
+	// ...but the name is still reserved: y can't create a colliding bottom-class
+	// "secret" channel, because collision detection still sees it.
+	err = y.runCmdErr(nil, "rt", "new-channel", "-t", tm, "--name", "secret")
+	require.Error(t, err)
+	require.Equal(t, core.RTChannelExistsError{}, err)
 }

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/foks-proj/go-foks/client/librt"
 	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
 	"github.com/stretchr/testify/require"
@@ -169,6 +170,87 @@ func TestRTMinderMakeChannelSimple(t *testing.T) {
 	assertChannel(7, proto.RTChannelClass_Bottom, "zd")
 }
 
+// TestRTMinderGeneralNameReserved checks the minder reserves the "general"
+// name for the default (empty-name) channel: an explicit "general" is rejected
+// case-insensitively, while the empty name (which *is* "#general") still works.
+func TestRTMinderGeneralNameReserved(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+	tm := tew.makeTeamForOwner(t, bluey)
+
+	mb := librt.NewMetaContext(tew.NewClientMetaContextWithEracer(t, bluey))
+	minder := librt.NewMinder(mb.G().ActiveUser())
+	fqt := tm.ToFQTeamParsed(t)
+
+	// An explicit "general" is rejected, and the check normalizes case, so
+	// "General"/"GENERAL" are too.
+	reserved := core.RTGenericError("cannot make channel named #general")
+	for _, nm := range []proto.RTChannelName{"general", "General", "GENERAL"} {
+		_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, nm, "", proto.RolePairOpt{})
+		require.Equal(t, reserved, err, "name %q", nm)
+	}
+
+	// The default channel (empty name) -- the real "#general" -- is still fine.
+	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "", "the real general", proto.RolePairOpt{})
+	require.NoError(t, err)
+
+	// None of the rejected attempts created anything; only the default exists.
+	lst, err := minder.ListAllChannelsForTeam(mb, fqt, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Len(t, lst.Channels, 1)
+	require.Equal(t, proto.RTChannelName(""), lst.Channels[0].Name)
+}
+
+// TestRTMinderChannelNameCaseFoldCollision checks the minder's collision
+// detection normalizes case: "bar" and "Bar" are the same name within the same
+// class, so the second create collides. (Companion to the same-case collisions
+// in TestRTMinderMakeChannelSimple.)
+func TestRTMinderChannelNameCaseFoldCollision(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+	tm := tew.makeTeamForOwner(t, bluey)
+
+	mb := librt.NewMetaContext(tew.NewClientMetaContextWithEracer(t, bluey))
+	minder := librt.NewMinder(mb.G().ActiveUser())
+	fqt := tm.ToFQTeamParsed(t)
+
+	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "bar", "the bar channel", proto.RolePairOpt{})
+	require.NoError(t, err)
+
+	// "Bar" normalizes to "bar" -- same name, same (admin) class -> collision.
+	_, err = minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "Bar", "the BAR channel", proto.RolePairOpt{})
+	require.Equal(t, core.RTChannelExistsError{}, err)
+
+	// Only the first channel exists, stored as it was passed.
+	lst, err := minder.ListAllChannelsForTeam(mb, fqt, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Len(t, lst.Channels, 1)
+	require.Equal(t, proto.RTChannelName("bar"), lst.Channels[0].Name)
+}
+
+func makeChannelSpecifier(nm proto.RTChannelName) lcl.RTChannelSpecifier {
+	return lcl.NewRTChannelSpecifierWithName(
+		lcl.RTChannelNameAndClass{
+			Name: nm,
+		},
+	)
+}
+
+func makeChannelSpecifierWithString(s string) lcl.RTChannelSpecifier {
+	return makeChannelSpecifier(proto.RTChannelName(s))
+}
+
+func makeChannelSpecifierWithClass(s string, kls proto.RTChannelClass) lcl.RTChannelSpecifier {
+	return lcl.NewRTChannelSpecifierWithName(
+		lcl.RTChannelNameAndClass{
+			Name:  proto.RTChannelName(s),
+			Klass: kls,
+		},
+	)
+}
+
 func TestRTMinderSendAndGetThread(t *testing.T) {
 	tew := testEnvBeta(t)
 	bluey := tew.NewTestUser(t)
@@ -186,7 +268,8 @@ func TestRTMinderSendAndGetThread(t *testing.T) {
 	bodies := []string{"hello world", "second message", "a third one"}
 	var lastSeq proto.RTMsgSeq
 	for _, b := range bodies {
-		res, err := minder.Send(mb, fqt, proto.RTAppID_Chat, "foo", nil, []byte(b))
+		res, err := minder.Send(mb, fqt, proto.RTAppID_Chat,
+			makeChannelSpecifierWithString("foo"), []byte(b))
 		require.NoError(t, err)
 		require.NotNil(t, res)
 		require.Equal(t, lastSeq+1, res.Seq)
@@ -195,8 +278,8 @@ func TestRTMinderSendAndGetThread(t *testing.T) {
 
 	// Read them all back; they should decrypt and come in seq order. We reached
 	// the far edge (end == lastSeq) exactly, so this is not a "final" short read.
-	msgs, final, err := minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat, "foo",
-		nil, 1, lastSeq)
+	msgs, final, err := minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("foo"), 1, lastSeq)
 	require.NoError(t, err)
 	require.False(t, final)
 	require.Len(t, msgs, len(bodies))
@@ -210,8 +293,9 @@ func TestRTMinderSendAndGetThread(t *testing.T) {
 
 	// Reading a later sub-range should yield only the tail (served from cache,
 	// since the read above populated it).
-	msgs, final, err = minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat, "foo",
-		nil, 2, lastSeq)
+	msgs, final, err = minder.GetThreadBookended(mb, fqt,
+		proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("foo"), 2, lastSeq)
 	require.NoError(t, err)
 	require.False(t, final)
 	require.Len(t, msgs, 2)
@@ -219,7 +303,9 @@ func TestRTMinderSendAndGetThread(t *testing.T) {
 	require.Equal(t, "second message", string(msgs[0].Body))
 
 	// Sending to a non-existent channel fails.
-	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat, "nosuchchannel", nil, []byte("hi"))
+	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("nosuchchannel"),
+		[]byte("hi"))
 	require.Error(t, err)
 }
 
@@ -242,14 +328,17 @@ func TestRTMinderGetMsgsBySeq(t *testing.T) {
 
 	bodies := []string{"one", "two", "three", "four", "five"}
 	for _, b := range bodies {
-		_, err := minder.Send(mb, fqt, proto.RTAppID_Chat, "foo", nil, []byte(b))
+		_, err := minder.Send(mb, fqt, proto.RTAppID_Chat,
+			makeChannelSpecifierWithString("foo"),
+			[]byte(b))
 		require.NoError(t, err)
 	}
 
 	// Ask for a non-contiguous subset (2 and 4) plus a seq that doesn't exist
 	// (99). We should get exactly seqs 2 and 4 back, each decrypting correctly;
 	// the missing seq is simply absent.
-	msgs, err := minder.GetMsgs(mb, fqt, proto.RTAppID_Chat, "foo", nil,
+	msgs, err := minder.GetMsgs(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("foo"),
 		[]proto.RTMsgSeq{2, 4, 99})
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
@@ -264,12 +353,14 @@ func TestRTMinderGetMsgsBySeq(t *testing.T) {
 	require.Equal(t, "four", bySeq[4])
 
 	// An empty request yields nothing, not an error.
-	msgs, err = minder.GetMsgs(mb, fqt, proto.RTAppID_Chat, "foo", nil, nil)
+	msgs, err = minder.GetMsgs(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("foo"), nil)
 	require.NoError(t, err)
 	require.Len(t, msgs, 0)
 
 	// Requesting only missing seqs yields an empty result.
-	msgs, err = minder.GetMsgs(mb, fqt, proto.RTAppID_Chat, "foo", nil,
+	msgs, err = minder.GetMsgs(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("foo"),
 		[]proto.RTMsgSeq{100, 101})
 	require.NoError(t, err)
 	require.Len(t, msgs, 0)
@@ -312,11 +403,14 @@ func TestRTMinderGetThreadBookendedHoleFilling(t *testing.T) {
 			proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.DefaultRole})
 		require.NoError(t, err)
 		for i := 1; i <= n; i++ {
-			res, err := sender.Send(mb, fqt, proto.RTAppID_Chat, ch, nil, []byte(fmt.Sprintf("msg-%d", i)))
+			res, err := sender.Send(mb, fqt, proto.RTAppID_Chat,
+				makeChannelSpecifier(ch),
+				[]byte(fmt.Sprintf("msg-%d", i)))
 			require.NoError(t, err)
 			require.Equal(t, proto.RTMsgSeq(i), res.Seq)
 		}
-		primed, err := receiver.GetMsgs(mc, fqt, proto.RTAppID_Chat, ch, nil,
+		primed, err := receiver.GetMsgs(mc, fqt, proto.RTAppID_Chat,
+			makeChannelSpecifier(ch),
 			[]proto.RTMsgSeq{3, 5})
 		require.NoError(t, err)
 		require.Len(t, primed, 2)
@@ -335,16 +429,19 @@ func TestRTMinderGetThreadBookendedHoleFilling(t *testing.T) {
 
 		// coco's cache holds {3,5}. The server must supply leading [1,2], trailing
 		// [6,7], and the hole at 4; all of it merges into one ascending run.
-		msgs, final, err := receiver.GetThreadBookended(mc, fqt, proto.RTAppID_Chat, "asc",
-			nil, 1, n)
+		msgs, final, err := receiver.GetThreadBookended(mc, fqt,
+			proto.RTAppID_Chat,
+			makeChannelSpecifierWithString("asc"), 1, n)
 		require.NoError(t, err)
 		require.False(t, final) // reached end (== n) exactly
 		check(t, msgs, 1, 2, 3, 4, 5, 6, 7)
 
 		// The read above cached everything, so the second read is a pure cache
 		// hit (no holes, no bookends).
-		msgs, _, err = receiver.GetThreadBookended(mc, fqt, proto.RTAppID_Chat, "asc",
-			nil, 1, n)
+		msgs, _, err = receiver.GetThreadBookended(mc, fqt,
+			proto.RTAppID_Chat,
+			makeChannelSpecifierWithString("asc"),
+			1, n)
 		require.NoError(t, err)
 		check(t, msgs, 1, 2, 3, 4, 5, 6, 7)
 	})
@@ -354,8 +451,10 @@ func TestRTMinderGetThreadBookendedHoleFilling(t *testing.T) {
 
 		// Same sparse cache {3,5}, but walk 7..1: leading bookend [7,6], trailing
 		// [2,1], hole 4, merged newest-first.
-		msgs, final, err := receiver.GetThreadBookended(mc, fqt, proto.RTAppID_Chat, "desc",
-			nil, n, 1)
+		msgs, final, err := receiver.GetThreadBookended(mc, fqt,
+			proto.RTAppID_Chat,
+			makeChannelSpecifierWithString("desc"),
+			n, 1)
 		require.NoError(t, err)
 		require.False(t, final) // reached end (== 1) exactly
 		check(t, msgs, 7, 6, 5, 4, 3, 2, 1)
@@ -382,14 +481,17 @@ func TestRTMinderSenderReadsAreCacheHits(t *testing.T) {
 
 	const n = 5
 	for i := 1; i <= n; i++ {
-		res, err := minder.Send(mb, fqt, proto.RTAppID_Chat, "foo", nil, []byte(fmt.Sprintf("msg-%d", i)))
+		res, err := minder.Send(mb, fqt, proto.RTAppID_Chat,
+			makeChannelSpecifierWithString("foo"),
+			[]byte(fmt.Sprintf("msg-%d", i)))
 		require.NoError(t, err)
 		require.Equal(t, proto.RTMsgSeq(i), res.Seq)
 	}
 
 	// Reading back the full range it just sent is a pure cache hit.
 	before := minder.Metrics()
-	msgs, final, err := minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat, "foo", nil, 1, n)
+	msgs, final, err := minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("foo"), 1, n)
 	require.NoError(t, err)
 	require.False(t, final)
 	require.Len(t, msgs, n)
@@ -403,7 +505,8 @@ func TestRTMinderSenderReadsAreCacheHits(t *testing.T) {
 	// Contrast: asking past the cached range forces a (trailing) server fetch, so
 	// the counter must advance by exactly one -- proving it tracks round-trips.
 	before = minder.Metrics()
-	_, _, err = minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat, "foo", nil, 1, n+1)
+	_, _, err = minder.GetThreadBookended(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("foo"), 1, n+1)
 	require.NoError(t, err)
 	require.Equal(t, before.ServerThreadReads+1, minder.Metrics().ServerThreadReads,
 		"a read past the cached range must issue exactly one server RtGetThread")
@@ -438,7 +541,8 @@ func TestRTMinderPrevPointers(t *testing.T) {
 
 	const n = 4
 	for i := 1; i <= n; i++ {
-		res, err := sender.Send(mb, fqt, proto.RTAppID_Chat, "foo", nil, []byte(fmt.Sprintf("msg-%d", i)))
+		res, err := sender.Send(mb, fqt, proto.RTAppID_Chat,
+			makeChannelSpecifierWithString("foo"), []byte(fmt.Sprintf("msg-%d", i)))
 		require.NoError(t, err)
 		require.Equal(t, proto.RTMsgSeq(i), res.Seq)
 	}
@@ -463,12 +567,14 @@ func TestRTMinderPrevPointers(t *testing.T) {
 
 	// Receiver fetches from the server (cold cache) and must see the chain the
 	// sender stamped on each message.
-	got, _, err := receiver.GetThreadBookended(mc, fqt, proto.RTAppID_Chat, "foo", nil, 1, n)
+	got, _, err := receiver.GetThreadBookended(mc, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("foo"), 1, n)
 	require.NoError(t, err)
 	assertChain(t, "receiver", got)
 
 	// The sender's own read (served from its on-send cache) agrees.
-	got, _, err = sender.GetThreadBookended(mb, fqt, proto.RTAppID_Chat, "foo", nil, 1, n)
+	got, _, err = sender.GetThreadBookended(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("foo"), 1, n)
 	require.NoError(t, err)
 	assertChain(t, "sender", got)
 }
@@ -503,7 +609,8 @@ func TestRTMinderEvilServerOrdering(t *testing.T) {
 
 	const n = 4
 	for i := 1; i <= n; i++ {
-		_, err := sender.Send(mb, fqt, proto.RTAppID_Chat, "foo", nil, []byte(fmt.Sprintf("msg-%d", i)))
+		_, err := sender.Send(mb, fqt, proto.RTAppID_Chat,
+			makeChannelSpecifierWithString("foo"), []byte(fmt.Sprintf("msg-%d", i)))
 		require.NoError(t, err)
 	}
 	allSeqs := []proto.RTMsgSeq{1, 2, 3, 4}
@@ -513,7 +620,9 @@ func TestRTMinderEvilServerOrdering(t *testing.T) {
 	read := func(mut func(*rem.RTThreadPage)) ([]librt.ThreadMessage, error) {
 		recv := librt.NewMinder(mc.G().ActiveUser())
 		recv.SetTestHooks(&librt.MinderTestHooks{MutateReadRes: mut})
-		return recv.GetMsgs(mc, fqt, proto.RTAppID_Chat, "foo", nil, allSeqs)
+		return recv.GetMsgs(mc, fqt, proto.RTAppID_Chat,
+			makeChannelSpecifierWithString("foo"),
+			allSeqs)
 	}
 	requireOrderErr := func(t *testing.T, err error) {
 		require.Error(t, err)
@@ -600,7 +709,9 @@ func TestRTMinderEvilServerRecentsHoleFill(t *testing.T) {
 			proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.DefaultRole})
 		require.NoError(t, err)
 		for i := 1; i <= n; i++ {
-			_, err := sender.Send(mb, fqt, proto.RTAppID_Chat, ch, nil, []byte(fmt.Sprintf("msg-%d", i)))
+			_, err := sender.Send(mb, fqt, proto.RTAppID_Chat,
+				makeChannelSpecifier(ch),
+				[]byte(fmt.Sprintf("msg-%d", i)))
 			require.NoError(t, err)
 		}
 	}
@@ -623,7 +734,8 @@ func TestRTMinderEvilServerRecentsHoleFill(t *testing.T) {
 			},
 			MutateReadRes: fillerMut,
 		})
-		return recv.GetThreadRecentMsgs(mc, fqt, proto.RTAppID_Chat, ch, nil, 0)
+		return recv.GetThreadRecentMsgs(mc, fqt, proto.RTAppID_Chat,
+			makeChannelSpecifier(ch), 0)
 	}
 
 	t.Run("tampered_filler", func(t *testing.T) {
@@ -667,7 +779,8 @@ func TestRTMinderEvilServerRecentsHoleFill(t *testing.T) {
 				}
 			},
 		})
-		_, err := recv.GetThreadRecentMsgs(mc, fqt, proto.RTAppID_Chat, "bar", nil, 0)
+		_, err := recv.GetThreadRecentMsgs(mc, fqt, proto.RTAppID_Chat,
+			makeChannelSpecifier("bar"), 0)
 		requireOrderErr(t, err)
 	})
 }
@@ -718,22 +831,26 @@ func TestRTSendReadPermissions(t *testing.T) {
 	// --- write permission ---
 
 	// coco CAN write to the member-writable channel.
-	_, err = minderCoco.Send(mc, fqt, proto.RTAppID_Chat, "watercooler", nil, []byte("hi all"))
+	_, err = minderCoco.Send(mc, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("watercooler"), []byte("hi all"))
 	require.NoError(t, err)
 
 	// coco CANNOT write to the admin-writable channel, even though she can read it.
-	_, err = minderCoco.Send(mc, fqt, proto.RTAppID_Chat, "announce", nil, []byte("not an admin"))
+	_, err = minderCoco.Send(mc, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("announce"), []byte("not an admin"))
 	require.Equal(t, core.PermissionError("user role too low to send into channel"), err)
 
 	// the owner CAN write to the admin-writable channel.
-	_, err = minderBluey.Send(mb, fqt, proto.RTAppID_Chat, "announce", nil, []byte("official notice"))
+	_, err = minderBluey.Send(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("announce"), []byte("official notice"))
 	require.NoError(t, err)
 
 	// --- read permission ---
 
 	// coco CAN read the admin-writable (but member-readable) channel.
-	msgs, err := minderCoco.GetThreadRecentMsgs(mc, fqt, proto.RTAppID_Chat, "announce",
-		nil, 0)
+	msgs, err := minderCoco.GetThreadRecentMsgs(mc, fqt,
+		proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("announce"), 0)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	require.Equal(t, "official notice", string(msgs[0].Body))
@@ -746,8 +863,8 @@ func TestRTSendReadPermissions(t *testing.T) {
 	}
 
 	// ...and reading its thread fails: she can't resolve a channel she can't see.
-	_, err = minderCoco.GetThreadRecentMsgs(mc, fqt, proto.RTAppID_Chat, "brass",
-		nil, 0)
+	_, err = minderCoco.GetThreadRecentMsgs(mc, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("brass"), 0)
 	require.Equal(t, core.RTNotFoundError("channel 'brass'"), err)
 }
 
@@ -765,24 +882,27 @@ func TestRTSendEncryptionRole(t *testing.T) {
 	fqt := tm.ToFQTeamParsed(t)
 
 	// A bottom channel readable/writable by members.
-	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "general", "all hands",
+	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "", "all hands",
 		proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.DefaultRole})
 	require.NoError(t, err)
 
 	// Encrypting at the channel's read role (the default path) works.
-	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat, "general", nil, []byte("hi"))
+	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString(""), []byte("hi"))
 	require.NoError(t, err)
 
 	// bluey (owner) holds the owner key, so she *can* encrypt at OwnerRole, but
 	// the channel's read role is member, so the server must reject it.
-	_, err = minder.SendWithTestHooks(mb, fqt, proto.RTAppID_Chat, "general",
-		nil, []byte("wrong role"),
+	_, err = minder.SendWithTestHooks(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString(""),
+		[]byte("wrong role"),
 		&librt.SendTestHooks{EncryptRoleOverride: &proto.OwnerRole})
 	require.Equal(t, core.BadArgsError("message must be encrypted at the channel's read role"), err)
 
 	// The rejected message was not persisted: only the one good message remains.
-	msgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, "general",
-		nil, 0)
+	msgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString(""),
+		0)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	require.Equal(t, "hi", string(msgs[0].Body))
@@ -802,10 +922,10 @@ func TestRTChannelDisambiguation(t *testing.T) {
 	fqt := tm.ToFQTeamParsed(t)
 
 	// Two channels both named "general": one admin-class, one bottom-class.
-	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "general", "for admins",
+	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "", "for admins",
 		proto.RolePairOpt{Read: &proto.AdminRole})
 	require.NoError(t, err)
-	_, err = minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "general", "for everyone",
+	_, err = minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "", "for everyone",
 		proto.RolePairOpt{Read: &proto.DefaultRole})
 	require.NoError(t, err)
 
@@ -813,23 +933,29 @@ func TestRTChannelDisambiguation(t *testing.T) {
 	bottom := proto.RTChannelClass_Bottom
 
 	// Addressing by name alone can't choose between them.
-	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat, "general", nil, []byte("hi"))
-	require.Equal(t, core.RTAmbiguousChannelError{Name: "general"}, err)
-	_, err = minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, "general", nil, 0)
-	require.Equal(t, core.RTAmbiguousChannelError{Name: "general"}, err)
+	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString(""), []byte("hi"))
+	require.Equal(t, core.RTAmbiguousChannelError{Name: ""}, err)
+	_, err = minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithString(""), 0)
+	require.Equal(t, core.RTAmbiguousChannelError{Name: ""}, err)
 
 	// A class disambiguates, and each channel keeps its own thread.
-	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat, "general", &admin, []byte("admin msg"))
+	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithClass("", admin),
+		[]byte("admin msg"))
 	require.NoError(t, err)
-	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat, "general", &bottom, []byte("bottom msg"))
+	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat,
+		makeChannelSpecifierWithClass("", bottom),
+		[]byte("bottom msg"))
 	require.NoError(t, err)
 
-	adminMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, "general", &admin, 0)
+	adminMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, makeChannelSpecifierWithClass("", admin), 0)
 	require.NoError(t, err)
 	require.Len(t, adminMsgs, 1)
 	require.Equal(t, "admin msg", string(adminMsgs[0].Body))
 
-	bottomMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, "general", &bottom, 0)
+	bottomMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, makeChannelSpecifierWithClass("", bottom), 0)
 	require.NoError(t, err)
 	require.Len(t, bottomMsgs, 1)
 	require.Equal(t, "bottom msg", string(bottomMsgs[0].Body))

--- a/lib/core/errors.go
+++ b/lib/core/errors.go
@@ -1364,11 +1364,11 @@ func (r RTRaceError) Error() string {
 // but more than one channel (of different classes) shares that name. The caller
 // should retry with a channel class to disambiguate. Name is the ambiguous name.
 type RTAmbiguousChannelError struct {
-	Name string
+	Name proto.RTChannelName
 }
 
 func (r RTAmbiguousChannelError) Error() string {
-	return fmt.Sprintf("ambiguous channel name %q; specify a channel class", r.Name)
+	return fmt.Sprintf("ambiguous channel name %q; specify a channel class", r.Name.DecorateToString())
 }
 
 type RTNotFoundError string
@@ -1586,7 +1586,7 @@ func ErrorToStatus(e error) proto.Status {
 	case RTRaceError:
 		return proto.NewStatusWithRtRace(te.Which)
 	case RTAmbiguousChannelError:
-		return proto.NewStatusWithRtAmbiguousChannelError(te.Name)
+		return proto.NewStatusWithRtAmbiguousChannelError(string(te.Name))
 	case RTNotFoundError:
 		return proto.NewStatusWithRtNotFoundError(string(te))
 	case RTMsgOrderError:
@@ -2037,7 +2037,7 @@ func StatusToError(s proto.Status) error {
 	case proto.StatusCode_RT_RACE:
 		return RTRaceError{Which: s.RtRace()}
 	case proto.StatusCode_RT_AMBIGUOUS_CHANNEL_ERROR:
-		return RTAmbiguousChannelError{Name: s.RtAmbiguousChannelError()}
+		return RTAmbiguousChannelError{Name: proto.RTChannelName(s.RtAmbiguousChannelError())}
 	case proto.StatusCode_RT_NOT_FOUND_ERROR:
 		return RTNotFoundError(string(s.RtNotFoundError()))
 	case proto.StatusCode_RT_MSG_ORDER_ERROR:

--- a/proto-src/lcl/realtime.snowp
+++ b/proto-src/lcl/realtime.snowp
@@ -2,11 +2,28 @@
 
 go:import "github.com/foks-proj/go-foks/proto/lib" as lib;
 
+struct RTChannelNameAndClass {
+    name @0 : lib.RTChannelName;
+    klass @1: lib.RTChannelClass;
+}
+
+enum RTChannelSpecifierType {
+    None @0;
+    ID @1;
+    Name @2;
+}
+
+variant RTChannelSpecifier switch (t : RTChannelSpecifierType) {
+    case ID @1: lib.RTChannelID;
+    case Name @2: RTChannelNameAndClass;
+    default: void;
+}
+
 struct RTConfig {
     team @0 : Option(lib.FQTeamParsed);
     appID @1 : lib.RTAppID;
     roles @2 : lib.RolePairOpt;
-    channel @3 : lib.RTChannelName;
+    channel @3 : RTChannelSpecifier;
 }
 
 struct RTChannelMetadataPlaintext {
@@ -18,6 +35,8 @@ struct RTChannelMetadataPlaintext {
     roles @5 : lib.RolePair;
     klass @6 : lib.RTChannelClass;
     updatedAt @7 : lib.RTChannelSetVersion;
+    unreadable @8 : Bool; // caller can't read this channel (role below read role);
+                          // kept for name-collision detection, hidden from the inbox
 }
 
 struct RTChannelSetForTeam {
@@ -25,6 +44,25 @@ struct RTChannelSetForTeam {
     vers @1 : lib.RTChannelSetVersion;
     appID @2 : lib.RTAppID;
     team @3 : lib.TeamID;
+}
+
+// A decrypted message as presented to the CLI / app layer.
+struct RTMsgView {
+    seq @0 : lib.RTMsgSeq;
+    msgID @1 : lib.RTMsgID;
+    prevID @2 : lib.RTMsgID;
+    prevSeq @3 : lib.RTMsgSeq;
+    typ @4 : lib.RTMsgType;
+    sender @5 : Option(lib.PartyID);   // nil for server-authored
+    sentAtTime @6 : lib.Time;          // client-asserted
+    insertTime @7 : lib.Time;          // server-asserted
+    body @8 : Blob;                    // decrypted plaintext (basic messages)
+    senderName @9 : Option(lib.NameUtf8); // resolved by agent via user load; nil if unresolvable
+}
+
+struct RTThreadView {
+    msgs @0 : List(RTMsgView);
+    atBeginning @1 : Bool; // page reached the start of the thread; no older messages
 }
 
 protocol RealTime
@@ -40,5 +78,16 @@ protocol RealTime
     clientRTListChannelsForTeam @1 (
         cfg @0 : RTConfig /* contains team and AppID to list channels */
     ) -> RTChannelSetForTeam;
+
+    clientRTSend @2 (
+        cfg @0 : RTConfig, /* contains team, AppID and channel to send into */
+        body @1 : Blob     /* plaintext message body */
+    ) -> lib.RTMsgSeq;     /* server-assigned sequence number */
+
+    clientRTGetThread @3 (
+        cfg @0 : RTConfig,      /* contains team, AppID and channel to read */
+        num @1 : Uint,          /* max messages in the page; 0 = default */
+        before @2 : lib.RTMsgSeq /* page messages older than this seq (exclusive); 0 = most recent */
+    ) -> RTThreadView;
 
 }

--- a/proto-src/lib/realtime.snowp
+++ b/proto-src/lib/realtime.snowp
@@ -138,8 +138,9 @@ struct RTBoxRG{
 typedef RTChannelSetVersion = Uint;
 
 enum RTChannelClass {
-    Bottom @0;
-    Admin @1;
+    None @0;
+    Bottom @1;
+    Admin @2;
 }
 
 enum MsgBodyType {

--- a/proto-src/rem/realtime.snowp
+++ b/proto-src/rem/realtime.snowp
@@ -71,6 +71,8 @@ struct RTChannelMetadata @0xddf6b26b2ace1535 {
     mtime @9 : lib.Time;
     updatedAt @10 : lib.RTChannelSetVersion;
     klass @11 : lib.RTChannelClass;
+    unreadable @12 : Bool; // caller's role is below the read role: name is shown
+                           // (for collision detection) but desc/lastMsg withheld
 }
 
 struct RTChannelSet {

--- a/proto/lcl/extras.go
+++ b/proto/lcl/extras.go
@@ -199,3 +199,26 @@ func (s *SKMWK) UnmarshalJSON(dat []byte) error { return lib.UnmarshalJsonFixed(
 func (a KVRestAuthToken) String() string {
 	return string(a)
 }
+
+func (r RTChannelSpecifier) StringErr() (string, error) {
+	t, err := r.GetT()
+	if err != nil {
+		return "", err
+	}
+	switch t {
+	case RTChannelSpecifierType_ID:
+		return r.Id().StringErr()
+	case RTChannelSpecifierType_Name:
+		return string(r.Name().Name), nil
+	default:
+		return "<unknown>", nil
+	}
+}
+
+func (r RTChannelSpecifier) String() string {
+	s, err := r.StringErr()
+	if err != nil {
+		return fmt.Sprintf("error: %s", err.Error())
+	}
+	return s
+}

--- a/proto/lcl/realtime.go
+++ b/proto/lcl/realtime.go
@@ -6,24 +6,231 @@ package lcl
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/foks-proj/go-snowpack-rpc/rpc"
 	"time"
 )
 
 import lib "github.com/foks-proj/go-foks/proto/lib"
 
+type RTChannelNameAndClass struct {
+	Name  lib.RTChannelName
+	Klass lib.RTChannelClass
+}
+type RTChannelNameAndClassInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Name    *lib.RTChannelNameInternal__
+	Klass   *lib.RTChannelClassInternal__
+}
+
+func (r RTChannelNameAndClassInternal__) Import() RTChannelNameAndClass {
+	return RTChannelNameAndClass{
+		Name: (func(x *lib.RTChannelNameInternal__) (ret lib.RTChannelName) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Name),
+		Klass: (func(x *lib.RTChannelClassInternal__) (ret lib.RTChannelClass) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Klass),
+	}
+}
+func (r RTChannelNameAndClass) Export() *RTChannelNameAndClassInternal__ {
+	return &RTChannelNameAndClassInternal__{
+		Name:  r.Name.Export(),
+		Klass: r.Klass.Export(),
+	}
+}
+func (r *RTChannelNameAndClass) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTChannelNameAndClass) Decode(dec rpc.Decoder) error {
+	var tmp RTChannelNameAndClassInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTChannelNameAndClass) Bytes() []byte { return nil }
+
+type RTChannelSpecifierType int
+
+const (
+	RTChannelSpecifierType_None RTChannelSpecifierType = 0
+	RTChannelSpecifierType_ID   RTChannelSpecifierType = 1
+	RTChannelSpecifierType_Name RTChannelSpecifierType = 2
+)
+
+var RTChannelSpecifierTypeMap = map[string]RTChannelSpecifierType{
+	"None": 0,
+	"ID":   1,
+	"Name": 2,
+}
+var RTChannelSpecifierTypeRevMap = map[RTChannelSpecifierType]string{
+	0: "None",
+	1: "ID",
+	2: "Name",
+}
+
+type RTChannelSpecifierTypeInternal__ RTChannelSpecifierType
+
+func (r RTChannelSpecifierTypeInternal__) Import() RTChannelSpecifierType {
+	return RTChannelSpecifierType(r)
+}
+func (r RTChannelSpecifierType) Export() *RTChannelSpecifierTypeInternal__ {
+	return ((*RTChannelSpecifierTypeInternal__)(&r))
+}
+
+type RTChannelSpecifier struct {
+	T     RTChannelSpecifierType
+	F_1__ *lib.RTChannelID       `json:"f1,omitempty"`
+	F_2__ *RTChannelNameAndClass `json:"f2,omitempty"`
+}
+type RTChannelSpecifierInternal__ struct {
+	_struct  struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	T        RTChannelSpecifierType
+	Switch__ RTChannelSpecifierInternalSwitch__
+}
+type RTChannelSpecifierInternalSwitch__ struct {
+	_struct struct{}                         `codec:",omitempty"` //lint:ignore U1000 msgpack internal field
+	F_1__   *lib.RTChannelIDInternal__       `codec:"1"`
+	F_2__   *RTChannelNameAndClassInternal__ `codec:"2"`
+}
+
+func (r RTChannelSpecifier) GetT() (ret RTChannelSpecifierType, err error) {
+	switch r.T {
+	case RTChannelSpecifierType_ID:
+		if r.F_1__ == nil {
+			return ret, errors.New("unexpected nil case for F_1__")
+		}
+	case RTChannelSpecifierType_Name:
+		if r.F_2__ == nil {
+			return ret, errors.New("unexpected nil case for F_2__")
+		}
+	default:
+		break
+	}
+	return r.T, nil
+}
+func (r RTChannelSpecifier) Id() lib.RTChannelID {
+	if r.F_1__ == nil {
+		panic("unexpected nil case; should have been checked")
+	}
+	if r.T != RTChannelSpecifierType_ID {
+		panic(fmt.Sprintf("unexpected switch value (%v) when Id is called", r.T))
+	}
+	return *r.F_1__
+}
+func (r RTChannelSpecifier) Name() RTChannelNameAndClass {
+	if r.F_2__ == nil {
+		panic("unexpected nil case; should have been checked")
+	}
+	if r.T != RTChannelSpecifierType_Name {
+		panic(fmt.Sprintf("unexpected switch value (%v) when Name is called", r.T))
+	}
+	return *r.F_2__
+}
+func NewRTChannelSpecifierWithId(v lib.RTChannelID) RTChannelSpecifier {
+	return RTChannelSpecifier{
+		T:     RTChannelSpecifierType_ID,
+		F_1__: &v,
+	}
+}
+func NewRTChannelSpecifierWithName(v RTChannelNameAndClass) RTChannelSpecifier {
+	return RTChannelSpecifier{
+		T:     RTChannelSpecifierType_Name,
+		F_2__: &v,
+	}
+}
+func NewRTChannelSpecifierDefault(s RTChannelSpecifierType) RTChannelSpecifier {
+	return RTChannelSpecifier{
+		T: s,
+	}
+}
+func (r RTChannelSpecifierInternal__) Import() RTChannelSpecifier {
+	return RTChannelSpecifier{
+		T: r.T,
+		F_1__: (func(x *lib.RTChannelIDInternal__) *lib.RTChannelID {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *lib.RTChannelIDInternal__) (ret lib.RTChannelID) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(r.Switch__.F_1__),
+		F_2__: (func(x *RTChannelNameAndClassInternal__) *RTChannelNameAndClass {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *RTChannelNameAndClassInternal__) (ret RTChannelNameAndClass) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(r.Switch__.F_2__),
+	}
+}
+func (r RTChannelSpecifier) Export() *RTChannelSpecifierInternal__ {
+	return &RTChannelSpecifierInternal__{
+		T: r.T,
+		Switch__: RTChannelSpecifierInternalSwitch__{
+			F_1__: (func(x *lib.RTChannelID) *lib.RTChannelIDInternal__ {
+				if x == nil {
+					return nil
+				}
+				return (*x).Export()
+			})(r.F_1__),
+			F_2__: (func(x *RTChannelNameAndClass) *RTChannelNameAndClassInternal__ {
+				if x == nil {
+					return nil
+				}
+				return (*x).Export()
+			})(r.F_2__),
+		},
+	}
+}
+func (r *RTChannelSpecifier) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTChannelSpecifier) Decode(dec rpc.Decoder) error {
+	var tmp RTChannelSpecifierInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTChannelSpecifier) Bytes() []byte { return nil }
+
 type RTConfig struct {
 	Team    *lib.FQTeamParsed
 	AppID   lib.RTAppID
 	Roles   lib.RolePairOpt
-	Channel lib.RTChannelName
+	Channel RTChannelSpecifier
 }
 type RTConfigInternal__ struct {
 	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
 	Team    *lib.FQTeamParsedInternal__
 	AppID   *lib.RTAppIDInternal__
 	Roles   *lib.RolePairOptInternal__
-	Channel *lib.RTChannelNameInternal__
+	Channel *RTChannelSpecifierInternal__
 }
 
 func (r RTConfigInternal__) Import() RTConfig {
@@ -52,7 +259,7 @@ func (r RTConfigInternal__) Import() RTConfig {
 			}
 			return x.Import()
 		})(r.Roles),
-		Channel: (func(x *lib.RTChannelNameInternal__) (ret lib.RTChannelName) {
+		Channel: (func(x *RTChannelSpecifierInternal__) (ret RTChannelSpecifier) {
 			if x == nil {
 				return ret
 			}
@@ -98,6 +305,7 @@ type RTChannelMetadataPlaintext struct {
 	Roles      lib.RolePair
 	Klass      lib.RTChannelClass
 	UpdatedAt  lib.RTChannelSetVersion
+	Unreadable bool
 }
 type RTChannelMetadataPlaintextInternal__ struct {
 	_struct    struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -109,6 +317,7 @@ type RTChannelMetadataPlaintextInternal__ struct {
 	Roles      *lib.RolePairInternal__
 	Klass      *lib.RTChannelClassInternal__
 	UpdatedAt  *lib.RTChannelSetVersionInternal__
+	Unreadable *bool
 }
 
 func (r RTChannelMetadataPlaintextInternal__) Import() RTChannelMetadataPlaintext {
@@ -167,6 +376,12 @@ func (r RTChannelMetadataPlaintextInternal__) Import() RTChannelMetadataPlaintex
 			}
 			return x.Import()
 		})(r.UpdatedAt),
+		Unreadable: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.Unreadable),
 	}
 }
 func (r RTChannelMetadataPlaintext) Export() *RTChannelMetadataPlaintextInternal__ {
@@ -181,9 +396,10 @@ func (r RTChannelMetadataPlaintext) Export() *RTChannelMetadataPlaintextInternal
 			}
 			return (*x).Export()
 		})(r.Desc),
-		Roles:     r.Roles.Export(),
-		Klass:     r.Klass.Export(),
-		UpdatedAt: r.UpdatedAt.Export(),
+		Roles:      r.Roles.Export(),
+		Klass:      r.Klass.Export(),
+		UpdatedAt:  r.UpdatedAt.Export(),
+		Unreadable: &r.Unreadable,
 	}
 }
 func (r *RTChannelMetadataPlaintext) Encode(enc rpc.Encoder) error {
@@ -289,6 +505,217 @@ func (r *RTChannelSetForTeam) Decode(dec rpc.Decoder) error {
 
 func (r *RTChannelSetForTeam) Bytes() []byte { return nil }
 
+type RTMsgView struct {
+	Seq        lib.RTMsgSeq
+	MsgID      lib.RTMsgID
+	PrevID     lib.RTMsgID
+	PrevSeq    lib.RTMsgSeq
+	Typ        lib.RTMsgType
+	Sender     *lib.PartyID
+	SentAtTime lib.Time
+	InsertTime lib.Time
+	Body       []byte
+	SenderName *lib.NameUtf8
+}
+type RTMsgViewInternal__ struct {
+	_struct    struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Seq        *lib.RTMsgSeqInternal__
+	MsgID      *lib.RTMsgIDInternal__
+	PrevID     *lib.RTMsgIDInternal__
+	PrevSeq    *lib.RTMsgSeqInternal__
+	Typ        *lib.RTMsgTypeInternal__
+	Sender     *lib.PartyIDInternal__
+	SentAtTime *lib.TimeInternal__
+	InsertTime *lib.TimeInternal__
+	Body       *[]byte
+	SenderName *lib.NameUtf8Internal__
+}
+
+func (r RTMsgViewInternal__) Import() RTMsgView {
+	return RTMsgView{
+		Seq: (func(x *lib.RTMsgSeqInternal__) (ret lib.RTMsgSeq) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Seq),
+		MsgID: (func(x *lib.RTMsgIDInternal__) (ret lib.RTMsgID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.MsgID),
+		PrevID: (func(x *lib.RTMsgIDInternal__) (ret lib.RTMsgID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.PrevID),
+		PrevSeq: (func(x *lib.RTMsgSeqInternal__) (ret lib.RTMsgSeq) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.PrevSeq),
+		Typ: (func(x *lib.RTMsgTypeInternal__) (ret lib.RTMsgType) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Typ),
+		Sender: (func(x *lib.PartyIDInternal__) *lib.PartyID {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *lib.PartyIDInternal__) (ret lib.PartyID) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(r.Sender),
+		SentAtTime: (func(x *lib.TimeInternal__) (ret lib.Time) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.SentAtTime),
+		InsertTime: (func(x *lib.TimeInternal__) (ret lib.Time) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.InsertTime),
+		Body: (func(x *[]byte) (ret []byte) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.Body),
+		SenderName: (func(x *lib.NameUtf8Internal__) *lib.NameUtf8 {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *lib.NameUtf8Internal__) (ret lib.NameUtf8) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(r.SenderName),
+	}
+}
+func (r RTMsgView) Export() *RTMsgViewInternal__ {
+	return &RTMsgViewInternal__{
+		Seq:     r.Seq.Export(),
+		MsgID:   r.MsgID.Export(),
+		PrevID:  r.PrevID.Export(),
+		PrevSeq: r.PrevSeq.Export(),
+		Typ:     r.Typ.Export(),
+		Sender: (func(x *lib.PartyID) *lib.PartyIDInternal__ {
+			if x == nil {
+				return nil
+			}
+			return (*x).Export()
+		})(r.Sender),
+		SentAtTime: r.SentAtTime.Export(),
+		InsertTime: r.InsertTime.Export(),
+		Body:       &r.Body,
+		SenderName: (func(x *lib.NameUtf8) *lib.NameUtf8Internal__ {
+			if x == nil {
+				return nil
+			}
+			return (*x).Export()
+		})(r.SenderName),
+	}
+}
+func (r *RTMsgView) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTMsgView) Decode(dec rpc.Decoder) error {
+	var tmp RTMsgViewInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTMsgView) Bytes() []byte { return nil }
+
+type RTThreadView struct {
+	Msgs        []RTMsgView
+	AtBeginning bool
+}
+type RTThreadViewInternal__ struct {
+	_struct     struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Msgs        *[](*RTMsgViewInternal__)
+	AtBeginning *bool
+}
+
+func (r RTThreadViewInternal__) Import() RTThreadView {
+	return RTThreadView{
+		Msgs: (func(x *[](*RTMsgViewInternal__)) (ret []RTMsgView) {
+			if x == nil || len(*x) == 0 {
+				return nil
+			}
+			ret = make([]RTMsgView, len(*x))
+			for k, v := range *x {
+				if v == nil {
+					continue
+				}
+				ret[k] = (func(x *RTMsgViewInternal__) (ret RTMsgView) {
+					if x == nil {
+						return ret
+					}
+					return x.Import()
+				})(v)
+			}
+			return ret
+		})(r.Msgs),
+		AtBeginning: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.AtBeginning),
+	}
+}
+func (r RTThreadView) Export() *RTThreadViewInternal__ {
+	return &RTThreadViewInternal__{
+		Msgs: (func(x []RTMsgView) *[](*RTMsgViewInternal__) {
+			if len(x) == 0 {
+				return nil
+			}
+			ret := make([](*RTMsgViewInternal__), len(x))
+			for k, v := range x {
+				ret[k] = v.Export()
+			}
+			return &ret
+		})(r.Msgs),
+		AtBeginning: &r.AtBeginning,
+	}
+}
+func (r *RTThreadView) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTThreadView) Decode(dec rpc.Decoder) error {
+	var tmp RTThreadViewInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTThreadView) Bytes() []byte { return nil }
+
 var RealTimeProtocolID rpc.ProtocolUniqueID = rpc.ProtocolUniqueID(0xaaf0cd97)
 
 type ClientRTMakeChannelArg struct {
@@ -378,9 +805,116 @@ func (c *ClientRTListChannelsForTeamArg) Decode(dec rpc.Decoder) error {
 
 func (c *ClientRTListChannelsForTeamArg) Bytes() []byte { return nil }
 
+type ClientRTSendArg struct {
+	Cfg  RTConfig
+	Body []byte
+}
+type ClientRTSendArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Cfg     *RTConfigInternal__
+	Body    *[]byte
+}
+
+func (c ClientRTSendArgInternal__) Import() ClientRTSendArg {
+	return ClientRTSendArg{
+		Cfg: (func(x *RTConfigInternal__) (ret RTConfig) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(c.Cfg),
+		Body: (func(x *[]byte) (ret []byte) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(c.Body),
+	}
+}
+func (c ClientRTSendArg) Export() *ClientRTSendArgInternal__ {
+	return &ClientRTSendArgInternal__{
+		Cfg:  c.Cfg.Export(),
+		Body: &c.Body,
+	}
+}
+func (c *ClientRTSendArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(c.Export())
+}
+
+func (c *ClientRTSendArg) Decode(dec rpc.Decoder) error {
+	var tmp ClientRTSendArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*c = tmp.Import()
+	return nil
+}
+
+func (c *ClientRTSendArg) Bytes() []byte { return nil }
+
+type ClientRTGetThreadArg struct {
+	Cfg    RTConfig
+	Num    uint64
+	Before lib.RTMsgSeq
+}
+type ClientRTGetThreadArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Cfg     *RTConfigInternal__
+	Num     *uint64
+	Before  *lib.RTMsgSeqInternal__
+}
+
+func (c ClientRTGetThreadArgInternal__) Import() ClientRTGetThreadArg {
+	return ClientRTGetThreadArg{
+		Cfg: (func(x *RTConfigInternal__) (ret RTConfig) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(c.Cfg),
+		Num: (func(x *uint64) (ret uint64) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(c.Num),
+		Before: (func(x *lib.RTMsgSeqInternal__) (ret lib.RTMsgSeq) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(c.Before),
+	}
+}
+func (c ClientRTGetThreadArg) Export() *ClientRTGetThreadArgInternal__ {
+	return &ClientRTGetThreadArgInternal__{
+		Cfg:    c.Cfg.Export(),
+		Num:    &c.Num,
+		Before: c.Before.Export(),
+	}
+}
+func (c *ClientRTGetThreadArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(c.Export())
+}
+
+func (c *ClientRTGetThreadArg) Decode(dec rpc.Decoder) error {
+	var tmp ClientRTGetThreadArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*c = tmp.Import()
+	return nil
+}
+
+func (c *ClientRTGetThreadArg) Bytes() []byte { return nil }
+
 type RealTimeInterface interface {
 	ClientRTMakeChannel(context.Context, ClientRTMakeChannelArg) (lib.RTChannelID, error)
 	ClientRTListChannelsForTeam(context.Context, RTConfig) (RTChannelSetForTeam, error)
+	ClientRTSend(context.Context, ClientRTSendArg) (lib.RTMsgSeq, error)
+	ClientRTGetThread(context.Context, ClientRTGetThreadArg) (RTThreadView, error)
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h Header) error
 	MakeResHeader() Header
@@ -471,6 +1005,48 @@ func (c RealTimeClient) ClientRTListChannelsForTeam(ctx context.Context, cfg RTC
 	res = tmp.Data.Import()
 	return
 }
+func (c RealTimeClient) ClientRTSend(ctx context.Context, arg ClientRTSendArg) (res lib.RTMsgSeq, err error) {
+	warg := &rpc.DataWrap[Header, *ClientRTSendArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[Header, lib.RTMsgSeqInternal__]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(RealTimeProtocolID, 2, "RealTime.clientRTSend"), warg, &tmp, 0*time.Millisecond, realTimeErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	res = tmp.Data.Import()
+	return
+}
+func (c RealTimeClient) ClientRTGetThread(ctx context.Context, arg ClientRTGetThreadArg) (res RTThreadView, err error) {
+	warg := &rpc.DataWrap[Header, *ClientRTGetThreadArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[Header, RTThreadViewInternal__]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(RealTimeProtocolID, 3, "RealTime.clientRTGetThread"), warg, &tmp, 0*time.Millisecond, realTimeErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	res = tmp.Data.Import()
+	return
+}
 func RealTimeProtocol(i RealTimeInterface) rpc.ProtocolV2 {
 	return rpc.ProtocolV2{
 		Name: "RealTime",
@@ -533,6 +1109,64 @@ func RealTimeProtocol(i RealTimeInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "clientRTListChannelsForTeam",
+			},
+			2: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[Header, *ClientRTSendArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *ClientRTSendArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[Header, *ClientRTSendArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						tmp, err := i.ClientRTSend(ctx, (typedArg.Import()))
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[Header, *lib.RTMsgSeqInternal__]{
+							Data:   tmp.Export(),
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "clientRTSend",
+			},
+			3: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[Header, *ClientRTGetThreadArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *ClientRTGetThreadArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[Header, *ClientRTGetThreadArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						tmp, err := i.ClientRTGetThread(ctx, (typedArg.Import()))
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[Header, *RTThreadViewInternal__]{
+							Data:   tmp.Export(),
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "clientRTGetThread",
 			},
 		},
 		WrapError: RealTimeMakeGenericErrorWrapper(i.ErrorWrapper()),

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -5297,3 +5297,24 @@ func (r RTChannelIDShort) Int64() int64 {
 func (i RTMsgID) Eq(j RTMsgID) bool {
 	return hmac.Equal(i[:], j[:])
 }
+
+func (i RTChannelID) Eq(j RTChannelID) bool {
+	return hmac.Equal(i[:], j[:])
+}
+
+func (n RTChannelName) Eq(p RTChannelName) bool {
+	return n.Normalize() == p.Normalize()
+}
+
+func (n RTChannelName) Normalize() RTChannelName {
+	return RTChannelName(strings.ToLower(string(n)))
+}
+
+const RTGeneralChannel = RTChannelName("general")
+
+func (c RTChannelName) DecorateToString() string {
+	if c.IsEmpty() {
+		c = RTGeneralChannel
+	}
+	return "#" + string(c)
+}

--- a/proto/lib/realtime.go
+++ b/proto/lib/realtime.go
@@ -1338,17 +1338,20 @@ func (r RTChannelSetVersion) Bytes() []byte {
 type RTChannelClass int
 
 const (
-	RTChannelClass_Bottom RTChannelClass = 0
-	RTChannelClass_Admin  RTChannelClass = 1
+	RTChannelClass_None   RTChannelClass = 0
+	RTChannelClass_Bottom RTChannelClass = 1
+	RTChannelClass_Admin  RTChannelClass = 2
 )
 
 var RTChannelClassMap = map[string]RTChannelClass{
-	"Bottom": 0,
-	"Admin":  1,
+	"None":   0,
+	"Bottom": 1,
+	"Admin":  2,
 }
 var RTChannelClassRevMap = map[RTChannelClass]string{
-	0: "Bottom",
-	1: "Admin",
+	0: "None",
+	1: "Bottom",
+	2: "Admin",
 }
 
 type RTChannelClassInternal__ RTChannelClass

--- a/proto/rem/realtime.go
+++ b/proto/rem/realtime.go
@@ -437,6 +437,7 @@ type RTChannelMetadata struct {
 	Mtime      lib.Time
 	UpdatedAt  lib.RTChannelSetVersion
 	Klass      lib.RTChannelClass
+	Unreadable bool
 }
 type RTChannelMetadataInternal__ struct {
 	_struct    struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -452,6 +453,7 @@ type RTChannelMetadataInternal__ struct {
 	Mtime      *lib.TimeInternal__
 	UpdatedAt  *lib.RTChannelSetVersionInternal__
 	Klass      *lib.RTChannelClassInternal__
+	Unreadable *bool
 }
 
 func (r RTChannelMetadataInternal__) Import() RTChannelMetadata {
@@ -540,6 +542,12 @@ func (r RTChannelMetadataInternal__) Import() RTChannelMetadata {
 			}
 			return x.Import()
 		})(r.Klass),
+		Unreadable: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.Unreadable),
 	}
 }
 func (r RTChannelMetadata) Export() *RTChannelMetadataInternal__ {
@@ -562,10 +570,11 @@ func (r RTChannelMetadata) Export() *RTChannelMetadataInternal__ {
 			}
 			return (*x).Export()
 		})(r.LastMsg),
-		Ctime:     r.Ctime.Export(),
-		Mtime:     r.Mtime.Export(),
-		UpdatedAt: r.UpdatedAt.Export(),
-		Klass:     r.Klass.Export(),
+		Ctime:      r.Ctime.Export(),
+		Mtime:      r.Mtime.Export(),
+		UpdatedAt:  r.UpdatedAt.Export(),
+		Klass:      r.Klass.Export(),
+		Unreadable: &r.Unreadable,
 	}
 }
 func (r *RTChannelMetadata) Encode(enc rpc.Encoder) error {

--- a/scripts/srv/ecosystem.config.js
+++ b/scripts/srv/ecosystem.config.js
@@ -47,6 +47,7 @@ function apps() {
     app('kv_store', 'kv-store'),
     app('autocert', 'autocert'),
     bash_app('ssh-tun', 'ssh-tun.sh'),
+    app('realtime', 'realtime'),
   ].concat(lcl.beacon ? [app('beacon', 'beacon')] : [])
    .concat(lcl.quota ? [app('quota','quota')] : [])
    .concat(lcl.web ? [app('web', 'web')] : [])

--- a/scripts/srv/ssh-tun.sh
+++ b/scripts/srv/ssh-tun.sh
@@ -30,6 +30,7 @@ ssh -N ${key} \
     -R $(proxy_pair merkle_query) \
     -R $(proxy_pair beacon) \
     -R $(proxy_pair kv_store) \
+    -R $(proxy_pair realtime) \
     -R *:80:localhost:${HTTP_LOCAL_PORT} \
     -R *:443:localhost:${HTTPS_LOCAL_PORT} \
     root@${SSH_PROXY_HOSTNAME}

--- a/server/realtime/channels.go
+++ b/server/realtime/channels.go
@@ -272,6 +272,24 @@ func readAllChannels(
 			return nil, err
 		}
 
+		// The channel name is sealed at the class floor, so its name (and very
+		// existence) is visible to everyone the class gate admits -- this is
+		// needed for name-collision detection at create time, since names are
+		// ciphertext the server can't dedupe itself. The description and
+		// last-message preview, however, are sealed at the finer read role: don't
+		// hand them to a caller whose team role is below it. They couldn't decrypt
+		// the description anyway (it would only panic/err on the client), and the
+		// last-message metadata would leak channel activity they can't read.
+		readRoleKey, err := core.ImportRole(md.Roles.Read)
+		if err != nil {
+			return nil, err
+		}
+		if role.LessThan(*readRoleKey) {
+			md.DescBox = nil
+			md.LastMsg = nil
+			md.Unreadable = true
+		}
+
 		ret = append(ret, md)
 	}
 	if err = rows.Err(); err != nil {

--- a/server/shared/config.go
+++ b/server/shared/config.go
@@ -140,7 +140,7 @@ func ParseDbType(s string) (DbType, error) {
 		return DbTypeBeacon, nil
 	case "kv-store":
 		return DbTypeKVStore, nil
-	case "real-time":
+	case "realtime":
 		return DbTypeRealTime, nil
 	default:
 		return DbTypeNone, errors.New("unknown DB type: " + s)


### PR DESCRIPTION
Adds a CLI surface for Stage 1a chat plus the agent/library/server plumbing behind it.

## CLI (`client/foks/cmd/rt.go`)
- `rt send --team T [--channel C] "msg"`
- `rt read --team T [--channel C] [-n N] [--before SEQ]` — most-recent page by default; pages backwards with `--before`. The footer prints the next `--before` cursor or `(beginning of thread)`, so paging is self-documenting.
- `new-channel` now accepts `--read-role` / `--write-role`.

## Agent (`client/agent/rt.go`)
`ClientRTSend` and `ClientRTGetThread`; the read handler resolves sender UIDs to usernames and paginates through the minder.

## Library (`client/librt/minder.go`)
- `ResolveSenderNames` loads each distinct sender via a **team-mediated** user load (`AsLocalTeam`, required in closed viewership), memoized in a per-minder cache with a **jittered ~6h TTL** to avoid a thundering herd.
- `GetThreadPage` wraps `GetThreadBookended` with a `before` cursor and an `atBeginning` flag.
- `GetThreadBookended` now accepts an inclusive `start == end` (single-message window) instead of erroring.
- `TeamViewToken` exposes the team's view bearer token; `keysAtRoleGen` returns a `PermissionError` instead of panicking when the caller lacks the role key.

## Server (`server/realtime/channels.go`)
The channel list withholds the description/last-message and flags `unreadable` for callers below a channel's read role, while still returning the (class-floor-encrypted) **name** so client-side name-collision detection keeps working. The client hides `unreadable` channels from the inbox.

## Proto
`clientRTSend` / `clientRTGetThread`; `RTMsgView` (+`senderName`), `RTThreadView` (+`atBeginning`), `RTChannelMetadata`/`RTChannelMetadataPlaintext` (+`unreadable`).

## Tests (`integration-tests/cli/rt_test.go`)
send/read, cross-member sender resolution, backward paging (including the single-message window that exercises the `start==end` fix), and the unreadable-channel-hidden-but-name-reserved case. Full RT CLI + lib suites pass locally.

Co-authored-by: Claude Code <noreply@anthropic.com>