### PR TITLE
chat(1b): first stab at caching: channel sets

### DIFF
--- a/client/libclient/cache.go
+++ b/client/libclient/cache.go
@@ -1,0 +1,179 @@
+package libclient
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+type Versioner interface {
+	GetVersion() proto.Version
+}
+
+type memNode[V any, M any] struct {
+	v *V
+	m *M
+}
+
+type CacheSettings struct {
+	UseMem  bool
+	UseDisk bool
+}
+
+type Cache[
+	S Scoper, // Scoper for DB cache, usually an FQParty
+	K comparable, // The DB Key, like a DirID, etc
+	V Versioner, // The value to store
+	VP interface { // Pointer to the value to store, must implement core.Codecable
+		*V
+		core.Codecable
+	},
+	MV any, // A MemVal, something that we only store in memory (like decrypted data)
+] struct {
+	sync.RWMutex
+	typ      lcl.DataType
+	Scope    S
+	m        map[K]*memNode[V, MV]
+	dbt      DbType
+	Settings CacheSettings
+}
+
+func NewCache[
+	S Scoper,
+	K comparable,
+	V Versioner,
+	VP interface {
+		*V
+		core.Codecable
+	},
+	MV any,
+](typ lcl.DataType, s S, settings CacheSettings) *Cache[S, K, V, VP, MV] {
+	return &Cache[S, K, V, VP, MV]{
+		typ:      typ,
+		Scope:    s,
+		dbt:      DbTypeSoft,
+		Settings: settings,
+	}
+}
+
+func (c *Cache[S, K, V, VP, MV]) PutMem(k K, v V, mv *MV) {
+	c.Lock()
+	defer c.Unlock()
+	if !c.Settings.UseMem {
+		return
+	}
+	if c.m == nil {
+		c.m = make(map[K]*memNode[V, MV])
+	}
+	c.m[k] = &memNode[V, MV]{v: &v, m: mv}
+}
+
+func (c *Cache[S, K, V, VP, MV]) clearMem(k K) {
+	c.Lock()
+	defer c.Unlock()
+	if c.m == nil {
+		return
+	}
+	delete(c.m, k)
+}
+
+func (c *Cache[S, K, V, VP, MV]) putDb(m MetaContext, k K, v V) error {
+	if !c.Settings.UseDisk {
+		return nil
+	}
+	return m.DbPut(
+		c.dbt,
+		PutArg{
+			Scope: c.Scope,
+			Typ:   c.typ,
+			Key:   k,
+			Val:   (VP)(&v),
+		},
+	)
+}
+
+func (c *Cache[S, K, V, VP, MV]) Put(m MetaContext, k K, v V, memVal *MV) error {
+	err := c.putDb(m, k, v)
+	if err != nil {
+		return err
+	}
+	c.PutMem(k, v, memVal)
+	return nil
+}
+
+func (c *Cache[S, K, V, VP, MV]) getMem(k K) (*V, *MV) {
+	c.RLock()
+	defer c.RUnlock()
+	if c.m == nil {
+		return nil, nil
+	}
+	v := c.m[k]
+	if v == nil {
+		return nil, nil
+	}
+	return v.v, v.m
+}
+
+func (c *Cache[S, K, V, VP, MV]) getDb(m MetaContext, k K) (*V, error) {
+	if !c.Settings.UseDisk {
+		return nil, nil
+	}
+	var ret V
+	getSlot := (VP)(&ret)
+	_, err := m.DbGet(getSlot, c.dbt, c.Scope, c.typ, k)
+	if err != nil && errors.Is(err, core.RowNotFoundError{}) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
+func (c *Cache[S, K, V, VP, MV]) Get(m MetaContext, k K) (*V, *MV, error) {
+	v, memVal := c.getMem(k)
+	if v != nil {
+		return v, memVal, nil
+	}
+	ret, err := c.getDb(m, k)
+	if err != nil {
+		return nil, nil, err
+	}
+	if ret == nil {
+		return nil, nil, nil
+	}
+	c.PutMem(k, *ret, nil)
+
+	return ret, nil, nil
+}
+
+func (c *Cache[S, K, V, VP, MV]) ClearBefore(m MetaContext, k K, vers Versioner) error {
+	if vers.GetVersion() == 0 {
+		return nil
+	}
+	v, _ := c.getMem(k)
+	if v != nil {
+		cacheVers := (*v).GetVersion()
+		if cacheVers == 0 || cacheVers == vers.GetVersion() {
+			return nil
+		}
+		if cacheVers != 0 && cacheVers != vers.GetVersion() {
+			c.clearMem(k)
+		}
+	}
+	v, err := c.getDb(m, k)
+	if err != nil {
+		return err
+	}
+	if v == nil {
+		return nil
+	}
+	err = m.DbDelete(c.dbt, c.Scope, c.typ, k)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/client/libkv/cache.go
+++ b/client/libkv/cache.go
@@ -4,9 +4,7 @@
 package libkv
 
 import (
-	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/lib/core"
@@ -16,184 +14,15 @@ import (
 	"github.com/foks-proj/go-foks/proto/rem"
 )
 
-type Versioner interface {
-	GetVersion() proto.KVVersion
-}
-
-type memNode[V any, M any] struct {
-	v *V
-	m *M
-}
-
-type CacheSettings struct {
-	UseMem  bool
-	UseDisk bool
-}
-
-type Cache[
-	S libclient.Scoper, // Scoper for DB cache, usually an FQParty
-	K comparable, // The DB Key, like a DirID, etc
-	V Versioner, // The value to store
-	VP interface { // Pointer to the value to store, must implement core.Codecable
-		*V
-		core.Codecable
-	},
-	MV any, // A MemVal, something that we only store in memory (like decrypted data)
-] struct {
-	sync.RWMutex
-	typ      lcl.DataType
-	s        S
-	m        map[K]*memNode[V, MV]
-	dbt      libclient.DbType
-	settings CacheSettings
-}
-
-func NewCache[
-	S libclient.Scoper,
-	K comparable,
-	V Versioner,
-	VP interface {
-		*V
-		core.Codecable
-	},
-	MV any,
-](typ lcl.DataType, s S, settings CacheSettings) *Cache[S, K, V, VP, MV] {
-	return &Cache[S, K, V, VP, MV]{
-		typ:      typ,
-		s:        s,
-		dbt:      libclient.DbTypeSoft,
-		settings: settings,
-	}
-}
-
-func (c *Cache[S, K, V, VP, MV]) putMem(k K, v V, mv *MV) {
-	c.Lock()
-	defer c.Unlock()
-	if !c.settings.UseMem {
-		return
-	}
-	if c.m == nil {
-		c.m = make(map[K]*memNode[V, MV])
-	}
-	c.m[k] = &memNode[V, MV]{v: &v, m: mv}
-}
-
-func (c *Cache[S, K, V, VP, MV]) clearMem(k K) {
-	c.Lock()
-	defer c.Unlock()
-	if c.m == nil {
-		return
-	}
-	delete(c.m, k)
-}
-
-func (c *Cache[S, K, V, VP, MV]) putDb(m MetaContext, k K, v V) error {
-	if !c.settings.UseDisk {
-		return nil
-	}
-	return m.DbPut(
-		c.dbt,
-		libclient.PutArg{
-			Scope: c.s,
-			Typ:   c.typ,
-			Key:   k,
-			Val:   (VP)(&v),
-		},
-	)
-}
-
-func (c *Cache[S, K, V, VP, MV]) Put(m MetaContext, k K, v V, memVal *MV) error {
-	err := c.putDb(m, k, v)
-	if err != nil {
-		return err
-	}
-	c.putMem(k, v, memVal)
-	return nil
-}
-
-func (c *Cache[S, K, V, VP, MV]) getMem(k K) (*V, *MV) {
-	c.RLock()
-	defer c.RUnlock()
-	if c.m == nil {
-		return nil, nil
-	}
-	v := c.m[k]
-	if v == nil {
-		return nil, nil
-	}
-	return v.v, v.m
-}
-
-func (c *Cache[S, K, V, VP, MV]) getDb(m MetaContext, k K) (*V, error) {
-	if !c.settings.UseDisk {
-		return nil, nil
-	}
-	var ret V
-	getSlot := (VP)(&ret)
-	_, err := m.DbGet(getSlot, c.dbt, c.s, c.typ, k)
-	if err != nil && errors.Is(err, core.RowNotFoundError{}) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &ret, nil
-}
-
-func (c *Cache[S, K, V, VP, MV]) Get(m MetaContext, k K) (*V, *MV, error) {
-	v, memVal := c.getMem(k)
-	if v != nil {
-		return v, memVal, nil
-	}
-	ret, err := c.getDb(m, k)
-	if err != nil {
-		return nil, nil, err
-	}
-	if ret == nil {
-		return nil, nil, nil
-	}
-	c.putMem(k, *ret, nil)
-
-	return ret, nil, nil
-}
-
-func (c *Cache[S, K, V, VP, MV]) ClearBefore(m MetaContext, k K, vers proto.KVVersion) error {
-	if vers == 0 {
-		return nil
-	}
-	v, _ := c.getMem(k)
-	if v != nil {
-		cacheVers := (*v).GetVersion()
-		if cacheVers == 0 || cacheVers == vers {
-			return nil
-		}
-		if cacheVers != 0 && cacheVers != vers {
-			c.clearMem(k)
-		}
-	}
-	v, err := c.getDb(m, k)
-	if err != nil {
-		return err
-	}
-	if v == nil {
-		return nil
-	}
-	err = m.DbDelete(c.dbt, c.s, c.typ, k)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 type RootCache struct {
-	*Cache[*proto.FQParty, core.EmptyKey, proto.KVRoot, *proto.KVRoot, struct{}]
+	*libclient.Cache[*proto.FQParty, core.EmptyKey, proto.KVRoot, *proto.KVRoot, struct{}]
 }
 
 func (r *RootCache) ClearBefore(m MetaContext, vers proto.KVVersion) error {
-	if !r.settings.UseDisk {
+	if !r.Settings.UseDisk {
 		return nil
 	}
-	return r.Cache.ClearBefore(m, core.EmptyKey{}, vers)
+	return r.Cache.ClearBefore(m.Base(), core.EmptyKey{}, vers)
 }
 
 type DirSeedPair struct {
@@ -202,25 +31,25 @@ type DirSeedPair struct {
 }
 
 type DirCache struct {
-	*Cache[*proto.FQParty, proto.DirID, proto.KVDirPair, *proto.KVDirPair, DirSeedPair]
+	*libclient.Cache[*proto.FQParty, proto.DirID, proto.KVDirPair, *proto.KVDirPair, DirSeedPair]
 }
 
-func NewRootCache(p proto.FQParty, settings CacheSettings) *RootCache {
-	return &RootCache{NewCache[*proto.FQParty, core.EmptyKey, proto.KVRoot, *proto.KVRoot, struct{}](lcl.DataType_KVNSRoot, &p, settings)}
+func NewRootCache(p proto.FQParty, settings libclient.CacheSettings) *RootCache {
+	return &RootCache{libclient.NewCache[*proto.FQParty, core.EmptyKey, proto.KVRoot, *proto.KVRoot, struct{}](lcl.DataType_KVNSRoot, &p, settings)}
 }
 
 func (r *RootCache) Get(m MetaContext) (*proto.KVRoot, error) {
-	v, _, err := r.Cache.Get(m, core.EmptyKey{})
+	v, _, err := r.Cache.Get(m.Base(), core.EmptyKey{})
 	return v, err
 }
 
 func (r *RootCache) Put(m MetaContext, v proto.KVRoot) error {
-	return r.Cache.Put(m, core.EmptyKey{}, v, nil)
+	return r.Cache.Put(m.Base(), core.EmptyKey{}, v, nil)
 }
 
-func NewDirCache(p proto.FQParty, settings CacheSettings) *DirCache {
+func NewDirCache(p proto.FQParty, settings libclient.CacheSettings) *DirCache {
 	return &DirCache{
-		Cache: NewCache[
+		Cache: libclient.NewCache[
 			*proto.FQParty,
 			proto.DirID,
 			proto.KVDirPair,
@@ -299,7 +128,7 @@ func NewDirPair(o proto.FQParty, d proto.KVDirPair, s *DirSeedPair) *DirPair {
 }
 
 func (d *DirCache) Get(m MetaContext, k proto.DirID) (*DirPair, error) {
-	v, memVal, err := d.Cache.Get(m, k)
+	v, memVal, err := d.Cache.Get(m.Base(), k)
 	if err != nil {
 		return nil, err
 	}
@@ -307,17 +136,17 @@ func (d *DirCache) Get(m MetaContext, k proto.DirID) (*DirPair, error) {
 	if v == nil {
 		return nil, nil
 	}
-	return NewDirPair(*d.s, *v, memVal), nil
+	return NewDirPair(*d.Scope, *v, memVal), nil
 }
 
 func (d *DirCache) Put(m MetaContext, v *DirPair) error {
 	dp, seed := v.Split()
-	return d.Cache.Put(m, v.Id(), *dp, seed)
+	return d.Cache.Put(m.Base(), v.Id(), *dp, seed)
 }
 
 func (d *DirCache) PutMem(v *DirPair) {
 	dp, seed := v.Split()
-	d.Cache.putMem(v.Id(), *dp, seed)
+	d.Cache.PutMem(v.Id(), *dp, seed)
 }
 
 type Dirent struct {
@@ -326,12 +155,12 @@ type Dirent struct {
 }
 
 type DirentCache struct {
-	*Cache[*proto.FQParty, proto.HMAC, proto.KVDirent, *proto.KVDirent, proto.KVPathComponent]
+	*libclient.Cache[*proto.FQParty, proto.HMAC, proto.KVDirent, *proto.KVDirent, proto.KVPathComponent]
 }
 
-func NewDirentCache(p proto.FQParty, settings CacheSettings) *DirentCache {
+func NewDirentCache(p proto.FQParty, settings libclient.CacheSettings) *DirentCache {
 	return &DirentCache{
-		Cache: NewCache[
+		Cache: libclient.NewCache[
 			*proto.FQParty,
 			proto.HMAC,
 			proto.KVDirent,
@@ -342,7 +171,7 @@ func NewDirentCache(p proto.FQParty, settings CacheSettings) *DirentCache {
 }
 
 func (d *DirentCache) Get(m MetaContext, k proto.HMAC) (*Dirent, error) {
-	v, memVal, err := d.Cache.Get(m, k)
+	v, memVal, err := d.Cache.Get(m.Base(), k)
 	if err != nil {
 		return nil, err
 	}
@@ -357,11 +186,11 @@ func (d *DirentCache) Get(m MetaContext, k proto.HMAC) (*Dirent, error) {
 }
 
 func (d *DirentCache) Put(m MetaContext, v *Dirent) error {
-	return d.Cache.Put(m, v.NameMac, v.KVDirent, v.Nm)
+	return d.Cache.Put(m.Base(), v.NameMac, v.KVDirent, v.Nm)
 }
 
 func (d *DirentCache) PutMem(v *Dirent) {
-	d.Cache.putMem(v.NameMac, v.KVDirent, v.Nm)
+	d.Cache.PutMem(v.NameMac, v.KVDirent, v.Nm)
 }
 
 func (d *DirPair) WriteTo() *DirWithSeed {
@@ -377,12 +206,12 @@ type Symlink struct {
 }
 
 type SymlinkCache struct {
-	*Cache[*proto.FQParty, proto.SymlinkID, proto.SmallFileBox, *proto.SmallFileBox, Symlink]
+	*libclient.Cache[*proto.FQParty, proto.SymlinkID, proto.SmallFileBox, *proto.SmallFileBox, Symlink]
 }
 
-func NewSymlinkCache(p proto.FQParty, settings CacheSettings) *SymlinkCache {
+func NewSymlinkCache(p proto.FQParty, settings libclient.CacheSettings) *SymlinkCache {
 	return &SymlinkCache{
-		Cache: NewCache[
+		Cache: libclient.NewCache[
 			*proto.FQParty,
 			proto.SymlinkID,
 			proto.SmallFileBox,
@@ -393,16 +222,16 @@ func NewSymlinkCache(p proto.FQParty, settings CacheSettings) *SymlinkCache {
 }
 
 func (s *SymlinkCache) PutMem(i proto.SymlinkID, b *proto.SmallFileBox, v *Symlink) {
-	s.Cache.putMem(i, *b, v)
+	s.Cache.PutMem(i, *b, v)
 }
 
 type SmallFileCache struct {
-	*Cache[*proto.FQParty, proto.SmallFileID, proto.SmallFileBox, *proto.SmallFileBox, lcl.SmallFileData]
+	*libclient.Cache[*proto.FQParty, proto.SmallFileID, proto.SmallFileBox, *proto.SmallFileBox, lcl.SmallFileData]
 }
 
-func NewSmallFileCache(p proto.FQParty, settings CacheSettings) *SmallFileCache {
+func NewSmallFileCache(p proto.FQParty, settings libclient.CacheSettings) *SmallFileCache {
 	return &SmallFileCache{
-		Cache: NewCache[
+		Cache: libclient.NewCache[
 			*proto.FQParty,
 			proto.SmallFileID,
 			proto.SmallFileBox,
@@ -413,16 +242,16 @@ func NewSmallFileCache(p proto.FQParty, settings CacheSettings) *SmallFileCache 
 }
 
 func (s *SmallFileCache) PutMem(i proto.SmallFileID, b *proto.SmallFileBox, v *lcl.SmallFileData) {
-	s.Cache.putMem(i, *b, v)
+	s.Cache.PutMem(i, *b, v)
 }
 
 type LargeFileMetadataCache struct {
-	*Cache[*proto.FQParty, proto.FileID, proto.LargeFileMetadata, *proto.LargeFileMetadata, proto.FileKeySeed]
+	*libclient.Cache[*proto.FQParty, proto.FileID, proto.LargeFileMetadata, *proto.LargeFileMetadata, proto.FileKeySeed]
 }
 
-func NewLargeFileMetadataCache(p proto.FQParty, settings CacheSettings) *LargeFileMetadataCache {
+func NewLargeFileMetadataCache(p proto.FQParty, settings libclient.CacheSettings) *LargeFileMetadataCache {
 	return &LargeFileMetadataCache{
-		Cache: NewCache[
+		Cache: libclient.NewCache[
 			*proto.FQParty,
 			proto.FileID,
 			proto.LargeFileMetadata,
@@ -447,13 +276,13 @@ func (c ChunkIndex) DbKey() (proto.DbKey, error) {
 }
 
 type LargeFileChunkCache struct {
-	*Cache[*proto.FQParty, ChunkIndex, rem.GetEncryptedChunkRes, *rem.GetEncryptedChunkRes, struct{}]
+	*libclient.Cache[*proto.FQParty, ChunkIndex, rem.GetEncryptedChunkRes, *rem.GetEncryptedChunkRes, struct{}]
 }
 
-func NewLargeFileChunkCache(p proto.FQParty, settings CacheSettings) *LargeFileChunkCache {
+func NewLargeFileChunkCache(p proto.FQParty, settings libclient.CacheSettings) *LargeFileChunkCache {
 	settings.UseMem = false
 	return &LargeFileChunkCache{
-		Cache: NewCache[
+		Cache: libclient.NewCache[
 			*proto.FQParty,
 			ChunkIndex,
 			rem.GetEncryptedChunkRes,
@@ -464,12 +293,12 @@ func NewLargeFileChunkCache(p proto.FQParty, settings CacheSettings) *LargeFileC
 }
 
 type GitRefSetCache struct {
-	*Cache[*proto.FQParty, proto.DirID, proto.GitRefBoxedSet, *proto.GitRefBoxedSet, gitRefSet]
+	*libclient.Cache[*proto.FQParty, proto.DirID, proto.GitRefBoxedSet, *proto.GitRefBoxedSet, gitRefSet]
 }
 
-func NewGitRefSetCache(p proto.FQParty, settings CacheSettings) *GitRefSetCache {
+func NewGitRefSetCache(p proto.FQParty, settings libclient.CacheSettings) *GitRefSetCache {
 	return &GitRefSetCache{
-		Cache: NewCache[
+		Cache: libclient.NewCache[
 			*proto.FQParty,
 			proto.DirID,
 			proto.GitRefBoxedSet,
@@ -565,7 +394,7 @@ func (c *CacheAccess) VisitDir(d proto.DirID, p *proto.KVDirPair) {
 	if p == nil {
 		return
 	}
-	v := p.GetVersion()
+	v := proto.KVVersion(p.GetVersion())
 	if c.Dir == nil {
 		c.Dir = make(map[proto.DirID]DirCacheAccess)
 	}

--- a/client/libkv/getfile.go
+++ b/client/libkv/getfile.go
@@ -76,7 +76,7 @@ func (kvp *KVParty) getSmallFile(
 	*smallFilePackage,
 	error,
 ) {
-	enc, plain, err := kvp.caches.smallFile.Get(m, id)
+	enc, plain, err := kvp.caches.smallFile.Get(m.Base(), id)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (k *Minder) getSmallFile(
 	if err != nil {
 		return nil, err
 	}
-	err = kvp.caches.smallFile.Put(m, sfid, sfb, &dat)
+	err = kvp.caches.smallFile.Put(m.Base(), sfid, sfb, &dat)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (kvp *KVParty) getLargeFileMetadata(
 	*proto.FileKeySeed,
 	error,
 ) {
-	lfmd, seed, err := kvp.caches.lfmd.Get(m, fid)
+	lfmd, seed, err := kvp.caches.lfmd.Get(m.Base(), fid)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -212,7 +212,7 @@ func (kvp *KVParty) getLargeFileMetadata(
 	if err != nil {
 		return nil, nil, err
 	}
-	kvp.caches.lfmd.putMem(fid, *lfmd, seed)
+	kvp.caches.lfmd.PutMem(fid, *lfmd, seed)
 	return lfmd, seed, nil
 }
 
@@ -256,7 +256,7 @@ func (k *Minder) getFileMetadata(
 	if err != nil {
 		return nil, nil, err
 	}
-	err = kvp.caches.lfmd.Put(m, fid, lfmd, seed)
+	err = kvp.caches.lfmd.Put(m.Base(), fid, lfmd, seed)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -272,7 +272,7 @@ func (k *Minder) getLargeFileEncryptedChunk(
 	*rem.GetEncryptedChunkRes,
 	error,
 ) {
-	chnk, _, err := kvp.caches.lfch.Get(m, ChunkIndex{FileID: fid, Offset: offset})
+	chnk, _, err := kvp.caches.lfch.Get(m.Base(), ChunkIndex{FileID: fid, Offset: offset})
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (k *Minder) getLargeFileEncryptedChunk(
 	}
 	chnk = &res
 	offset = res.Offset
-	err = kvp.caches.lfch.Put(m, ChunkIndex{FileID: fid, Offset: offset}, res, nil)
+	err = kvp.caches.lfch.Put(m.Base(), ChunkIndex{FileID: fid, Offset: offset}, res, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/libkv/gitrefs.go
+++ b/client/libkv/gitrefs.go
@@ -115,7 +115,7 @@ func (g *gitRefDirExplorer) client(m MetaContext) (*rem.KVAuth, *rem.KVStoreClie
 }
 
 func (g *gitRefDirExplorer) loadCache(m MetaContext) error {
-	disk, mem, err := g.kvp.caches.gitRefSet.Get(m, *g.did)
+	disk, mem, err := g.kvp.caches.gitRefSet.Get(m.Base(), *g.did)
 	if err != nil {
 		return err
 	}
@@ -311,7 +311,7 @@ func (g *gitRefDirExplorer) writeBack(m MetaContext) error {
 		DirVersion: g.dir.GetVersion(),
 		Refs:       g.resBoxed,
 	}
-	return g.kvp.caches.gitRefSet.Put(m, *g.did, out, g.mem)
+	return g.kvp.caches.gitRefSet.Put(m.Base(), *g.did, out, g.mem)
 }
 
 func (g *gitRefDirExplorer) init(m MetaContext) error {

--- a/client/libkv/minder.go
+++ b/client/libkv/minder.go
@@ -20,7 +20,7 @@ type KVParty struct {
 	sync.RWMutex
 	caches *caches
 	root   *proto.KVRoot
-	cs     CacheSettings
+	cs     libclient.CacheSettings
 	plcn   *libclient.PLCNode
 }
 
@@ -78,7 +78,7 @@ type caches struct {
 	upload    map[proto.FileID]*fileUploadState
 }
 
-func newCaches(p proto.FQParty, settings CacheSettings) *caches {
+func newCaches(p proto.FQParty, settings libclient.CacheSettings) *caches {
 	return &caches{
 		root:      NewRootCache(p, settings),
 		dirent:    NewDirentCache(p, settings),
@@ -98,18 +98,18 @@ type Minder struct {
 	base          *libclient.BaseMinder[KVParty, *KVParty]
 	au            *libclient.UserContext
 	probes        libclient.ProbeCollection
-	cacheSettings CacheSettings
+	cacheSettings libclient.CacheSettings
 
 	localCliMu sync.Mutex
 	localCli   *rem.KVStoreClient
 }
 
 func NewMinder(au *libclient.UserContext) *Minder {
-	cs := CacheSettings{UseMem: true, UseDisk: true}
+	cs := libclient.CacheSettings{UseMem: true, UseDisk: true}
 	return NewMinderWithCacheSettings(au, cs)
 }
 
-func NewMinderWithCacheSettings(au *libclient.UserContext, cs CacheSettings) *Minder {
+func NewMinderWithCacheSettings(au *libclient.UserContext, cs libclient.CacheSettings) *Minder {
 	ret := &Minder{cacheSettings: cs, au: au}
 	ret.base = libclient.NewBaseMinder(
 		au,
@@ -465,7 +465,7 @@ func (kvp *KVParty) getSymlink(
 	*symlinkPackage,
 	error,
 ) {
-	enc, plain, err := kvp.caches.symlink.Get(m, id)
+	enc, plain, err := kvp.caches.symlink.Get(m.Base(), id)
 	if err != nil {
 		return nil, err
 	}
@@ -1014,7 +1014,7 @@ func (k *Minder) lookupDirent(
 		if err != nil {
 			return nil, err
 		}
-		err = kvp.caches.symlink.Put(m, *slid, res.Data.Symlink(), nil)
+		err = kvp.caches.symlink.Put(m.Base(), *slid, res.Data.Symlink(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1023,7 +1023,7 @@ func (k *Minder) lookupDirent(
 		if err != nil {
 			return nil, err
 		}
-		err = kvp.caches.smallFile.Put(m, *sfid, res.Data.Smallfile(), nil)
+		err = kvp.caches.smallFile.Put(m.Base(), *sfid, res.Data.Smallfile(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1032,7 +1032,7 @@ func (k *Minder) lookupDirent(
 		if err != nil {
 			return nil, err
 		}
-		err = kvp.caches.lfmd.Put(m, *fid, res.Data.File(), nil)
+		err = kvp.caches.lfmd.Put(m.Base(), *fid, res.Data.File(), nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1238,7 +1238,7 @@ func (k *Minder) loadSymlink(
 	if err != nil {
 		return nil, err
 	}
-	err = kvp.caches.symlink.Put(m, *slid, sfb, ret)
+	err = kvp.caches.symlink.Put(m.Base(), *slid, sfb, ret)
 	if err != nil {
 		return nil, err
 	}
@@ -1811,7 +1811,7 @@ func (k *Minder) listWithDirID(
 		if err != nil {
 			return nil, err
 		}
-		err = kvp.caches.smallFile.Put(m, *sfid, ext.Sfb, nil)
+		err = kvp.caches.smallFile.Put(m.Base(), *sfid, ext.Sfb, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/client/libkv/putfile.go
+++ b/client/libkv/putfile.go
@@ -65,7 +65,7 @@ func (k *Minder) prepSmallFile(
 		return nil, nil, err
 	}
 	cachePut := func(m MetaContext) error {
-		return kvp.caches.smallFile.Put(m, *sfid, sfb, &data)
+		return kvp.caches.smallFile.Put(m.Base(), *sfid, sfb, &data)
 	}
 
 	return nid, cachePut, err
@@ -128,7 +128,7 @@ func (k *Minder) prepSymlink(
 		Raw:  path,
 	}
 	cachePut := func(m MetaContext) error {
-		return kvp.caches.symlink.Put(m, *sid, sfb, &cacheVal)
+		return kvp.caches.symlink.Put(m.Base(), *sid, sfb, &cacheVal)
 	}
 
 	return nid, cachePut, err
@@ -391,7 +391,7 @@ func (k *Minder) PutFileFirst(
 
 		// Cache the result in case we decide to fetch it again soon.
 		cacheFn := func(m MetaContext) error {
-			err = kvp.caches.lfmd.Put(m, *fid, md, &fks)
+			err = kvp.caches.lfmd.Put(m.Base(), *fid, md, &fks)
 			if err != nil {
 				return err
 			}
@@ -475,7 +475,7 @@ func (k *Minder) PutFileChunk(
 		Final:  final,
 	}
 
-	err = kvp.caches.lfch.Put(m, ChunkIndex{FileID: id, Offset: offset}, cacheEntry, nil)
+	err = kvp.caches.lfch.Put(m.Base(), ChunkIndex{FileID: id, Offset: offset}, cacheEntry, nil)
 	if err != nil {
 		return err
 	}

--- a/client/libkv/retry.go
+++ b/client/libkv/retry.go
@@ -28,7 +28,7 @@ func (m MetaContext) clearCaches(
 		return err
 	}
 	for _, dir := range vv.Path {
-		err = kvp.caches.dir.ClearBefore(m, dir.Id, dir.Vers)
+		err = kvp.caches.dir.ClearBefore(m.Base(), dir.Id, dir.Vers)
 		if err != nil {
 			return err
 		}
@@ -43,7 +43,7 @@ func (m MetaContext) clearCaches(
 				continue
 			}
 
-			err = kvp.caches.dirent.ClearBefore(m, cde.Hmac, de.Vers)
+			err = kvp.caches.dirent.ClearBefore(m.Base(), cde.Hmac, de.Vers)
 			if err != nil {
 				return err
 			}

--- a/client/librt/cache.go
+++ b/client/librt/cache.go
@@ -6,6 +6,12 @@ package librt
 import (
 	"container/list"
 	"sync"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
 )
 
 // LRU is a fixed-capacity, least-recently-used cache. It is safe for concurrent
@@ -111,4 +117,60 @@ func (l *LRU[K, V]) Purge() {
 func (l *LRU[K, V]) removeElement(el *list.Element) {
 	l.ll.Remove(el)
 	delete(l.items, el.Value.(*lruEntry[K, V]).key)
+}
+
+type ChannelSetCache struct {
+	*libclient.Cache[
+		*proto.FQParty,
+		lcl.RTChannelSetID,
+		rem.RTChannelSet,
+		*rem.RTChannelSet,
+		lcl.RTChannelMetadataPlaintextAbbrev,
+	]
+}
+
+func NewChannelSetCache(p proto.FQParty, settings libclient.CacheSettings) *ChannelSetCache {
+	return &ChannelSetCache{
+		Cache: libclient.NewCache[
+			*proto.FQParty,
+			lcl.RTChannelSetID,
+			rem.RTChannelSet,
+			*rem.RTChannelSet,
+			lcl.RTChannelMetadataPlaintextAbbrev,
+		](lcl.DataType_RTChannelSet, &p, settings),
+	}
+}
+
+type caches struct {
+	channelSets *ChannelSetCache
+}
+
+func newCaches(
+	p proto.FQParty,
+	settings libclient.CacheSettings,
+) *caches {
+	return &caches{
+		channelSets: NewChannelSetCache(p, settings),
+	}
+}
+
+func DeriveRTChannelSetID(
+	p proto.FQParty,
+	i proto.RTAppID,
+) (
+	*lcl.RTChannelSetID,
+	error,
+) {
+	var ret lcl.RTChannelSetID
+	err := core.PrefixedHashInto(
+		&lcl.RTChannelSetHashInput{
+			Fqp:   p,
+			AppID: i,
+		},
+		ret[:],
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &ret, nil
 }

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -21,7 +21,9 @@ import (
 
 type RTParty struct {
 	sync.RWMutex
-	plcn *libclient.PLCNode
+	plcn   *libclient.PLCNode
+	caches *caches
+	cs     libclient.CacheSettings
 }
 
 func (k *RTParty) TeamID() (*proto.TeamID, error) {
@@ -136,6 +138,14 @@ func (d *Minder) Metrics() MinderMetrics {
 }
 
 func NewMinder(au *libclient.UserContext) *Minder {
+	cs := libclient.CacheSettings{UseMem: true, UseDisk: true}
+	return NewMinderWithCacheSettings(au, cs)
+}
+
+func NewMinderWithCacheSettings(
+	au *libclient.UserContext,
+	cs libclient.CacheSettings,
+) *Minder {
 	if au == nil {
 		panic("nil active user")
 	}
@@ -146,7 +156,10 @@ func NewMinder(au *libclient.UserContext) *Minder {
 	}
 	ret.base = libclient.NewBaseMinder(
 		au,
-		func(n *RTParty) {},
+		func(n *RTParty) {
+			n.caches = newCaches(au.FQParty(), cs)
+			n.cs = cs
+		},
 	)
 	return ret
 }
@@ -586,6 +599,25 @@ func (k *Minder) listAllChannelsForTeam(
 	*lcl.RTChannelSetForTeam,
 	error,
 ) {
+
+	chsid, err := DeriveRTChannelSetID(rtp.plcn.FQParty(), appID)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastKnownVersion proto.RTChannelSetVersion
+	cached, _, err := rtp.caches.channelSets.Get(m.Base(), *chsid)
+	if err != nil {
+		return nil, err
+	}
+	d := make(map[proto.RTChannelID]rem.RTChannelMetadata)
+	if cached != nil {
+		lastKnownVersion = cached.Vers
+		for _, chdenc := range cached.Lst {
+			d[chdenc.Id] = chdenc
+		}
+	}
+
 	_, cli, err := k.clientLocal(m.Base(), k.au)
 	if err != nil {
 		return nil, err
@@ -598,14 +630,28 @@ func (k *Minder) listAllChannelsForTeam(
 		rem.RtListAllChannelsForTeamArg{
 			Team:  fqt.Team,
 			AppID: appID,
+			Last:  lastKnownVersion,
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	var out lcl.RTChannelSetForTeam
+	// Stomp the cached version with the new versions, in case
+	// we changed metadata.
 	for _, chmdenc := range encList.Lst {
+		d[chmdenc.Id] = chmdenc
+	}
+
+	mdlist := make([]rem.RTChannelMetadata, len(d))
+	i := 0
+	for _, v := range d {
+		mdlist[i] = v
+		i++
+	}
+
+	var out lcl.RTChannelSetForTeam
+	for _, chmdenc := range mdlist {
 		chmdpt, err := k.decryptChannelMetadata(m, rtp, chmdenc)
 		if err != nil {
 			return nil, err
@@ -615,6 +661,13 @@ func (k *Minder) listAllChannelsForTeam(
 	out.Vers = encList.Vers
 	out.Team = fqt.Team
 	out.AppID = appID
+
+	encList.Lst = mdlist
+
+	err = rtp.caches.channelSets.Put(m.Base(), *chsid, encList, nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return &out, nil
 }

--- a/docs/chat-server-design.md
+++ b/docs/chat-server-design.md
@@ -753,11 +753,14 @@ CLI-only in the core FOKS repository.
 - Simple CLI-based interface
 
 ### Stage 1b
+- Caching: channel / channel sets
+
+### Stage 1c
 
 - build ad-hoc team machinery into core FOKS
 - Complementary client features
 
-### Stage 1c
+### Stage 1d
 
 - potentially build signatures for KV-store, and messages
     - ward off misattribution attacks

--- a/integration-tests/lib/gitrefs_test.go
+++ b/integration-tests/lib/gitrefs_test.go
@@ -6,6 +6,7 @@ package lib
 import (
 	"testing"
 
+	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/client/libkv"
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
@@ -13,7 +14,7 @@ import (
 )
 
 func TestGitRefs(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 3, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 3, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	x, y, z := mdt.dev[0], mdt.dev[1], mdt.dev[2]
 	parent := "/app/git/redbulls/"
 	heads := parent + "refs/heads"
@@ -83,7 +84,7 @@ func TestGitRefs(t *testing.T) {
 }
 
 func TestGitRefsHEAD(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 1, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 1, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	x := mdt.dev[0]
 	parent := "/app/git/nycfc/"
 	x.mkdir(t, parent)

--- a/integration-tests/lib/kv_store_test.go
+++ b/integration-tests/lib/kv_store_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/client/libkv"
 	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/proto/lcl"
@@ -165,7 +166,7 @@ func TestKVStoreUserSimpleOps(t *testing.T) {
 	tew.DirectMerklePokeInTest(t)
 	mc := libkv.NewMetaContext(tew.NewClientMetaContext(t, bluey))
 
-	test := func(cs libkv.CacheSettings) {
+	test := func(cs libclient.CacheSettings) {
 		nm, err := core.RandomDomain()
 		require.NoError(t, err)
 		kvm := libkv.NewMinderWithCacheSettings(mc.G().ActiveUser(), cs)
@@ -194,9 +195,9 @@ func TestKVStoreUserSimpleOps(t *testing.T) {
 		readFile(t, kvm, mc, proto.KVPath(f2), buf)
 	}
 
-	test(libkv.CacheSettings{})
-	test(libkv.CacheSettings{UseMem: false, UseDisk: true})
-	test(libkv.CacheSettings{UseMem: true, UseDisk: true})
+	test(libclient.CacheSettings{})
+	test(libclient.CacheSettings{UseMem: false, UseDisk: true})
+	test(libclient.CacheSettings{UseMem: true, UseDisk: true})
 
 }
 
@@ -242,20 +243,20 @@ func TestKVStoreTeamSimple(t *testing.T) {
 		return p1, buf
 	}
 
-	test := func(cs libkv.CacheSettings) (proto.KVPath, []byte) {
+	test := func(cs libclient.CacheSettings) (proto.KVPath, []byte) {
 		kvm := libkv.NewMinderWithCacheSettings(mc.G().ActiveUser(), cs)
 		return testFn(t, mc, kvm)
 	}
 
-	test(libkv.CacheSettings{})
-	test(libkv.CacheSettings{UseMem: false, UseDisk: true})
-	pLast, bLast := test(libkv.CacheSettings{UseMem: true, UseDisk: true})
+	test(libclient.CacheSettings{})
+	test(libclient.CacheSettings{UseMem: false, UseDisk: true})
+	pLast, bLast := test(libclient.CacheSettings{UseMem: true, UseDisk: true})
 
-	kvmBingo := libkv.NewMinderWithCacheSettings(mBingo.G().ActiveUser(), libkv.CacheSettings{})
+	kvmBingo := libkv.NewMinderWithCacheSettings(mBingo.G().ActiveUser(), libclient.CacheSettings{})
 	readFileWithConfig(t, kvmBingo, mBingo, pLast, bLast, cfg, 0)
 
 	mCoco := libkv.NewMetaContext(tew.NewClientMetaContextWithEracer(t, coco))
-	kvmCoco := libkv.NewMinderWithCacheSettings(mCoco.G().ActiveUser(), libkv.CacheSettings{})
+	kvmCoco := libkv.NewMinderWithCacheSettings(mCoco.G().ActiveUser(), libclient.CacheSettings{})
 	_, err := kvmCoco.GetFile(mCoco, cfg, pLast)
 
 	// simple permission denied test -- should fail on the FS root, since we made it with
@@ -270,14 +271,14 @@ func kvTestAllCacheOptions(t *testing.T, testFn func(*testing.T, libkv.MetaConte
 	tew.DirectMerklePokeInTest(t)
 	mc := libkv.NewMetaContext(tew.NewClientMetaContext(t, bluey))
 
-	test := func(cs libkv.CacheSettings) {
+	test := func(cs libclient.CacheSettings) {
 		kvm := libkv.NewMinderWithCacheSettings(mc.G().ActiveUser(), cs)
 		testFn(t, mc, kvm)
 	}
 
-	test(libkv.CacheSettings{})
-	test(libkv.CacheSettings{UseMem: false, UseDisk: true})
-	test(libkv.CacheSettings{UseMem: true, UseDisk: true})
+	test(libclient.CacheSettings{})
+	test(libclient.CacheSettings{UseMem: false, UseDisk: true})
+	test(libclient.CacheSettings{UseMem: true, UseDisk: true})
 }
 
 func makeSmallFile(t *testing.T, mc libkv.MetaContext, kvm *libkv.Minder, path proto.KVPath, data string) *libkv.PutFileRes {
@@ -588,7 +589,7 @@ func TestSimpleOverwrite(t *testing.T) {
 	bluey := tew.NewTestUser(t)
 	tew.DirectMerklePokeInTest(t)
 	mc := libkv.NewMetaContext(tew.NewClientMetaContext(t, bluey))
-	kvm := libkv.NewMinderWithCacheSettings(mc.G().ActiveUser(), libkv.CacheSettings{UseDisk: true})
+	kvm := libkv.NewMinderWithCacheSettings(mc.G().ActiveUser(), libclient.CacheSettings{UseDisk: true})
 	nm, err := core.RandomDomain()
 	require.NoError(t, err)
 	f1 := proto.KVPath("/" + nm + "/foo.txt")
@@ -666,7 +667,7 @@ func (r *multiDeviceTest) reset(t *testing.T) {
 	r.prfx = prfx
 }
 
-func setupMultiDeviceTest(t *testing.T, n int, cs libkv.CacheSettings) *multiDeviceTest {
+func setupMultiDeviceTest(t *testing.T, n int, cs libclient.CacheSettings) *multiDeviceTest {
 	tew := testEnvBeta(t)
 	user := tew.NewTestUser(t)
 	d0 := user.eldest
@@ -695,7 +696,7 @@ func setupMultiDeviceTest(t *testing.T, n int, cs libkv.CacheSettings) *multiDev
 }
 
 func TestCacheInvalidations(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 2, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 2, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	x, y := mdt.dev[0], mdt.dev[1]
 	x.mkdir(t, "/a/b")
 	path := "/a/b/c.txt"
@@ -728,7 +729,7 @@ func TestCacheInvalidations(t *testing.T) {
 }
 
 func TestSymlinkLoop(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 2, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 2, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	x, y := mdt.dev[0], mdt.dev[1]
 	x.mkdir(t, "/a")
 	x.ln(t, "/a/b", "/a/c")
@@ -745,7 +746,7 @@ func TestSymlinkLoop(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 1, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 1, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	dev := mdt.dev[0]
 	mc := dev.mc
 	dev.mkdir(t, "/a")
@@ -789,7 +790,7 @@ func TestList(t *testing.T) {
 }
 
 func TestLocks(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 2, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 2, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	x, y := mdt.dev[0], mdt.dev[1]
 
 	x.mkdir(t, "/a")
@@ -836,7 +837,7 @@ func TestSmallFileRightAtSmallFileBoundary(t *testing.T) {
 	bluey := tew.NewTestUser(t)
 	tew.DirectMerklePokeInTest(t)
 	mc := libkv.NewMetaContext(tew.NewClientMetaContext(t, bluey))
-	kvm := libkv.NewMinderWithCacheSettings(mc.G().ActiveUser(), libkv.CacheSettings{})
+	kvm := libkv.NewMinderWithCacheSettings(mc.G().ActiveUser(), libclient.CacheSettings{})
 
 	_, err := kvm.Mkdir(mc, lcl.KVConfig{MkdirP: true}, proto.KVPath("/a"))
 	require.NoError(t, err)
@@ -856,7 +857,7 @@ func TestSmallFileRightAtSmallFileBoundary(t *testing.T) {
 }
 
 func TestListByMtime(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 1, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 1, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	dev := mdt.dev[0]
 	mc := dev.mc
 	dev.mkdir(t, "/a")
@@ -889,7 +890,7 @@ func TestListByMtime(t *testing.T) {
 }
 
 func TestListCache(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 1, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 1, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	dev := mdt.dev[0]
 	dev.mkdir(t, "/a")
 	dev.mkdir(t, "/b")
@@ -907,7 +908,7 @@ func TestListCache(t *testing.T) {
 }
 
 func TestUnlink(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 1, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 1, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	dev := mdt.dev[0]
 	dev.mkdir(t, "/a")
 	dev.echo(t, "aa", "/a/b")
@@ -925,7 +926,7 @@ func TestUnlink(t *testing.T) {
 }
 
 func TestChangeChunkSize(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 1, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 1, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	dev := mdt.dev[0]
 	file := dev.pathify("r.txt")
 	dat := writeRandomFileWithConfig(t, dev.kvm, dev.mc, file, 10777, lcl.KVConfig{}, 4096)

--- a/integration-tests/lib/quota_test.go
+++ b/integration-tests/lib/quota_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/foks-proj/go-foks/client/libkv"
+	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/integration-tests/common"
 	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/proto/infra"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestLargeFileUsage(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 1, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 1, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	dev := mdt.dev[0]
 	file := dev.pathify("big.txt")
 	sz := 1024 * 1024
@@ -39,7 +39,7 @@ func randomPlanName(t *testing.T) string {
 }
 
 func TestWritesOverQuotaFail(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 1, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 1, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	m := mdt.tew.MetaContext()
 	ctx := m.Ctx()
 	cli, fn := common.TestQuotaSrvCli(t, m)
@@ -147,7 +147,7 @@ func TestWritesOverQuotaFail(t *testing.T) {
 }
 
 func TestQuotaAndTeams(t *testing.T) {
-	mdt := setupMultiDeviceTest(t, 1, libkv.CacheSettings{UseMem: true, UseDisk: true})
+	mdt := setupMultiDeviceTest(t, 1, libclient.CacheSettings{UseMem: true, UseDisk: true})
 	m := mdt.tew.MetaContext()
 	ctx := m.Ctx()
 	cli, fn := common.TestQuotaSrvCli(t, m)

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -202,6 +202,45 @@ func TestRTMinderGeneralNameReserved(t *testing.T) {
 	require.Equal(t, proto.RTChannelName(""), lst.Channels[0].Name)
 }
 
+// TestRTMinderMakeChannelWarmCacheNoRace guards against a regression in the
+// channel-set caching path. When the client's cached version already matches
+// the server's, the server returns an empty delta; if it (or the client) lets
+// the set version collapse to 0, the next MakeChannel computes a stale
+// SetVers and spuriously loses the optimistic-concurrency check, forcing a
+// retry. With no contention there should be exactly zero races.
+func TestRTMinderMakeChannelWarmCacheNoRace(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+	tm := tew.makeTeamForOwner(t, bluey)
+
+	mb := librt.NewMetaContext(tew.NewClientMetaContextWithEracer(t, bluey))
+	minder := librt.NewMinder(mb.G().ActiveUser())
+	fqt := tm.ToFQTeamParsed(t)
+
+	// Create one channel, then list -- this warms the cache to the current
+	// server version, so the next list will take the "already fresh" path.
+	_, err := minder.MakeChannel(mb, fqt, proto.RTAppID_Chat, "first", "first channel", proto.RolePairOpt{})
+	require.NoError(t, err)
+	_, err = minder.ListAllChannelsForTeam(mb, fqt, proto.RTAppID_Chat)
+	require.NoError(t, err)
+
+	// A second create with a warm, current cache must succeed without ever
+	// hitting the race-retry path. HitRaceHook fires once per retry; with the
+	// version bug it fired (i == 0) before succeeding on the retry.
+	raced := false
+	hooks := librt.MakeChannelTestHooks{
+		HitRaceHook: func(i int) { raced = true },
+	}
+	_, err = minder.MakeChannelWithTestHooks(mb, fqt, proto.RTAppID_Chat, "second", "second channel", proto.RolePairOpt{}, &hooks)
+	require.NoError(t, err)
+	require.False(t, raced, "warm-cache create should not hit the race-retry path")
+
+	lst, err := minder.ListAllChannelsForTeam(mb, fqt, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Len(t, lst.Channels, 2)
+}
+
 // TestRTMinderChannelNameCaseFoldCollision checks the minder's collision
 // detection normalizes case: "bar" and "Bar" are the same name within the same
 // tier, so the second create collides. (Companion to the same-case collisions

--- a/integration-tests/lib/vanity_test.go
+++ b/integration-tests/lib/vanity_test.go
@@ -178,7 +178,7 @@ func TestNewVanityDomain(t *testing.T) {
 	kvmc := libkv.NewMetaContext(mu)
 	kvm := libkv.NewMinderWithCacheSettings(
 		mu.G().ActiveUser(),
-		libkv.CacheSettings{UseMem: true, UseDisk: true},
+		libclient.CacheSettings{UseMem: true, UseDisk: true},
 	)
 
 	writeRandomFile(t, kvm, kvmc, "/smol1.txt", 1024*5)

--- a/proto-src/lcl/db.snowp
+++ b/proto-src/lcl/db.snowp
@@ -36,6 +36,7 @@ enum DataType {
 
     RTThreadMsgData @97;
     RTOutboxMsg @98;
+    RTChannelSet @99;
 }
 
 typedef ScopeLabel = Blob;

--- a/proto-src/lcl/realtime.snowp
+++ b/proto-src/lcl/realtime.snowp
@@ -91,3 +91,16 @@ protocol RealTime
     ) -> RTThreadView;
 
 }
+
+struct RTChannelSetHashInput @0xc6985a2917572061 {
+    fqp @0 : lib.FQParty;
+    appID @1 : lib.RTAppID;
+}
+
+// A hash of the above, to identify a channel for 
+typedef RTChannelSetID = lib.StdHash;
+
+struct RTChannelMetadataPlaintextAbbrev {
+    name @0 : lib.RTChannelName;
+    desc @1 : Option(lib.RTChannelDesc);
+}

--- a/proto-src/lib/common.snowp
+++ b/proto-src/lib/common.snowp
@@ -573,3 +573,4 @@ struct Date {
 }
 
 typedef DbKey = Blob;
+typedef Version = Uint;

--- a/proto-src/rem/realtime.snowp
+++ b/proto-src/rem/realtime.snowp
@@ -160,9 +160,12 @@ protocol RealTime
     // caller to have at least one user_channels row in this team. Stage 1a
     // does no pagination; channel counts are expected to be small. Note, we 
     // are focusing on a particular team, not all channels available to the user.
+    // Include a `last` so that only new changes to the channel set are included,
+    // allowing fresh caches to power the flow rather than needing new server data.
     rtListAllChannelsForTeam @2 (
         team @0 : lib.TeamID,
-        appID @1 : lib.RTAppID
+        appID @1 : lib.RTAppID,
+        last @2 : lib.RTChannelSetVersion
     ) -> RTChannelSet;
 
     // Send a message. Team auth at write role of the channel.

--- a/proto/lcl/db.go
+++ b/proto/lcl/db.go
@@ -75,6 +75,7 @@ const (
 	DataType_KVGitRefSet          DataType = 73
 	DataType_RTThreadMsgData      DataType = 97
 	DataType_RTOutboxMsg          DataType = 98
+	DataType_RTChannelSet         DataType = 99
 )
 
 var DataTypeMap = map[string]DataType{
@@ -104,6 +105,7 @@ var DataTypeMap = map[string]DataType{
 	"KVGitRefSet":          73,
 	"RTThreadMsgData":      97,
 	"RTOutboxMsg":          98,
+	"RTChannelSet":         99,
 }
 var DataTypeRevMap = map[DataType]string{
 	0:  "None",
@@ -132,6 +134,7 @@ var DataTypeRevMap = map[DataType]string{
 	73: "KVGitRefSet",
 	97: "RTThreadMsgData",
 	98: "RTOutboxMsg",
+	99: "RTChannelSet",
 }
 
 type DataTypeInternal__ DataType

--- a/proto/lcl/extras.go
+++ b/proto/lcl/extras.go
@@ -222,3 +222,7 @@ func (r RTChannelSpecifier) String() string {
 	}
 	return s
 }
+
+func (r RTChannelSetForTeam) GetVersion() lib.Version {
+	return r.Vers.GetVersion()
+}

--- a/proto/lcl/realtime.go
+++ b/proto/lcl/realtime.go
@@ -1173,6 +1173,154 @@ func RealTimeProtocol(i RealTimeInterface) rpc.ProtocolV2 {
 	}
 }
 
+type RTChannelSetHashInput struct {
+	Fqp   lib.FQParty
+	AppID lib.RTAppID
+}
+type RTChannelSetHashInputInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Fqp     *lib.FQPartyInternal__
+	AppID   *lib.RTAppIDInternal__
+}
+
+func (r RTChannelSetHashInputInternal__) Import() RTChannelSetHashInput {
+	return RTChannelSetHashInput{
+		Fqp: (func(x *lib.FQPartyInternal__) (ret lib.FQParty) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Fqp),
+		AppID: (func(x *lib.RTAppIDInternal__) (ret lib.RTAppID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.AppID),
+	}
+}
+func (r RTChannelSetHashInput) Export() *RTChannelSetHashInputInternal__ {
+	return &RTChannelSetHashInputInternal__{
+		Fqp:   r.Fqp.Export(),
+		AppID: r.AppID.Export(),
+	}
+}
+func (r *RTChannelSetHashInput) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTChannelSetHashInput) Decode(dec rpc.Decoder) error {
+	var tmp RTChannelSetHashInputInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+var RTChannelSetHashInputTypeUniqueID = rpc.TypeUniqueID(0xc6985a2917572061)
+
+func (r *RTChannelSetHashInput) GetTypeUniqueID() rpc.TypeUniqueID {
+	return RTChannelSetHashInputTypeUniqueID
+}
+func (r *RTChannelSetHashInput) Bytes() []byte { return nil }
+
+type RTChannelSetID lib.StdHash
+type RTChannelSetIDInternal__ lib.StdHashInternal__
+
+func (r RTChannelSetID) Export() *RTChannelSetIDInternal__ {
+	tmp := ((lib.StdHash)(r))
+	return ((*RTChannelSetIDInternal__)(tmp.Export()))
+}
+func (r RTChannelSetIDInternal__) Import() RTChannelSetID {
+	tmp := (lib.StdHashInternal__)(r)
+	return RTChannelSetID((func(x *lib.StdHashInternal__) (ret lib.StdHash) {
+		if x == nil {
+			return ret
+		}
+		return x.Import()
+	})(&tmp))
+}
+
+func (r *RTChannelSetID) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTChannelSetID) Decode(dec rpc.Decoder) error {
+	var tmp RTChannelSetIDInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r RTChannelSetID) Bytes() []byte {
+	return ((lib.StdHash)(r)).Bytes()
+}
+
+type RTChannelMetadataPlaintextAbbrev struct {
+	Name lib.RTChannelName
+	Desc *lib.RTChannelDesc
+}
+type RTChannelMetadataPlaintextAbbrevInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Name    *lib.RTChannelNameInternal__
+	Desc    *lib.RTChannelDescInternal__
+}
+
+func (r RTChannelMetadataPlaintextAbbrevInternal__) Import() RTChannelMetadataPlaintextAbbrev {
+	return RTChannelMetadataPlaintextAbbrev{
+		Name: (func(x *lib.RTChannelNameInternal__) (ret lib.RTChannelName) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Name),
+		Desc: (func(x *lib.RTChannelDescInternal__) *lib.RTChannelDesc {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *lib.RTChannelDescInternal__) (ret lib.RTChannelDesc) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(r.Desc),
+	}
+}
+func (r RTChannelMetadataPlaintextAbbrev) Export() *RTChannelMetadataPlaintextAbbrevInternal__ {
+	return &RTChannelMetadataPlaintextAbbrevInternal__{
+		Name: r.Name.Export(),
+		Desc: (func(x *lib.RTChannelDesc) *lib.RTChannelDescInternal__ {
+			if x == nil {
+				return nil
+			}
+			return (*x).Export()
+		})(r.Desc),
+	}
+}
+func (r *RTChannelMetadataPlaintextAbbrev) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTChannelMetadataPlaintextAbbrev) Decode(dec rpc.Decoder) error {
+	var tmp RTChannelMetadataPlaintextAbbrevInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTChannelMetadataPlaintextAbbrev) Bytes() []byte { return nil }
+
 func init() {
 	rpc.AddUnique(RealTimeProtocolID)
+	rpc.AddUnique(RTChannelSetHashInputTypeUniqueID)
 }

--- a/proto/lib/common.go
+++ b/proto/lib/common.go
@@ -7467,6 +7467,41 @@ func (d DbKey) Bytes() []byte {
 	return (d)[:]
 }
 
+type Version uint64
+type VersionInternal__ uint64
+
+func (v Version) Export() *VersionInternal__ {
+	tmp := ((uint64)(v))
+	return ((*VersionInternal__)(&tmp))
+}
+func (v VersionInternal__) Import() Version {
+	tmp := (uint64)(v)
+	return Version((func(x *uint64) (ret uint64) {
+		if x == nil {
+			return ret
+		}
+		return *x
+	})(&tmp))
+}
+
+func (v *Version) Encode(enc rpc.Encoder) error {
+	return enc.Encode(v.Export())
+}
+
+func (v *Version) Decode(dec rpc.Decoder) error {
+	var tmp VersionInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*v = tmp.Import()
+	return nil
+}
+
+func (v Version) Bytes() []byte {
+	return nil
+}
+
 func init() {
 	rpc.AddUnique(HostIDTypeUniqueID)
 	rpc.AddUnique(FQUserTypeUniqueID)

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -3483,31 +3483,29 @@ func (k KVNodeID) IsTombstone() bool {
 	return len(k) < 1 || k[0] == byte(KVNodeType_None)
 }
 
-func (k KVRoot) GetVersion() KVVersion {
-	return k.Vers
-}
+func (k KVRoot) GetVersion() Version { return Version(k.Vers) }
 
-func (k KVDirPair) GetVersion() KVVersion {
+func (k KVDirPair) GetVersion() Version {
 	if k.Encrypting != nil {
-		return k.Encrypting.Version
+		return Version(k.Encrypting.Version)
 	}
-	return k.Active.Version
+	return Version(k.Active.Version)
 }
 
-func (k KVDirent) GetVersion() KVVersion {
-	return k.Version
+func (k KVDirent) GetVersion() Version {
+	return Version(k.Version)
 }
 
-func (s SmallFileBox) GetVersion() KVVersion {
-	return 0
+func (s SmallFileBox) GetVersion() Version {
+	return Version(0)
 }
 
-func (m LargeFileMetadata) GetVersion() KVVersion {
-	return m.Vers
+func (m LargeFileMetadata) GetVersion() Version {
+	return Version(m.Vers)
 }
 
-func (r GitRefBoxedSet) GetVersion() KVVersion {
-	return 0
+func (r GitRefBoxedSet) GetVersion() Version {
+	return Version(0)
 }
 
 func (t EntityType) IsECDSA() bool {
@@ -5317,4 +5315,25 @@ func (c RTChannelName) DecorateToString() string {
 		c = RTGeneralChannel
 	}
 	return "#" + string(c)
+}
+
+func (v RTChannelSetVersion) IsFirst() bool {
+	return v == RTChannelSetVersion(1)
+}
+
+func (v RTChannelSetVersion) IsValid() bool {
+	return v > RTChannelSetVersion(0)
+}
+
+func (v RTChannelSetVersion) Int() int {
+	return int(v)
+}
+func (v Version) GetVersion() Version {
+	return v
+}
+func (v KVVersion) GetVersion() Version {
+	return Version(v)
+}
+func (v RTChannelSetVersion) GetVersion() Version {
+	return Version(v)
 }

--- a/proto/rem/extras.go
+++ b/proto/rem/extras.go
@@ -93,8 +93,8 @@ func (r TeamRawInboxRowVar) Token() (lib.TeamRSVP, error) {
 	return zed, lib.DataError("bad team join req type")
 }
 
-func (r GetEncryptedChunkRes) GetVersion() lib.KVVersion {
-	return 0
+func (r GetEncryptedChunkRes) GetVersion() lib.Version {
+	return lib.Version(0)
 }
 
 func (i LockID) ExportToDB() []byte {
@@ -150,4 +150,8 @@ func (a MultiUseInviteCode) Cmp(b MultiUseInviteCode) int {
 	x1 := strings.ToLower(a.String())
 	x2 := strings.ToLower(b.String())
 	return strings.Compare(x1, x2)
+}
+
+func (r RTChannelSet) GetVersion() lib.Version {
+	return lib.Version(r.Vers)
 }

--- a/proto/rem/realtime.go
+++ b/proto/rem/realtime.go
@@ -1309,11 +1309,13 @@ func (r *RtGetChannelArg) Bytes() []byte { return nil }
 type RtListAllChannelsForTeamArg struct {
 	Team  lib.TeamID
 	AppID lib.RTAppID
+	Last  lib.RTChannelSetVersion
 }
 type RtListAllChannelsForTeamArgInternal__ struct {
 	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
 	Team    *lib.TeamIDInternal__
 	AppID   *lib.RTAppIDInternal__
+	Last    *lib.RTChannelSetVersionInternal__
 }
 
 func (r RtListAllChannelsForTeamArgInternal__) Import() RtListAllChannelsForTeamArg {
@@ -1330,12 +1332,19 @@ func (r RtListAllChannelsForTeamArgInternal__) Import() RtListAllChannelsForTeam
 			}
 			return x.Import()
 		})(r.AppID),
+		Last: (func(x *lib.RTChannelSetVersionInternal__) (ret lib.RTChannelSetVersion) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Last),
 	}
 }
 func (r RtListAllChannelsForTeamArg) Export() *RtListAllChannelsForTeamArgInternal__ {
 	return &RtListAllChannelsForTeamArgInternal__{
 		Team:  r.Team.Export(),
 		AppID: r.AppID.Export(),
+		Last:  r.Last.Export(),
 	}
 }
 func (r *RtListAllChannelsForTeamArg) Encode(enc rpc.Encoder) error {

--- a/server/realtime/channels.go
+++ b/server/realtime/channels.go
@@ -16,6 +16,7 @@ func ListAllChannels(
 	m shared.MetaContext,
 	team proto.TeamID,
 	app proto.RTAppID,
+	last proto.RTChannelSetVersion,
 ) (
 	*rem.RTChannelSet,
 	error,
@@ -39,13 +40,20 @@ func ListAllChannels(
 	vers, mtime, err := readChannelSet(m, rtdb, team, app)
 	if err != nil {
 		return nil, err
-
 	}
 	var ret rem.RTChannelSet
 	ret.Mtime = mtime
 	ret.Vers = vers
 
-	lst, err := readAllChannels(m, rtdb, team, app, *role)
+	// User already has a fresh version, so there's no need to send the channel
+	// list back. Still return the current version (and an empty list) so the
+	// caller can confirm its cache is current rather than collapsing to v0.
+	if vers == last {
+		ret.Lst = []rem.RTChannelMetadata{}
+		return &ret, nil
+	}
+
+	lst, err := readAllChannels(m, rtdb, team, app, *role, last)
 	if err != nil {
 		return nil, err
 	}
@@ -97,6 +105,7 @@ func readAllChannels(
 	team proto.TeamID,
 	app proto.RTAppID,
 	role core.RoleKey,
+	last proto.RTChannelSetVersion,
 ) (
 	[]rem.RTChannelMetadata,
 	error,
@@ -125,12 +134,17 @@ func readAllChannels(
 		     cp.short_host_id = c.short_host_id
 		     AND cp.channel_id = c.channel_id
 		     AND cp.party_no = c.last_sender_no
-		 WHERE c.short_host_id=$1 AND c.parent_team_id=$2 AND c.app_id=$3 AND c.tier = ANY($4)
+		 WHERE c.short_host_id=$1 
+		 AND c.parent_team_id=$2 
+		 AND c.app_id=$3 
+		 AND c.tier = ANY($4)
+		 AND c.updated_at_set_vers > $5
 		 ORDER BY c.channel_id ASC`,
 		m.ShortHostID().ExportToDB(),
 		team.ExportToDB(),
 		appDB,
 		tiers,
+		last.Int(),
 	)
 	if err != nil {
 		return nil, err
@@ -336,7 +350,7 @@ func (c *channelMaker) checkPerms(m shared.MetaContext) error {
 }
 
 func (c *channelMaker) checkArgs(m shared.MetaContext) error {
-	if c.vers < 1 {
+	if !c.vers.IsValid() {
 		return core.BadArgsError("c.vers must be 1 or greater")
 	}
 	if c.vers != c.md.UpdatedAt {
@@ -346,11 +360,14 @@ func (c *channelMaker) checkArgs(m shared.MetaContext) error {
 }
 
 func (c *channelMaker) commit(m shared.MetaContext) error {
-
-	if c.vers == 1 {
+	switch {
+	case !c.vers.IsValid():
+		return core.BadArgsError("bad channel version (must be > 0)")
+	case c.vers.IsFirst():
 		return c.insertNewChannelSetRow(m)
+	default:
+		return c.updateChannelSet(m)
 	}
-	return c.updateChannelSet(m)
 }
 
 func (c *channelMaker) insertNewChannelSetRow(m shared.MetaContext) error {

--- a/server/realtime/server.go
+++ b/server/realtime/server.go
@@ -67,7 +67,7 @@ func (c *ClientConn) RtListAllChannelsForTeam(
 ) {
 	var ret rem.RTChannelSet
 	m := shared.NewMetaContextConn(ctx, c)
-	p, err := ListAllChannels(m, arg.Team, arg.AppID)
+	p, err := ListAllChannels(m, arg.Team, arg.AppID, arg.Last)
 	if err != nil {
 		return ret, err
 	}

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -65,6 +65,9 @@ var serverConfigPatch3 string
 //go:embed patches/foks_realtime/p1.sql
 var realtimePatch1 string
 
+//go:embed patches/foks_realtime/p2.sql
+var realtimePatch2 string
+
 var Patches = map[string]map[int]string{
 	"foks_users": {
 		1: usersPatch1,
@@ -80,5 +83,6 @@ var Patches = map[string]map[int]string{
 	},
 	"foks_realtime": {
 		1: realtimePatch1,
+		2: realtimePatch2,
 	},
 }

--- a/server/sql/foks_realtime.sql
+++ b/server/sql/foks_realtime.sql
@@ -86,6 +86,12 @@ CREATE TABLE channels (
 CREATE INDEX channels_team_app_idx ON channels(short_host_id, parent_team_id, app_id);
 
 /*
+ * Allows clients to ask for all channels updated since a particular set version,
+ * so it can get only the updates since last sync.
+ */
+CREATE INDEX channel_set_updates_idx ON channels(short_host_id, parent_team_id, updated_at_set_vers);
+
+/*
  * channel_parties: per-channel dictionary that interns message senders into a
  * small ordinal, so the unbounded messages tables carry a 4-byte sender_no
  * instead of two wide EntityID columns. Mirrors the short_host_id pattern.

--- a/server/sql/patches/foks_realtime/p2.sql
+++ b/server/sql/patches/foks_realtime/p2.sql
@@ -1,0 +1,6 @@
+
+/* 
+ * Allows clients to ask for all channels updated since a particular set version,
+ * so it can get only the updates since last sync.
+ */
+CREATE INDEX channel_set_updates_idx ON channels(short_host_id, parent_team_id, updated_at_set_vers);


### PR DESCRIPTION
- move a lot of libkv/cache logic to libclient/cache so we can use
  across kv and rt
- use same cache machinery as in libkv, with minimal changes
- put channel sets into a cache, indexed by team ID + appID
- all cached in one set
- incremental update from server
- some testing to make sure that some basic scenarios work
- at current, we still need a round trip with every CLI operation; we
  can of course do better, but unclear if we should right now.
