### PR TITLE
ci: bump checkout/setup-go to Node 24 action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: |
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             gcc make libpcsclite-dev pkg-config
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true


### PR DESCRIPTION
## Problem

Every CI run logs a Node 20 deprecation warning (e.g. [this run](https://github.com/foks-proj/go-foks/actions/runs/27857211293/job/82446825539)):

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-go@v5.
```

The two actions pinned in `.github/workflows/ci.yml` ship a runtime that targets Node 20, which GitHub is [deprecating](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Runners currently force them onto Node 24; eventually the old versions stop working.

## Fix

Bump both to the majors whose runtime targets Node 24:

- `actions/checkout@v4` → `actions/checkout@v5`
- `actions/setup-go@v5` → `actions/setup-go@v6`

The `with:` inputs (`go-version-file`, `cache`) are unchanged across the bump. Warnings-only cleanup; nothing was failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)