### PR TITLE
rt: rename "channel class" to "channel tier"

### DIFF
--- a/client/foks/cmd/rt.go
+++ b/client/foks/cmd/rt.go
@@ -17,24 +17,24 @@ type quickRTOpts struct {
 
 func parseChannelSpecifier(
 	nameOrId string,
-	klass string,
+	tierStr string,
 ) (
 	*lcl.RTChannelSpecifier,
 	error,
 ) {
 	none := lcl.NewRTChannelSpecifierDefault(lcl.RTChannelSpecifierType_None)
-	if nameOrId == "" && klass == "" {
+	if nameOrId == "" && tierStr == "" {
 		return &none, nil
 	}
-	cc := proto.RTChannelClass_None
-	if len(klass) > 0 {
-		switch klass {
+	tier := proto.RTChannelTier_None
+	if len(tierStr) > 0 {
+		switch tierStr {
 		case "a", "admin":
-			cc = proto.RTChannelClass_Admin
+			tier = proto.RTChannelTier_Admin
 		case "d", "default", "bottom":
-			cc = proto.RTChannelClass_Bottom
+			tier = proto.RTChannelTier_Bottom
 		default:
-			return nil, core.BadArgsError("bad channel class")
+			return nil, core.BadArgsError("bad channel tier")
 		}
 	}
 
@@ -65,18 +65,18 @@ func parseChannelSpecifier(
 	}
 	switch {
 	case chid != nil:
-		if cc != proto.RTChannelClass_None {
+		if tier != proto.RTChannelTier_None {
 			return nil, core.BadArgsError(
-				"cannot specify channel ID and class together",
+				"cannot specify channel ID and tier together",
 			)
 		}
 		tmp := lcl.NewRTChannelSpecifierWithId(*chid)
 		ret = &tmp
-	case !cn.IsEmpty() || cc != proto.RTChannelClass_None:
+	case !cn.IsEmpty() || tier != proto.RTChannelTier_None:
 		tmp := lcl.NewRTChannelSpecifierWithName(
-			lcl.RTChannelNameAndClass{
-				Name:  cn,
-				Klass: cc,
+			lcl.RTChannelNameAndTier{
+				Name: cn,
+				Tier: tier,
 			},
 		)
 		ret = &tmp
@@ -102,7 +102,7 @@ func quickRTCmd(
 		long = short
 	}
 	var teamStr string
-	var rrs, wrs, chs, chcs string
+	var rrs, wrs, chs, chTier string
 	var rr, wr *proto.Role
 	run := func(cmd *cobra.Command, arg []string) error {
 		var fqt *proto.FQTeamParsed
@@ -131,7 +131,7 @@ func quickRTCmd(
 		}
 		chsp, err := parseChannelSpecifier(
 			chs,
-			chcs,
+			chTier,
 		)
 		if err != nil {
 			return err
@@ -170,7 +170,7 @@ func quickRTCmd(
 	}
 	if opts.SupportChannel {
 		cmd.Flags().StringVar(&chs, "channel", "", "specify channel name (with '#') or channel ID (#general by default)")
-		cmd.Flags().StringVar(&chcs, "channel-class", "", "disambiguate with channel class (can be \"a\"/\"admin\" or \"d\"/\"default\")")
+		cmd.Flags().StringVar(&chTier, "channel-tier", "", "disambiguate with channel tier (can be \"a\"/\"admin\" or \"d\"/\"default\")")
 	}
 	if setup != nil {
 		setup(cmd)
@@ -216,7 +216,7 @@ func rtNewChannel(m libclient.MetaContext, top *cobra.Command) {
 				return ArgsError("can only specify a description if not the default channel")
 			}
 			cfg.Channel = lcl.NewRTChannelSpecifierWithName(
-				lcl.RTChannelNameAndClass{
+				lcl.RTChannelNameAndTier{
 					Name: ch,
 				},
 			)
@@ -247,7 +247,7 @@ func rtListChannels(m libclient.MetaContext, top *cobra.Command) {
 		m, top,
 		"list-channels", []string{"ls-channels", "channels"},
 		"list the channels in a team",
-		"list the channels in a team, sorted by channel class and name",
+		"list the channels in a team, sorted by channel tier and name",
 		quickRTOpts{},
 		nil,
 		func(args []string, cfg lcl.RTConfig, cli lcl.RealTimeClient) error {

--- a/client/foks/cmd/tables.go
+++ b/client/foks/cmd/tables.go
@@ -700,17 +700,17 @@ func displayRTChannelName(n proto.RTChannelName) string {
 }
 
 type rtChannelRow struct {
-	name  string
-	klass proto.RTChannelClass
-	desc  string
-	id    string
+	name string
+	tier proto.RTChannelTier
+	desc string
+	id   string
 }
 
-// rtChannelClassGlyph renders a channel class as a single character to keep
+// rtChannelTierGlyph renders a channel tier as a single character to keep
 // the table tight: a star for admin channels, and ⊥ for bottom channels.
-func rtChannelClassGlyph(c proto.RTChannelClass) string {
+func rtChannelTierGlyph(c proto.RTChannelTier) string {
 	switch c {
-	case proto.RTChannelClass_Admin:
+	case proto.RTChannelTier_Admin:
 		return "★"
 	default:
 		return "⊥"
@@ -720,7 +720,7 @@ func rtChannelClassGlyph(c proto.RTChannelClass) string {
 func (r rtChannelRow) toTableRow() table.Row {
 	return table.Row{
 		r.name,
-		rtChannelClassGlyph(r.klass),
+		rtChannelTierGlyph(r.tier),
 		r.desc,
 		r.id,
 	}
@@ -729,7 +729,7 @@ func (r rtChannelRow) toTableRow() table.Row {
 func (r rtChannelRow) headers() table.Row {
 	return table.Row{
 		"Channel",
-		"Class",
+		"Tier",
 		"Description",
 		"Channel ID",
 	}
@@ -737,9 +737,9 @@ func (r rtChannelRow) headers() table.Row {
 
 func (r rtChannelRow) lessThan(other tableRow) bool {
 	or := other.(rtChannelRow)
-	// Sort by channel class first, with admin (the higher class) on top.
-	if r.klass != or.klass {
-		return r.klass > or.klass
+	// Sort by channel tier first, with admin (the higher tier) on top.
+	if r.tier != or.tier {
+		return r.tier > or.tier
 	}
 	// Then sort by channel name.
 	return cicmp(r.name, or.name) < 0
@@ -762,10 +762,10 @@ func outputRTChannelListTable(
 			desc = string(*c.Desc)
 		}
 		ret := rtChannelRow{
-			name:  displayRTChannelName(c.Name),
-			klass: c.Klass,
-			desc:  desc,
-			id:    id,
+			name: displayRTChannelName(c.Name),
+			tier: c.Tier,
+			desc: desc,
+			id:   id,
 		}
 		return ret, nil
 	}

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -234,12 +234,12 @@ func (d *Minder) makeChannelOneAttempt(
 	}
 
 	type chKey struct {
-		name  proto.RTChannelName
-		klass proto.RTChannelClass
+		name proto.RTChannelName
+		tier proto.RTChannelTier
 	}
 	chMap := make(map[chKey]struct{})
 	for _, chmd := range chlst.Channels {
-		chMap[chKey{name: chmd.Name.Normalize(), klass: chmd.Klass}] = struct{}{}
+		chMap[chKey{name: chmd.Name.Normalize(), tier: chmd.Tier}] = struct{}{}
 	}
 
 	// A note on roles, which are tricky. If no roles were specified, we use
@@ -254,7 +254,7 @@ func (d *Minder) makeChannelOneAttempt(
 	// 10 different channels named "#general" per team, once for each Member viz level.
 	// We'll have at most 2 channels named "#general", one for the plebs, and one
 	// for the admins (and above).
-	newChClass := proto.RTChannelClass_Bottom
+	newChTier := proto.RTChannelTier_Bottom
 	readRole := roles.Read
 	nameRole := proto.MinRTRole
 
@@ -274,13 +274,13 @@ func (d *Minder) makeChannelOneAttempt(
 		return nil, err
 	}
 	if isAdmin {
-		newChClass = proto.RTChannelClass_Admin
+		newChTier = proto.RTChannelTier_Admin
 		nameRole = proto.AdminRole
 	}
 
 	if _, found := chMap[chKey{
-		name:  nm.Normalize(),
-		klass: newChClass,
+		name: nm.Normalize(),
+		tier: newChTier,
 	}]; found {
 		return nil, core.RTChannelExistsError{}
 	}
@@ -347,7 +347,7 @@ func (d *Minder) makeChannelOneAttempt(
 		Write: *wRole,
 	}
 	update.UpdatedAt = chlst.Vers + 1
-	update.Klass = newChClass
+	update.Tier = newChTier
 
 	arg := rem.RtNewChannelArg{
 		Md:      update,
@@ -530,7 +530,7 @@ func (k *Minder) decryptChannelMetadata(
 	ret.ParentTeam = chmdenc.ParentTeam
 	ret.AppID = chmdenc.AppID
 	ret.Roles = chmdenc.Roles
-	ret.Klass = chmdenc.Klass
+	ret.Tier = chmdenc.Tier
 	ret.UpdatedAt = chmdenc.UpdatedAt
 	ret.Unreadable = chmdenc.Unreadable
 
@@ -565,9 +565,9 @@ func (k *Minder) ListAllChannelsForTeam(
 	slices.SortFunc(
 		ret.Channels,
 		func(a lcl.RTChannelMetadataPlaintext, b lcl.RTChannelMetadataPlaintext) int {
-			if a.Klass != b.Klass {
-				if a.Klass == proto.RTChannelClass_Admin &&
-					b.Klass == proto.RTChannelClass_Bottom {
+			if a.Tier != b.Tier {
+				if a.Tier == proto.RTChannelTier_Admin &&
+					b.Tier == proto.RTChannelTier_Bottom {
 					return -1
 				}
 				return 1
@@ -634,9 +634,9 @@ type ThreadMessage struct {
 }
 
 // resolveChannel finds a channel in `team` by name. A name can exist in more
-// than one class (e.g. an admin and a bottom "#general"); pass a non-nil klass
-// to disambiguate. With klass==nil, an ambiguous name returns
-// RTAmbiguousChannelError so the caller (or a UI) can retry with a class.
+// than one tier (e.g. an admin and a bottom "#general"); pass a non-nil tier
+// to disambiguate. With tier==nil, an ambiguous name returns
+// RTAmbiguousChannelError so the caller (or a UI) can retry with a tier.
 func (d *Minder) resolveChannel(
 	m MetaContext,
 	rtp *RTParty,
@@ -658,14 +658,14 @@ func (d *Minder) resolveChannel(
 
 	var searchID *proto.RTChannelID
 	var searchName proto.RTChannelName
-	var searchClass proto.RTChannelClass
+	var searchTier proto.RTChannelTier
 
 	switch t {
 	case lcl.RTChannelSpecifierType_None:
 		/* noop */
 	case lcl.RTChannelSpecifierType_Name:
 		searchName = spc.Name().Name
-		searchClass = spc.Name().Klass
+		searchTier = spc.Name().Tier
 	case lcl.RTChannelSpecifierType_ID:
 		tmp := spc.Id()
 		searchID = &tmp
@@ -688,11 +688,11 @@ func (d *Minder) resolveChannel(
 		if !ch.Name.Eq(searchName) {
 			continue
 		}
-		if searchClass != proto.RTChannelClass_None && ch.Klass != searchClass {
+		if searchTier != proto.RTChannelTier_None && ch.Tier != searchTier {
 			continue
 		}
 		if found != nil {
-			// Only reachable when klass==nil; a (name, class) pair is unique.
+			// Only reachable when tier==nil; a (name, tier) pair is unique.
 			return nil, core.RTAmbiguousChannelError{Name: searchName}
 		}
 		found = ch
@@ -755,7 +755,7 @@ type SendTestHooks struct {
 }
 
 // Send encrypts and sends a basic message into the named channel of a team.
-// klass disambiguates when a name exists in more than one class; pass nil when
+// tier disambiguates when a name exists in more than one tier; pass nil when
 // the name is unique.
 func (d *Minder) Send(
 	m MetaContext,
@@ -1219,7 +1219,7 @@ func newMsgSession() *msgSession {
 }
 
 // GetThreadBookened fetches and decrypts a page of messages from the named channel.
-// klass disambiguates when a name exists in more than one class; pass nil when
+// tier disambiguates when a name exists in more than one tier; pass nil when
 // the name is unique.
 //
 // The limits are given by inclusive bookends. The direction is infered from the
@@ -1751,8 +1751,8 @@ func (d *Minder) decodeAndCacheServerMsgs(
 // channel by seq. Used to fill holes between locally-cached messages and a
 // paged GetThread fetch. Only messages that exist server-side are returned
 // (each carries its own Seq); requested seqs with no message are omitted, so
-// the result may be shorter than `seqs` and in unspecified order. klass
-// disambiguates when a name exists in more than one class; pass nil when the
+// the result may be shorter than `seqs` and in unspecified order. tier
+// disambiguates when a name exists in more than one tier; pass nil when the
 // name is unique.
 func (d *Minder) GetMsgs(
 	m MetaContext,

--- a/integration-tests/cli/rt_test.go
+++ b/integration-tests/cli/rt_test.go
@@ -33,7 +33,7 @@ func TestRTChannelMakeAndList(t *testing.T) {
 	b.runCmdToJSON(t, &teamRes, "team", "create", tm)
 	merklePoke(t)
 
-	// Without read/write roles, `new-channel` creates admin-class channels.
+	// Without read/write roles, `new-channel` creates admin-tier channels.
 	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "foo", "--description", "foobars and doobars")
 	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "hotels", "--description", "zips and dips and blips")
 	// The default channel has the empty name and (necessarily) no description.
@@ -49,15 +49,15 @@ func TestRTChannelMakeAndList(t *testing.T) {
 	b.runCmdToJSON(t, &set, "rt", "list-channels", "-t", tm)
 	require.Len(t, set.Channels, 3)
 
-	// Channels come back sorted by class (admin first) and then by name; the
+	// Channels come back sorted by tier (admin first) and then by name; the
 	// default channel's empty name sorts first.
-	assertChannel := func(idx int, klass proto.RTChannelClass, name proto.RTChannelName) {
-		require.Equal(t, klass, set.Channels[idx].Klass)
+	assertChannel := func(idx int, tier proto.RTChannelTier, name proto.RTChannelName) {
+		require.Equal(t, tier, set.Channels[idx].Tier)
 		require.Equal(t, name, set.Channels[idx].Name)
 	}
-	assertChannel(0, proto.RTChannelClass_Admin, "")
-	assertChannel(1, proto.RTChannelClass_Admin, "foo")
-	assertChannel(2, proto.RTChannelClass_Admin, "hotels")
+	assertChannel(0, proto.RTChannelTier_Admin, "")
+	assertChannel(1, proto.RTChannelTier_Admin, "foo")
+	assertChannel(2, proto.RTChannelTier_Admin, "hotels")
 
 	// The columnar text output renders the default channel as "#general" and
 	// prefixes named channels with "#".
@@ -265,7 +265,7 @@ func TestRTChannelNameNoHashPrefix(t *testing.T) {
 }
 
 // TestRTChannelNameCaseFoldCollision verifies channel names are case-folded:
-// "bar" and "Bar" both normalize to "bar", so within the same class the second
+// "bar" and "Bar" both normalize to "bar", so within the same tier the second
 // create collides with the first.
 func TestRTChannelNameCaseFoldCollision(t *testing.T) {
 	bob := makeBobAndHisAgent(t)
@@ -282,7 +282,7 @@ func TestRTChannelNameCaseFoldCollision(t *testing.T) {
 
 	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "bar")
 
-	// "Bar" normalizes to "bar" -- same name, same (admin) class -> collision.
+	// "Bar" normalizes to "bar" -- same name, same (admin) tier -> collision.
 	err := b.runCmdErr(nil, "rt", "new-channel", "-t", tm, "--name", "Bar")
 	require.Error(t, err)
 	require.Equal(t, core.RTChannelExistsError{}, err)
@@ -294,12 +294,12 @@ func TestRTChannelNameCaseFoldCollision(t *testing.T) {
 	require.Equal(t, proto.RTChannelName("bar"), set.Channels[0].Name)
 }
 
-// TestRTChannelClassFlag exercises the --channel-class flag on `rt send` / `rt
-// read`. A name may live in two classes at once (an admin "dup" and a
-// bottom/member "dup"); without a class the name is ambiguous, and the flag
-// ("a"/"admin" vs "d"/"default"/"bottom") picks one. An unknown class is a
+// TestRTChannelTierFlag exercises the --channel-tier flag on `rt send` / `rt
+// read`. A name may live in two tiers at once (an admin "dup" and a
+// bottom/member "dup"); without a tier the name is ambiguous, and the flag
+// ("a"/"admin" vs "d"/"default"/"bottom") picks one. An unknown tier is a
 // bad-args error.
-func TestRTChannelClassFlag(t *testing.T) {
+func TestRTChannelTierFlag(t *testing.T) {
 	bob := makeBobAndHisAgent(t)
 	b := bob.agent
 	defer b.stop(t)
@@ -312,7 +312,7 @@ func TestRTChannelClassFlag(t *testing.T) {
 	b.runCmdToJSON(t, &teamRes, "team", "create", tm)
 	merklePoke(t)
 
-	// "dup" in two classes: no roles -> admin class; member roles -> bottom class.
+	// "dup" in two tiers: no roles -> admin tier; member roles -> bottom tier.
 	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "dup")
 	b.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "dup",
 		"--read-role", "m/0", "--write-role", "m/0")
@@ -321,30 +321,30 @@ func TestRTChannelClassFlag(t *testing.T) {
 	b.runCmdToJSON(t, &set, "rt", "list-channels", "-t", tm)
 	require.Len(t, set.Channels, 2)
 
-	// Addressing "dup" with no class is ambiguous.
-	err := b.runCmdErr(nil, "rt", "send", "-t", tm, "--channel", "dup", "no class")
+	// Addressing "dup" with no tier is ambiguous.
+	err := b.runCmdErr(nil, "rt", "send", "-t", tm, "--channel", "dup", "no tier")
 	require.Error(t, err)
 	require.Equal(t, core.RTAmbiguousChannelError{Name: "dup"}, err)
 
-	// The flag disambiguates: short and long forms of each class.
-	b.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "dup", "--channel-class", "a", "to admin")
-	b.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "dup", "--channel-class", "d", "to bottom")
+	// The flag disambiguates: short and long forms of each tier.
+	b.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "dup", "--channel-tier", "a", "to admin")
+	b.runCmd(t, nil, "rt", "send", "-t", tm, "--channel", "dup", "--channel-tier", "d", "to bottom")
 
-	// Each class's channel holds only its own message.
+	// Each tier's channel holds only its own message.
 	var adminThread lcl.RTThreadView
-	b.runCmdToJSON(t, &adminThread, "rt", "read", "-t", tm, "--channel", "dup", "--channel-class", "admin")
+	b.runCmdToJSON(t, &adminThread, "rt", "read", "-t", tm, "--channel", "dup", "--channel-tier", "admin")
 	require.Len(t, adminThread.Msgs, 1)
 	require.Equal(t, "to admin", string(adminThread.Msgs[0].Body))
 
 	var bottomThread lcl.RTThreadView
-	b.runCmdToJSON(t, &bottomThread, "rt", "read", "-t", tm, "--channel", "dup", "--channel-class", "bottom")
+	b.runCmdToJSON(t, &bottomThread, "rt", "read", "-t", tm, "--channel", "dup", "--channel-tier", "bottom")
 	require.Len(t, bottomThread.Msgs, 1)
 	require.Equal(t, "to bottom", string(bottomThread.Msgs[0].Body))
 
-	// An unrecognized class is a bad-args error.
-	err = b.runCmdErr(nil, "rt", "send", "-t", tm, "--channel", "dup", "--channel-class", "bogus", "nope")
+	// An unrecognized tier is a bad-args error.
+	err = b.runCmdErr(nil, "rt", "send", "-t", tm, "--channel", "dup", "--channel-tier", "bogus", "nope")
 	require.Error(t, err)
-	require.Equal(t, core.BadArgsError("bad channel class"), err)
+	require.Equal(t, core.BadArgsError("bad channel tier"), err)
 }
 
 // TestRTReadPaging walks backwards through a thread with `rt read --before`,
@@ -406,9 +406,9 @@ func TestRTReadPaging(t *testing.T) {
 }
 
 // TestRTUnreadableChannelHiddenFromInbox checks the server's read-role gating of
-// the channel list within the member tier. A bottom-class channel is sealed at
-// member viz 5; a member at viz 0 still receives it (the class gate admits all
-// members to bottom-class channels) but is below the read role, so its
+// the channel list within the member tier. A bottom-tier channel is sealed at
+// member viz 5; a member at viz 0 still receives it (the tier gate admits all
+// members to bottom-tier channels) but is below the read role, so its
 // description/last-message are withheld and it's flagged unreadable and hidden
 // from the inbox. Its name is still returned, though, so client-side collision
 // detection reserves it -- the lower member can't create a same-named channel.
@@ -460,7 +460,7 @@ func TestRTUnreadableChannelHiddenFromInbox(t *testing.T) {
 	z := admit("m/5")
 	defer z.stop(t)
 
-	// A bottom-class channel readable only at member viz 5.
+	// A bottom-tier channel readable only at member viz 5.
 	x.runCmd(t, nil, "rt", "new-channel", "-t", tm, "--name", "secret",
 		"--description", "eyes only", "--read-role", "m/5", "--write-role", "m/5")
 
@@ -484,7 +484,7 @@ func TestRTUnreadableChannelHiddenFromInbox(t *testing.T) {
 	y.runCmdToJSON(t, &yset, "rt", "list-channels", "-t", tm)
 	require.Len(t, yset.Channels, 0)
 
-	// ...but the name is still reserved: y can't create a colliding bottom-class
+	// ...but the name is still reserved: y can't create a colliding bottom-tier
 	// "secret" channel, because collision detection still sees it.
 	err = y.runCmdErr(nil, "rt", "new-channel", "-t", tm, "--name", "secret")
 	require.Error(t, err)

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -89,25 +89,25 @@ func TestRTMinderMakeChannelSimple(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, lst.Channels, 6)
 
-	assertChannel := func(idx int, klass proto.RTChannelClass, name proto.RTChannelName) {
-		require.Equal(t, lst.Channels[idx].Klass, klass)
+	assertChannel := func(idx int, tier proto.RTChannelTier, name proto.RTChannelName) {
+		require.Equal(t, lst.Channels[idx].Tier, tier)
 		require.Equal(t, lst.Channels[idx].Name, name)
 	}
 
-	assertChannel(0, proto.RTChannelClass_Admin, "")
-	assertChannel(1, proto.RTChannelClass_Admin, "foo")
-	assertChannel(2, proto.RTChannelClass_Admin, "hotels")
-	assertChannel(3, proto.RTChannelClass_Bottom, "")
-	assertChannel(4, proto.RTChannelClass_Bottom, "alumni")
-	assertChannel(5, proto.RTChannelClass_Bottom, "hotels")
+	assertChannel(0, proto.RTChannelTier_Admin, "")
+	assertChannel(1, proto.RTChannelTier_Admin, "foo")
+	assertChannel(2, proto.RTChannelTier_Admin, "hotels")
+	assertChannel(3, proto.RTChannelTier_Bottom, "")
+	assertChannel(4, proto.RTChannelTier_Bottom, "alumni")
+	assertChannel(5, proto.RTChannelTier_Bottom, "hotels")
 
 	lst, err = minderCoco.ListAllChannelsForTeam(mc, fqt, proto.RTAppID_Chat)
 	require.NoError(t, err)
 	require.Len(t, lst.Channels, 3)
 
-	assertChannel(0, proto.RTChannelClass_Bottom, "")
-	assertChannel(1, proto.RTChannelClass_Bottom, "alumni")
-	assertChannel(2, proto.RTChannelClass_Bottom, "hotels")
+	assertChannel(0, proto.RTChannelTier_Bottom, "")
+	assertChannel(1, proto.RTChannelTier_Bottom, "alumni")
+	assertChannel(2, proto.RTChannelTier_Bottom, "hotels")
 
 	// now we'll test the race-and-retry features
 	ch1 := make(chan struct{})
@@ -161,13 +161,13 @@ func TestRTMinderMakeChannelSimple(t *testing.T) {
 	lst, err = minderCoco.ListAllChannelsForTeam(mc, fqt, proto.RTAppID_Chat)
 	require.NoError(t, err)
 	require.Len(t, lst.Channels, 4)
-	assertChannel(3, proto.RTChannelClass_Bottom, "zd")
+	assertChannel(3, proto.RTChannelTier_Bottom, "zd")
 
 	lst, err = minderBluey.ListAllChannelsForTeam(mb, fqt, proto.RTAppID_Chat)
 	require.NoError(t, err)
 	require.Len(t, lst.Channels, 8)
-	assertChannel(3, proto.RTChannelClass_Admin, "zc")
-	assertChannel(7, proto.RTChannelClass_Bottom, "zd")
+	assertChannel(3, proto.RTChannelTier_Admin, "zc")
+	assertChannel(7, proto.RTChannelTier_Bottom, "zd")
 }
 
 // TestRTMinderGeneralNameReserved checks the minder reserves the "general"
@@ -204,7 +204,7 @@ func TestRTMinderGeneralNameReserved(t *testing.T) {
 
 // TestRTMinderChannelNameCaseFoldCollision checks the minder's collision
 // detection normalizes case: "bar" and "Bar" are the same name within the same
-// class, so the second create collides. (Companion to the same-case collisions
+// tier, so the second create collides. (Companion to the same-case collisions
 // in TestRTMinderMakeChannelSimple.)
 func TestRTMinderChannelNameCaseFoldCollision(t *testing.T) {
 	tew := testEnvBeta(t)
@@ -219,7 +219,7 @@ func TestRTMinderChannelNameCaseFoldCollision(t *testing.T) {
 	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "bar", "the bar channel", proto.RolePairOpt{})
 	require.NoError(t, err)
 
-	// "Bar" normalizes to "bar" -- same name, same (admin) class -> collision.
+	// "Bar" normalizes to "bar" -- same name, same (admin) tier -> collision.
 	_, err = minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "Bar", "the BAR channel", proto.RolePairOpt{})
 	require.Equal(t, core.RTChannelExistsError{}, err)
 
@@ -232,7 +232,7 @@ func TestRTMinderChannelNameCaseFoldCollision(t *testing.T) {
 
 func makeChannelSpecifier(nm proto.RTChannelName) lcl.RTChannelSpecifier {
 	return lcl.NewRTChannelSpecifierWithName(
-		lcl.RTChannelNameAndClass{
+		lcl.RTChannelNameAndTier{
 			Name: nm,
 		},
 	)
@@ -242,11 +242,11 @@ func makeChannelSpecifierWithString(s string) lcl.RTChannelSpecifier {
 	return makeChannelSpecifier(proto.RTChannelName(s))
 }
 
-func makeChannelSpecifierWithClass(s string, kls proto.RTChannelClass) lcl.RTChannelSpecifier {
+func makeChannelSpecifierWithTier(s string, kls proto.RTChannelTier) lcl.RTChannelSpecifier {
 	return lcl.NewRTChannelSpecifierWithName(
-		lcl.RTChannelNameAndClass{
-			Name:  proto.RTChannelName(s),
-			Klass: kls,
+		lcl.RTChannelNameAndTier{
+			Name: proto.RTChannelName(s),
+			Tier: kls,
 		},
 	)
 }
@@ -786,7 +786,7 @@ func TestRTMinderEvilServerRecentsHoleFill(t *testing.T) {
 }
 
 // TestRTSendReadPermissions exercises the server-side authorization machinery
-// for send (write role) and read (read role / channel class), from the point of
+// for send (write role) and read (read role / channel tier), from the point of
 // view of a low-privilege member who must be *denied* — the cases the
 // owner-only happy-path tests never reach.
 func TestRTSendReadPermissions(t *testing.T) {
@@ -822,7 +822,7 @@ func TestRTSendReadPermissions(t *testing.T) {
 		proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.DefaultRole})
 	require.NoError(t, err)
 
-	// "brass": an admin-class channel coco shouldn't even be able to see.
+	// "brass": an admin-tier channel coco shouldn't even be able to see.
 	_, err = minderBluey.MakeChannel(mb, fqt, proto.RTAppID_Chat, "brass",
 		"admins only",
 		proto.RolePairOpt{Read: &proto.AdminRole, Write: &proto.AdminRole})
@@ -855,7 +855,7 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.Len(t, msgs, 1)
 	require.Equal(t, "official notice", string(msgs[0].Body))
 
-	// coco can't even see the admin-class channel, so she can't address it.
+	// coco can't even see the admin-tier channel, so she can't address it.
 	lst, err := minderCoco.ListAllChannelsForTeam(mc, fqt, proto.RTAppID_Chat)
 	require.NoError(t, err)
 	for _, ch := range lst.Channels {
@@ -909,7 +909,7 @@ func TestRTSendEncryptionRole(t *testing.T) {
 }
 
 // TestRTChannelDisambiguation covers a name shared by an admin and a bottom
-// channel: addressing by name alone is ambiguous, but a channel class resolves
+// channel: addressing by name alone is ambiguous, but a channel tier resolves
 // it to exactly one channel.
 func TestRTChannelDisambiguation(t *testing.T) {
 	tew := testEnvBeta(t)
@@ -921,7 +921,7 @@ func TestRTChannelDisambiguation(t *testing.T) {
 	minder := librt.NewMinder(mb.G().ActiveUser())
 	fqt := tm.ToFQTeamParsed(t)
 
-	// Two channels both named "general": one admin-class, one bottom-class.
+	// Two channels both named "general": one admin-tier, one bottom-tier.
 	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "", "for admins",
 		proto.RolePairOpt{Read: &proto.AdminRole})
 	require.NoError(t, err)
@@ -929,8 +929,8 @@ func TestRTChannelDisambiguation(t *testing.T) {
 		proto.RolePairOpt{Read: &proto.DefaultRole})
 	require.NoError(t, err)
 
-	admin := proto.RTChannelClass_Admin
-	bottom := proto.RTChannelClass_Bottom
+	admin := proto.RTChannelTier_Admin
+	bottom := proto.RTChannelTier_Bottom
 
 	// Addressing by name alone can't choose between them.
 	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat,
@@ -940,22 +940,22 @@ func TestRTChannelDisambiguation(t *testing.T) {
 		makeChannelSpecifierWithString(""), 0)
 	require.Equal(t, core.RTAmbiguousChannelError{Name: ""}, err)
 
-	// A class disambiguates, and each channel keeps its own thread.
+	// A tier disambiguates, and each channel keeps its own thread.
 	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat,
-		makeChannelSpecifierWithClass("", admin),
+		makeChannelSpecifierWithTier("", admin),
 		[]byte("admin msg"))
 	require.NoError(t, err)
 	_, err = minder.Send(mb, fqt, proto.RTAppID_Chat,
-		makeChannelSpecifierWithClass("", bottom),
+		makeChannelSpecifierWithTier("", bottom),
 		[]byte("bottom msg"))
 	require.NoError(t, err)
 
-	adminMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, makeChannelSpecifierWithClass("", admin), 0)
+	adminMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, makeChannelSpecifierWithTier("", admin), 0)
 	require.NoError(t, err)
 	require.Len(t, adminMsgs, 1)
 	require.Equal(t, "admin msg", string(adminMsgs[0].Body))
 
-	bottomMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, makeChannelSpecifierWithClass("", bottom), 0)
+	bottomMsgs, err := minder.GetThreadRecentMsgs(mb, fqt, proto.RTAppID_Chat, makeChannelSpecifierWithTier("", bottom), 0)
 	require.NoError(t, err)
 	require.Len(t, bottomMsgs, 1)
 	require.Equal(t, "bottom msg", string(bottomMsgs[0].Body))

--- a/lib/core/errors.go
+++ b/lib/core/errors.go
@@ -1361,14 +1361,14 @@ func (r RTRaceError) Error() string {
 }
 
 // RTAmbiguousChannelError is returned when a channel is addressed by name only
-// but more than one channel (of different classes) shares that name. The caller
-// should retry with a channel class to disambiguate. Name is the ambiguous name.
+// but more than one channel (of different tiers) shares that name. The caller
+// should retry with a channel tier to disambiguate. Name is the ambiguous name.
 type RTAmbiguousChannelError struct {
 	Name proto.RTChannelName
 }
 
 func (r RTAmbiguousChannelError) Error() string {
-	return fmt.Sprintf("ambiguous channel name %q; specify a channel class", r.Name.DecorateToString())
+	return fmt.Sprintf("ambiguous channel name %q; specify a channel tier", r.Name.DecorateToString())
 }
 
 type RTNotFoundError string

--- a/proto-src/lcl/realtime.snowp
+++ b/proto-src/lcl/realtime.snowp
@@ -2,9 +2,9 @@
 
 go:import "github.com/foks-proj/go-foks/proto/lib" as lib;
 
-struct RTChannelNameAndClass {
+struct RTChannelNameAndTier {
     name @0 : lib.RTChannelName;
-    klass @1: lib.RTChannelClass;
+    tier @1: lib.RTChannelTier;
 }
 
 enum RTChannelSpecifierType {
@@ -15,7 +15,7 @@ enum RTChannelSpecifierType {
 
 variant RTChannelSpecifier switch (t : RTChannelSpecifierType) {
     case ID @1: lib.RTChannelID;
-    case Name @2: RTChannelNameAndClass;
+    case Name @2: RTChannelNameAndTier;
     default: void;
 }
 
@@ -33,7 +33,7 @@ struct RTChannelMetadataPlaintext {
     name @3 : lib.RTChannelName;
     desc @4 : Option(lib.RTChannelDesc);
     roles @5 : lib.RolePair;
-    klass @6 : lib.RTChannelClass;
+    tier @6 : lib.RTChannelTier;
     updatedAt @7 : lib.RTChannelSetVersion;
     unreadable @8 : Bool; // caller can't read this channel (role below read role);
                           // kept for name-collision detection, hidden from the inbox

--- a/proto-src/lib/realtime.snowp
+++ b/proto-src/lib/realtime.snowp
@@ -137,7 +137,7 @@ struct RTBoxRG{
 
 typedef RTChannelSetVersion = Uint;
 
-enum RTChannelClass {
+enum RTChannelTier {
     None @0;
     Bottom @1;
     Admin @2;

--- a/proto-src/rem/realtime.snowp
+++ b/proto-src/rem/realtime.snowp
@@ -70,7 +70,7 @@ struct RTChannelMetadata @0xddf6b26b2ace1535 {
     ctime @8 : lib.Time;
     mtime @9 : lib.Time;
     updatedAt @10 : lib.RTChannelSetVersion;
-    klass @11 : lib.RTChannelClass;
+    tier @11 : lib.RTChannelTier;
     unreadable @12 : Bool; // caller's role is below the read role: name is shown
                            // (for collision detection) but desc/lastMsg withheld
 }

--- a/proto/lcl/realtime.go
+++ b/proto/lcl/realtime.go
@@ -13,44 +13,44 @@ import (
 
 import lib "github.com/foks-proj/go-foks/proto/lib"
 
-type RTChannelNameAndClass struct {
-	Name  lib.RTChannelName
-	Klass lib.RTChannelClass
+type RTChannelNameAndTier struct {
+	Name lib.RTChannelName
+	Tier lib.RTChannelTier
 }
-type RTChannelNameAndClassInternal__ struct {
+type RTChannelNameAndTierInternal__ struct {
 	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
 	Name    *lib.RTChannelNameInternal__
-	Klass   *lib.RTChannelClassInternal__
+	Tier    *lib.RTChannelTierInternal__
 }
 
-func (r RTChannelNameAndClassInternal__) Import() RTChannelNameAndClass {
-	return RTChannelNameAndClass{
+func (r RTChannelNameAndTierInternal__) Import() RTChannelNameAndTier {
+	return RTChannelNameAndTier{
 		Name: (func(x *lib.RTChannelNameInternal__) (ret lib.RTChannelName) {
 			if x == nil {
 				return ret
 			}
 			return x.Import()
 		})(r.Name),
-		Klass: (func(x *lib.RTChannelClassInternal__) (ret lib.RTChannelClass) {
+		Tier: (func(x *lib.RTChannelTierInternal__) (ret lib.RTChannelTier) {
 			if x == nil {
 				return ret
 			}
 			return x.Import()
-		})(r.Klass),
+		})(r.Tier),
 	}
 }
-func (r RTChannelNameAndClass) Export() *RTChannelNameAndClassInternal__ {
-	return &RTChannelNameAndClassInternal__{
-		Name:  r.Name.Export(),
-		Klass: r.Klass.Export(),
+func (r RTChannelNameAndTier) Export() *RTChannelNameAndTierInternal__ {
+	return &RTChannelNameAndTierInternal__{
+		Name: r.Name.Export(),
+		Tier: r.Tier.Export(),
 	}
 }
-func (r *RTChannelNameAndClass) Encode(enc rpc.Encoder) error {
+func (r *RTChannelNameAndTier) Encode(enc rpc.Encoder) error {
 	return enc.Encode(r.Export())
 }
 
-func (r *RTChannelNameAndClass) Decode(dec rpc.Decoder) error {
-	var tmp RTChannelNameAndClassInternal__
+func (r *RTChannelNameAndTier) Decode(dec rpc.Decoder) error {
+	var tmp RTChannelNameAndTierInternal__
 	err := dec.Decode(&tmp)
 	if err != nil {
 		return err
@@ -59,7 +59,7 @@ func (r *RTChannelNameAndClass) Decode(dec rpc.Decoder) error {
 	return nil
 }
 
-func (r *RTChannelNameAndClass) Bytes() []byte { return nil }
+func (r *RTChannelNameAndTier) Bytes() []byte { return nil }
 
 type RTChannelSpecifierType int
 
@@ -91,8 +91,8 @@ func (r RTChannelSpecifierType) Export() *RTChannelSpecifierTypeInternal__ {
 
 type RTChannelSpecifier struct {
 	T     RTChannelSpecifierType
-	F_1__ *lib.RTChannelID       `json:"f1,omitempty"`
-	F_2__ *RTChannelNameAndClass `json:"f2,omitempty"`
+	F_1__ *lib.RTChannelID      `json:"f1,omitempty"`
+	F_2__ *RTChannelNameAndTier `json:"f2,omitempty"`
 }
 type RTChannelSpecifierInternal__ struct {
 	_struct  struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -100,9 +100,9 @@ type RTChannelSpecifierInternal__ struct {
 	Switch__ RTChannelSpecifierInternalSwitch__
 }
 type RTChannelSpecifierInternalSwitch__ struct {
-	_struct struct{}                         `codec:",omitempty"` //lint:ignore U1000 msgpack internal field
-	F_1__   *lib.RTChannelIDInternal__       `codec:"1"`
-	F_2__   *RTChannelNameAndClassInternal__ `codec:"2"`
+	_struct struct{}                        `codec:",omitempty"` //lint:ignore U1000 msgpack internal field
+	F_1__   *lib.RTChannelIDInternal__      `codec:"1"`
+	F_2__   *RTChannelNameAndTierInternal__ `codec:"2"`
 }
 
 func (r RTChannelSpecifier) GetT() (ret RTChannelSpecifierType, err error) {
@@ -129,7 +129,7 @@ func (r RTChannelSpecifier) Id() lib.RTChannelID {
 	}
 	return *r.F_1__
 }
-func (r RTChannelSpecifier) Name() RTChannelNameAndClass {
+func (r RTChannelSpecifier) Name() RTChannelNameAndTier {
 	if r.F_2__ == nil {
 		panic("unexpected nil case; should have been checked")
 	}
@@ -144,7 +144,7 @@ func NewRTChannelSpecifierWithId(v lib.RTChannelID) RTChannelSpecifier {
 		F_1__: &v,
 	}
 }
-func NewRTChannelSpecifierWithName(v RTChannelNameAndClass) RTChannelSpecifier {
+func NewRTChannelSpecifierWithName(v RTChannelNameAndTier) RTChannelSpecifier {
 	return RTChannelSpecifier{
 		T:     RTChannelSpecifierType_Name,
 		F_2__: &v,
@@ -170,11 +170,11 @@ func (r RTChannelSpecifierInternal__) Import() RTChannelSpecifier {
 			})(x)
 			return &tmp
 		})(r.Switch__.F_1__),
-		F_2__: (func(x *RTChannelNameAndClassInternal__) *RTChannelNameAndClass {
+		F_2__: (func(x *RTChannelNameAndTierInternal__) *RTChannelNameAndTier {
 			if x == nil {
 				return nil
 			}
-			tmp := (func(x *RTChannelNameAndClassInternal__) (ret RTChannelNameAndClass) {
+			tmp := (func(x *RTChannelNameAndTierInternal__) (ret RTChannelNameAndTier) {
 				if x == nil {
 					return ret
 				}
@@ -194,7 +194,7 @@ func (r RTChannelSpecifier) Export() *RTChannelSpecifierInternal__ {
 				}
 				return (*x).Export()
 			})(r.F_1__),
-			F_2__: (func(x *RTChannelNameAndClass) *RTChannelNameAndClassInternal__ {
+			F_2__: (func(x *RTChannelNameAndTier) *RTChannelNameAndTierInternal__ {
 				if x == nil {
 					return nil
 				}
@@ -303,7 +303,7 @@ type RTChannelMetadataPlaintext struct {
 	Name       lib.RTChannelName
 	Desc       *lib.RTChannelDesc
 	Roles      lib.RolePair
-	Klass      lib.RTChannelClass
+	Tier       lib.RTChannelTier
 	UpdatedAt  lib.RTChannelSetVersion
 	Unreadable bool
 }
@@ -315,7 +315,7 @@ type RTChannelMetadataPlaintextInternal__ struct {
 	Name       *lib.RTChannelNameInternal__
 	Desc       *lib.RTChannelDescInternal__
 	Roles      *lib.RolePairInternal__
-	Klass      *lib.RTChannelClassInternal__
+	Tier       *lib.RTChannelTierInternal__
 	UpdatedAt  *lib.RTChannelSetVersionInternal__
 	Unreadable *bool
 }
@@ -364,12 +364,12 @@ func (r RTChannelMetadataPlaintextInternal__) Import() RTChannelMetadataPlaintex
 			}
 			return x.Import()
 		})(r.Roles),
-		Klass: (func(x *lib.RTChannelClassInternal__) (ret lib.RTChannelClass) {
+		Tier: (func(x *lib.RTChannelTierInternal__) (ret lib.RTChannelTier) {
 			if x == nil {
 				return ret
 			}
 			return x.Import()
-		})(r.Klass),
+		})(r.Tier),
 		UpdatedAt: (func(x *lib.RTChannelSetVersionInternal__) (ret lib.RTChannelSetVersion) {
 			if x == nil {
 				return ret
@@ -397,7 +397,7 @@ func (r RTChannelMetadataPlaintext) Export() *RTChannelMetadataPlaintextInternal
 			return (*x).Export()
 		})(r.Desc),
 		Roles:      r.Roles.Export(),
-		Klass:      r.Klass.Export(),
+		Tier:       r.Tier.Export(),
 		UpdatedAt:  r.UpdatedAt.Export(),
 		Unreadable: &r.Unreadable,
 	}

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -5182,34 +5182,34 @@ func (t *RTMsgType) ImportFromDB(s string) error {
 	return nil
 }
 
-func (c RTChannelClass) String() string {
+func (c RTChannelTier) String() string {
 	switch c {
-	case RTChannelClass_Bottom:
+	case RTChannelTier_Bottom:
 		return "bottom"
-	case RTChannelClass_Admin:
+	case RTChannelTier_Admin:
 		return "admin"
 	}
 	return "error"
 }
 
-func (c RTChannelClass) ExportToDB() (string, error) {
+func (c RTChannelTier) ExportToDB() (string, error) {
 	switch c {
-	case RTChannelClass_Bottom:
+	case RTChannelTier_Bottom:
 		return "bottom", nil
-	case RTChannelClass_Admin:
+	case RTChannelTier_Admin:
 		return "admin", nil
 	}
-	return "", DataError(fmt.Sprintf("bad RTChannelClass (%d) for DB", c))
+	return "", DataError(fmt.Sprintf("bad RTChannelTier (%d) for DB", c))
 }
 
-func (c *RTChannelClass) ImportFromDB(s string) error {
+func (c *RTChannelTier) ImportFromDB(s string) error {
 	switch s {
 	case "bottom":
-		*c = RTChannelClass_Bottom
+		*c = RTChannelTier_Bottom
 	case "admin":
-		*c = RTChannelClass_Admin
+		*c = RTChannelTier_Admin
 	default:
-		return DataError(fmt.Sprintf("bad RTChannelClass (%s) in DB", s))
+		return DataError(fmt.Sprintf("bad RTChannelTier (%s) in DB", s))
 	}
 	return nil
 }

--- a/proto/lib/realtime.go
+++ b/proto/lib/realtime.go
@@ -1335,32 +1335,32 @@ func (r RTChannelSetVersion) Bytes() []byte {
 	return nil
 }
 
-type RTChannelClass int
+type RTChannelTier int
 
 const (
-	RTChannelClass_None   RTChannelClass = 0
-	RTChannelClass_Bottom RTChannelClass = 1
-	RTChannelClass_Admin  RTChannelClass = 2
+	RTChannelTier_None   RTChannelTier = 0
+	RTChannelTier_Bottom RTChannelTier = 1
+	RTChannelTier_Admin  RTChannelTier = 2
 )
 
-var RTChannelClassMap = map[string]RTChannelClass{
+var RTChannelTierMap = map[string]RTChannelTier{
 	"None":   0,
 	"Bottom": 1,
 	"Admin":  2,
 }
-var RTChannelClassRevMap = map[RTChannelClass]string{
+var RTChannelTierRevMap = map[RTChannelTier]string{
 	0: "None",
 	1: "Bottom",
 	2: "Admin",
 }
 
-type RTChannelClassInternal__ RTChannelClass
+type RTChannelTierInternal__ RTChannelTier
 
-func (r RTChannelClassInternal__) Import() RTChannelClass {
-	return RTChannelClass(r)
+func (r RTChannelTierInternal__) Import() RTChannelTier {
+	return RTChannelTier(r)
 }
-func (r RTChannelClass) Export() *RTChannelClassInternal__ {
-	return ((*RTChannelClassInternal__)(&r))
+func (r RTChannelTier) Export() *RTChannelTierInternal__ {
+	return ((*RTChannelTierInternal__)(&r))
 }
 
 type MsgBodyType int

--- a/proto/rem/realtime.go
+++ b/proto/rem/realtime.go
@@ -436,7 +436,7 @@ type RTChannelMetadata struct {
 	Ctime      lib.Time
 	Mtime      lib.Time
 	UpdatedAt  lib.RTChannelSetVersion
-	Klass      lib.RTChannelClass
+	Tier       lib.RTChannelTier
 	Unreadable bool
 }
 type RTChannelMetadataInternal__ struct {
@@ -452,7 +452,7 @@ type RTChannelMetadataInternal__ struct {
 	Ctime      *lib.TimeInternal__
 	Mtime      *lib.TimeInternal__
 	UpdatedAt  *lib.RTChannelSetVersionInternal__
-	Klass      *lib.RTChannelClassInternal__
+	Tier       *lib.RTChannelTierInternal__
 	Unreadable *bool
 }
 
@@ -536,12 +536,12 @@ func (r RTChannelMetadataInternal__) Import() RTChannelMetadata {
 			}
 			return x.Import()
 		})(r.UpdatedAt),
-		Klass: (func(x *lib.RTChannelClassInternal__) (ret lib.RTChannelClass) {
+		Tier: (func(x *lib.RTChannelTierInternal__) (ret lib.RTChannelTier) {
 			if x == nil {
 				return ret
 			}
 			return x.Import()
-		})(r.Klass),
+		})(r.Tier),
 		Unreadable: (func(x *bool) (ret bool) {
 			if x == nil {
 				return ret
@@ -573,7 +573,7 @@ func (r RTChannelMetadata) Export() *RTChannelMetadataInternal__ {
 		Ctime:      r.Ctime.Export(),
 		Mtime:      r.Mtime.Export(),
 		UpdatedAt:  r.UpdatedAt.Export(),
-		Klass:      r.Klass.Export(),
+		Tier:       r.Tier.Export(),
 		Unreadable: &r.Unreadable,
 	}
 }

--- a/server/realtime/channels.go
+++ b/server/realtime/channels.go
@@ -102,11 +102,11 @@ func readAllChannels(
 	error,
 ) {
 
-	// Every can read channel class "bottom", but only
+	// Every can read channel tier "bottom", but only
 	// admins and above can read "admin" channels.
-	var classes []string = []string{"bottom"}
+	var tiers []string = []string{"bottom"}
 	if role.IsAdminOrAbove() {
-		classes = append(classes, "admin")
+		tiers = append(tiers, "admin")
 	}
 	appDB, err := app.ExportToDB()
 	if err != nil {
@@ -119,18 +119,18 @@ func readAllChannels(
 		        c.write_role_type, c.write_role_viz_level,
 		        c.last_msg_type, c.last_msg_seq, c.last_send_time,
 		        cp.party_id, cp.uid,
-		        c.ctime, c.mtime, c.updated_at_set_vers, c.class
+		        c.ctime, c.mtime, c.updated_at_set_vers, c.tier
 		 FROM channels c
 		 LEFT JOIN channel_parties cp ON
 		     cp.short_host_id = c.short_host_id
 		     AND cp.channel_id = c.channel_id
 		     AND cp.party_no = c.last_sender_no
-		 WHERE c.short_host_id=$1 AND c.parent_team_id=$2 AND c.app_id=$3 AND c.class = ANY($4)
+		 WHERE c.short_host_id=$1 AND c.parent_team_id=$2 AND c.app_id=$3 AND c.tier = ANY($4)
 		 ORDER BY c.channel_id ASC`,
 		m.ShortHostID().ExportToDB(),
 		team.ExportToDB(),
 		appDB,
-		classes,
+		tiers,
 	)
 	if err != nil {
 		return nil, err
@@ -206,7 +206,7 @@ func readAllChannels(
 			lastSendTime                  *time.Time
 			ctime, mtime                  time.Time
 			updatedAtSetVers              int
-			classRaw                      string
+			tierRaw                       string
 		)
 		err := rows.Scan(
 			&idRaw, &seqno, &nameBoxRaw, &descBoxRaw,
@@ -214,7 +214,7 @@ func readAllChannels(
 			&lastMsgType, &lastMsgSeq, &lastSendTime,
 			&partyIDRaw, &uidRaw,
 			&ctime, &mtime, &updatedAtSetVers,
-			&classRaw,
+			&tierRaw,
 		)
 		if err != nil {
 			return nil, err
@@ -267,13 +267,13 @@ func readAllChannels(
 		if lm != nil {
 			md.LastMsg = lm
 		}
-		err = md.Klass.ImportFromDB(classRaw)
+		err = md.Tier.ImportFromDB(tierRaw)
 		if err != nil {
 			return nil, err
 		}
 
-		// The channel name is sealed at the class floor, so its name (and very
-		// existence) is visible to everyone the class gate admits -- this is
+		// The channel name is sealed at the tier floor, so its name (and very
+		// existence) is visible to everyone the tier gate admits -- this is
 		// needed for name-collision detection at create time, since names are
 		// ciphertext the server can't dedupe itself. The description and
 		// last-message preview, however, are sealed at the finer read role: don't
@@ -329,8 +329,8 @@ func (c *channelMaker) checkPerms(m shared.MetaContext) error {
 	if writeRole.LessThan(*readRole) {
 		return core.PermissionError("write role is less than read role")
 	}
-	if c.md.Klass == proto.RTChannelClass_Admin && !c.dstRole.IsAdminOrAbove() {
-		return core.PermissionError("user role too low to make an admin class channel")
+	if c.md.Tier == proto.RTChannelTier_Admin && !c.dstRole.IsAdminOrAbove() {
+		return core.PermissionError("user role too low to make an admin tier channel")
 	}
 	return nil
 }
@@ -434,7 +434,7 @@ func (c *channelMaker) insertChannel(m shared.MetaContext) error {
 		return err
 	}
 
-	class, err := c.md.Klass.ExportToDB()
+	tier, err := c.md.Tier.ExportToDB()
 	if err != nil {
 		return err
 	}
@@ -448,7 +448,7 @@ func (c *channelMaker) insertChannel(m shared.MetaContext) error {
 		m.Ctx(),
 		`INSERT INTO channels
 			(short_host_id, channel_id, parent_team_id, app_id, channel_id_full,
-			 seqno, name_box, name_box_ptk_gen, class, desc_box, desc_box_ptk_gen,
+			 seqno, name_box, name_box_ptk_gen, tier, desc_box, desc_box_ptk_gen,
 			 read_role_type, read_role_viz_level, write_role_type, write_role_viz_level,
 			 ctime, mtime, updated_at_set_vers)
 		VALUES($1, $2, $3, $4, $5,
@@ -463,7 +463,7 @@ func (c *channelMaker) insertChannel(m shared.MetaContext) error {
 		int64(c.md.Seqno),
 		nameBox,
 		int(c.md.NameBox.Rg.Gen),
-		class,
+		tier,
 		descBox,
 		descGen,
 		readType,

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -62,6 +62,9 @@ var serverConfigPatch2 string
 //go:embed patches/foks_server_config/p3.sql
 var serverConfigPatch3 string
 
+//go:embed patches/foks_realtime/p1.sql
+var realtimePatch1 string
+
 var Patches = map[string]map[int]string{
 	"foks_users": {
 		1: usersPatch1,
@@ -74,5 +77,8 @@ var Patches = map[string]map[int]string{
 		1: serverConfigPatch1,
 		2: serverConfigPatch2,
 		3: serverConfigPatch3,
+	},
+	"foks_realtime": {
+		1: realtimePatch1,
 	},
 }

--- a/server/sql/foks_realtime.sql
+++ b/server/sql/foks_realtime.sql
@@ -42,14 +42,14 @@ CREATE TABLE channel_sets (
 );
 
 /*
- * At first, there are two classes of channels: bottom and admin. For admin class,
+ * At first, there are two tiers of channels: bottom and admin. For admin tier,
  * only admins and above can see the name of the channel. For bottom, anyone (including lowly bots)
- * can see the channel name. So a class can have two "general" channels, one for *, 
+ * can see the channel name. So a tier can have two "general" channels, one for *,
  * and one for admin+. Note that there can be finer granularity on channel descriptions
  * and channel data. But for channel names, we need to enforce this simplification so
  * that clients won't collide in generating channel names.
  */
-CREATE TYPE channel_class AS ENUM('bottom', 'admin');
+CREATE TYPE channel_tier AS ENUM('bottom', 'admin');
 
 /*
  * channels: every (team, app) pair has 1+ channels. channel_id is unique
@@ -65,7 +65,7 @@ CREATE TABLE channels (
     seqno INTEGER NOT NULL, /* metadata seqno; CAS on update */
     name_box BYTEA NOT NULL, /* PTK-encrypted channel name + structural variant */
     name_box_ptk_gen INTEGER NOT NULL, /* PTK gen used for name_box */
-    class channel_class NOT NULL, /* see desc of channel_class above */
+    tier channel_tier NOT NULL, /* see desc of channel_tier above */
     desc_box BYTEA, /* PTK-encrypted channel descriptio + structural variant */
     desc_box_ptk_gen INTEGER, /* PTK gen used for desc_box */
     read_role_type SMALLINT NOT NULL, /* read role of the data (not channel name) */

--- a/server/sql/patches/foks_realtime/p1.sql
+++ b/server/sql/patches/foks_realtime/p1.sql
@@ -1,0 +1,6 @@
+
+/* Rename the channel "class" concept to "tier" (see foks_realtime.sql).
+ * Renaming the enum type and the column preserves all existing data and the
+ * 'bottom'/'admin' values; only the names change. */
+ALTER TYPE channel_class RENAME TO channel_tier;
+ALTER TABLE channels RENAME COLUMN class TO tier;


### PR DESCRIPTION
Renames the **channel class** concept to **channel tier** across the proto schema, generated Go, hand-written code, the CLI, **and the Postgres schema** — variables, structs, command-line flags, and the database.

## What changed

**Proto (`proto-src/*.snowp`, regenerated with `make proto`)**
- enum `RTChannelClass` → `RTChannelTier`
- struct `RTChannelNameAndClass` → `RTChannelNameAndTier`
- field `klass` → `tier` (generated Go field `Klass` → `Tier`)

**Hand-written Go**
- field accesses `.Klass` → `.Tier`; locals/params/helpers: `newChClass`→`newChTier`, `searchClass`→`searchTier`, `rtChannelClassGlyph`→`rtChannelTierGlyph`, `makeChannelSpecifierWithClass`→`makeChannelSpecifierWithTier`, `cc`/`klass`/`classRaw`/`classes`→`tier`/`tierRaw`/`tiers`, etc.
- enum `String`/`ExportToDB`/`ImportFromDB` and error text updated

**CLI**
- flag `--channel-class` → `--channel-tier` (help text too)
- `list-channels` column header `Class` → `Tier`
- error strings: `bad channel class` → `bad channel tier`; ambiguous-channel hint now says `specify a channel tier`
- test `TestRTChannelClassFlag` → `TestRTChannelTierFlag`

**Database schema (Postgres)**
- `server/sql/foks_realtime.sql` (base schema, fresh installs): enum `channel_class` → `channel_tier`, column `channels.class` → `channels.tier`
- `server/realtime/channels.go`: the SQL query literals now reference the `tier` column
- `server/sql/patches/foks_realtime/p1.sql`: upgrade path for existing deployed DBs via `ALTER TYPE ... RENAME TO` / `ALTER TABLE ... RENAME COLUMN` (data- and value-preserving — only names change), registered in `sql/embed.go`'s `Patches` map

This follows the established convention (cf. `foks_users/p5`, `foks_server_config/p3`): the base schema carries the final state for fresh installs, and the numbered patch carries the incremental DDL to bring older databases forward. The enum still serializes to the same `'bottom'`/`'admin'` values, so the rename is wire- and storage-compatible.

## Verification
- `make proto` regenerates cleanly; no stray `RTChannelClass`/`Klass`/`--channel-class`/`channel_class` remain.
- `go build ./...` and `go vet` (incl. tests) clean.
- `TestRT*` integration suites (cli + lib) and `proto/lib` unit tests pass; the lib suite spins up a fresh DB from the renamed base schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
