### PR TITLE
cli: add command to delete a git repository

### DIFF
--- a/client/foks/cmd/git.go
+++ b/client/foks/cmd/git.go
@@ -98,6 +98,50 @@ func gitCreate(m libclient.MetaContext, top *cobra.Command) {
 	)
 }
 
+func gitDelete(m libclient.MetaContext, top *cobra.Command) {
+	quickGitCmd(m, top,
+		"delete reponame", []string{"rm", "remove"},
+		"Delete a git repository",
+		"Delete a git repository",
+		quickKVOpts{
+			SupportReadRole:  true,
+			SupportWriteRole: true,
+		},
+		nil,
+		func(arg []string, cfg lcl.KVConfig, cli lcl.GitClient) error {
+			if len(arg) != 1 {
+				return ArgsError("expected exactly one argument -- the repo name")
+			}
+			name, err := libgit.NormalizedRepoName(arg[0])
+			if err != nil {
+				return err
+			}
+			gp := libgit.NewGitPath(name)
+			path := gp.PrefixJoined()
+			cfg.Recursive = true
+			kvCli := lcl.KVClient{
+				Cli:            cli.Cli,
+				ErrorUnwrapper: lcl.KVErrorUnwrapper(cli.ErrorUnwrapper),
+				MakeArgHeader:  cli.MakeArgHeader,
+				CheckResHeader: cli.CheckResHeader,
+			}
+			err = kvCli.ClientKVRm(m.Ctx(), lcl.ClientKVRmArg{
+				Cfg:  cfg,
+				Path: path,
+			})
+			if err != nil {
+				return err
+			}
+			m.G().UIs().Terminal.Printf("Deleted: %s\n", name)
+			err = PartingConsoleMessage(m)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	)
+}
+
 func gitShellConfig(m libclient.MetaContext, top *cobra.Command) {
 	quickCmd(m, top,
 		"shell-config",
@@ -270,6 +314,7 @@ func gitCmd(m libclient.MetaContext) *cobra.Command {
 		},
 	}
 	gitCreate(m, top)
+	gitDelete(m, top)
 	gitShellConfig(m, top)
 	gitLs(m, top)
 	gitGetDefaultBranch(m, top)

--- a/client/foks/cmd/git.go
+++ b/client/foks/cmd/git.go
@@ -103,10 +103,7 @@ func gitDelete(m libclient.MetaContext, top *cobra.Command) {
 		"delete reponame", []string{"rm", "remove"},
 		"Delete a git repository",
 		"Delete a git repository",
-		quickKVOpts{
-			SupportReadRole:  true,
-			SupportWriteRole: true,
-		},
+		quickKVOpts{},
 		nil,
 		func(arg []string, cfg lcl.KVConfig, cli lcl.GitClient) error {
 			if len(arg) != 1 {

--- a/integration-tests/cli/git_test.go
+++ b/integration-tests/cli/git_test.go
@@ -548,3 +548,34 @@ func TestEmptyFile(t *testing.T) {
 	sr2.Git(t, "clone", sr.Origin(), ".")
 	sr2.ReadFile(t, "f1", "")
 }
+
+func TestGitDeleteRepo(t *testing.T) {
+	gte, cleanup := newGitTestEnv(t)
+	defer cleanup()
+	au := gte.newAgentAndUser(t)
+	sr := gte.NewScratchRepo(t)
+
+	// Create repository.
+	sr.Git(t, "init")
+	merklePoke(t)
+	au.agent.runCmd(t, nil, "git", "create", gte.Desc.RepoName)
+
+	// List repos and assert it is present.
+	var allRepos []proto.GitURL
+	au.agent.runCmdToJSON(t, &allRepos, "git", "ls", "--json")
+	require.Len(t, allRepos, 1)
+	require.Equal(t, proto.GitRepo(gte.Desc.RepoName), allRepos[0].Repo)
+
+	// Delete repository.
+	merklePoke(t)
+	out := au.agent.runCmdToBytes(t, "git", "delete", gte.Desc.RepoName)
+	require.Contains(t, string(out), fmt.Sprintf("Deleted: %s", gte.Desc.RepoName))
+
+	// List repos and assert it is empty.
+	au.agent.runCmdToJSON(t, &allRepos, "git", "ls", "--json")
+	require.Len(t, allRepos, 0)
+
+	// Deleting non-existent repository should fail.
+	err := au.agent.runCmdErr(nil, "git", "delete", "nonexistent-repo")
+	require.Error(t, err)
+}


### PR DESCRIPTION
I had a go at building a `git delete <repo>` command to provide an arguably more intuitive user experience when working with git repositories.

Run the added test with:
```
$ go test -v ./integration-tests/cli -run ^TestGitDeleteRepo$
```

Closes #279