### PR TITLE
fix(db): allow former members to rejoin a team (partial unique index)

### DIFF
--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -53,6 +53,9 @@ var usersPatch4 string
 //go:embed patches/foks_users/p5.sql
 var usersPatch5 string
 
+//go:embed patches/foks_users/p6.sql
+var usersPatch6 string
+
 //go:embed patches/foks_server_config/p1.sql
 var serverConfigPatch1 string
 
@@ -75,6 +78,7 @@ var Patches = map[string]map[int]string{
 		3: usersPatch3,
 		4: usersPatch4,
 		5: usersPatch5,
+		6: usersPatch6,
 	},
 	"foks_server_config": {
 		1: serverConfigPatch1,

--- a/server/sql/foks_users.sql
+++ b/server/sql/foks_users.sql
@@ -605,7 +605,9 @@ CREATE TABLE local_joinreqs (
     PRIMARY KEY(short_host_id, team_id, token),
     FOREIGN KEY(short_host_id, team_id) REFERENCES teams(short_host_id, team_id)
 );
-CREATE UNIQUE INDEX local_joinreq_joiner_idx ON local_joinreqs(short_host_id, team_id, joiner_party_id, joiner_src_role_type, joiner_src_viz_level);
+/* Partial (state='pending'): one PENDING join request per joiner at a time;
+   historical approved/rejected rows don't block a rejoin (see patch p6). */
+CREATE UNIQUE INDEX local_joinreq_joiner_idx ON local_joinreqs(short_host_id, team_id, joiner_party_id, joiner_src_role_type, joiner_src_viz_level) WHERE state = 'pending';
 CREATE INDEX local_joinreqs_inbox_idx ON local_joinreqs(short_host_id, team_id, state, ctime);
 
 CREATE TYPE team_bearer_token_state as ENUM('inert', 'active', 'expired', 'revoked');

--- a/server/sql/patches/foks_users/p6.sql
+++ b/server/sql/patches/foks_users/p6.sql
@@ -1,0 +1,22 @@
+/*
+ * Rejoin-after-leave fix (SECO): allow a former member to create a NEW join
+ * request once their earlier one is no longer pending.
+ *
+ * The original index enforced "one join request per joiner per team, EVER" —
+ * but admit/reject only UPDATE the row's state (never delete), so a user who
+ * joined once, left, and was re-invited could never re-RSVP: the insert hit
+ * the index and returned TeamInviteAlreadyAcceptedError ("team invite
+ * already accepted" — observed in the wild on 2026-06-10).
+ *
+ * The partial index preserves the original intent (no duplicate PENDING
+ * requests — the insert handler's IsDuplicateKeyError check keeps working,
+ * same index name) while letting historical approved/rejected/withdrawn rows
+ * accumulate harmlessly. All readers are state- or token-scoped; the parallel
+ * remote_joinreqs table never had joiner uniqueness at all.
+ */
+
+DROP INDEX IF EXISTS local_joinreq_joiner_idx;
+CREATE UNIQUE INDEX local_joinreq_joiner_idx
+    ON local_joinreqs(short_host_id, team_id, joiner_party_id,
+                      joiner_src_role_type, joiner_src_viz_level)
+    WHERE state = 'pending';


### PR DESCRIPTION
local_joinreq_joiner_idx enforced "one join request per joiner per team,
EVER". admit/reject only UPDATE a row's state and never delete it, so a
user who joined once, left, and was re-invited could never create a new
RSVP -- the insert hit the unique index and returned
TeamInviteAlreadyAcceptedError ("team invite already accepted", observed
in the wild on 2026-06-10).

Recreate the index as PARTIAL (WHERE state = 'pending'): at most one
pending join request per joiner at a time, while historical
approved/rejected/withdrawn rows accumulate harmlessly. The insert
handler is unchanged -- the index keeps its name, so IsDuplicateKeyError
still maps a conflict to the same error, now fired only for genuine
pending duplicates. Verified safe: all readers of local_joinreqs are
state- or token-scoped, no FKs reference it, nothing consumes
TeamInviteAlreadyAcceptedError programmatically, and the parallel
remote_joinreqs path never had joiner uniqueness at all.

Base schema (foks_users.sql) updated for fresh installs; existing
databases migrate via patch p6.
