### PR TITLE
test: fix stop-then-restart agent socket race in CLI tests

### DIFF
--- a/integration-tests/cli/base_test.go
+++ b/integration-tests/cli/base_test.go
@@ -436,6 +436,14 @@ func (a *testAgent) runCmdToJSON(
 }
 
 func (a *testAgent) runAgent(t *testing.T) {
+	// Make sure any previous agent on this socket is fully gone before we
+	// start. Otherwise the readiness probe below can connect to the old,
+	// still-closing listener and return too early -- the stop-then-restart
+	// race that a plain dial-up check (#261) doesn't cover. This is a no-op
+	// (one immediately-failing dial) when nothing is listening, so the wait
+	// only happens on an actual restart, not on a first start or teardown.
+	sock := a.socketPath(t)
+	a.waitForSocketDown(t, sock)
 	// Agent runs in the background; grab its global context though
 	// so we can manipulate it (and break it) in tests.
 	go func() {
@@ -448,19 +456,23 @@ func (a *testAgent) runAgent(t *testing.T) {
 			t.Fail()
 		}
 	}()
-	a.waitForSocket(t)
+	a.waitForSocketUp(t, sock)
 }
 
 func (a *testAgent) runAgentWithHook(
 	t *testing.T,
 	hook func(libclient.MetaContext) error,
 ) {
+	sock := a.socketPath(t)
+	a.waitForSocketDown(t, sock)
 	// Agent runs in the background
 	go a.runCmd(t, hook, "agent")
-	a.waitForSocket(t)
+	a.waitForSocketUp(t, sock)
 }
 
-func (a *testAgent) waitForSocket(t *testing.T) {
+// socketPath returns the agent's configured unix socket path. It reads config
+// only, so it works whether or not an agent is currently running.
+func (a *testAgent) socketPath(t *testing.T) string {
 	var tui terminalUI
 	a.runCmd(t, func(m libclient.MetaContext) error {
 		uis := m.G().UIs()
@@ -468,12 +480,14 @@ func (a *testAgent) waitForSocket(t *testing.T) {
 		m.G().SetUIs(uis)
 		return nil
 	}, "ctl", "socket")
-	sock := tui.TrimmedString()
+	return tui.TrimmedString()
+}
 
-	// Poll until the agent is actually accepting connections, not just until
-	// the socket file exists. A stale socket file from a previous agent run
-	// can satisfy os.Stat before the new listener is up, leading to a flaky
-	// "failed to connect to agent" on the next CLI invocation.
+// waitForSocketUp polls until the agent is actually accepting connections, not
+// just until the socket file exists. A stale socket file from a previous agent
+// run can satisfy os.Stat before the new listener is up, leading to a flaky
+// "failed to connect to agent" on the next CLI invocation.
+func (a *testAgent) waitForSocketUp(t *testing.T, sock string) {
 	wait := time.Millisecond * 1
 	for i := 0; i < 20; i++ {
 		conn, err := net.DialTimeout("unix", sock, 50*time.Millisecond)
@@ -487,6 +501,25 @@ func (a *testAgent) waitForSocket(t *testing.T) {
 		}
 	}
 	t.Fatal("agent socket not reachable")
+}
+
+// waitForSocketDown polls until nothing is listening on the agent socket. It
+// returns immediately when the socket already refuses connections, so the only
+// time it actually waits is right after a stop, when the previous agent's
+// listener is still closing -- exactly the case a restart needs to serialize on.
+func (a *testAgent) waitForSocketDown(t *testing.T, sock string) {
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		conn, err := net.DialTimeout("unix", sock, 50*time.Millisecond)
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+		if time.Now().After(deadline) {
+			t.Fatal("agent socket still reachable; previous agent did not shut down")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func (a *testAgent) stop(t *testing.T) {


### PR DESCRIPTION
## Problem

Tests that stop and immediately restart the agent — e.g. `TestBotTokenAgentRestart` — flake on CI with:

```
failed to connect to agent at path /tmp/foks_test_*/.config/foks/foks.sock
```

(seen in [run 27725816467](https://github.com/foks-proj/go-foks/actions/runs/27725816467/job/82444087863), on an unrelated PR).

`ctl shutdown` returns as soon as the shutdown RPC is acked — the old agent's process and **listener are still alive** for a moment after. So on restart, `waitForSocket`'s dial can connect to the **dying old listener**, declare "ready," and return *before* the new agent has bound the socket. The next real CLI call (`status`) then lands in the window where the old listener has closed and the new one isn't up yet → connect fails.

The dial-based `waitForSocket` from #261 closed the stale-*file* hole but not the dying-*listener* hole: a dial happily succeeds against the old listener.

## Fix

Wait on the **down** side too: before (re)starting an agent, wait until the socket stops accepting connections. Then the up-probe can only ever observe the new agent.

To avoid slowing every test down, the wait does **not** go in `stop()` — ~110 of the 130 `stop(t)` calls are plain `defer` teardowns that never restart. Instead it lives in `runAgent`, gated on whether anything is actually listening:

- First start / teardown: socket already refuses → one immediately-failing dial → proceeds. No measurable cost.
- Restart: waits the few ms for the old listener to release, then probes for up.

`waitForSocket` is split into `socketPath` + `waitForSocketUp`, and `waitForSocketDown` is added. No call sites change.

## Verification

- `go vet ./integration-tests/cli/` clean.
- Previously-flaky `TestBotTokenAgentRestart` passes **3/3** (`-count=3`).
- No slowdown on the non-restart path: `TestAgentStartStop` stays **0.02s**.
- Restart-heavy `TestProvision*` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)