### PR TITLE
fix(libclient): guard nil getMobileSharedHome in Darwin.sharedHome (iOS)

### DIFF
--- a/client/libclient/home.go
+++ b/client/libclient/home.go
@@ -259,6 +259,10 @@ func (d Darwin) sharedHome() (string, error) {
 	}
 
 	// check if we have a shared container path, and if so, that is where the shared home is.
+	// PATCHED: nil guard for getMobileSharedHome — Config.HomeFinder() passes nil on iOS
+	if d.getMobileSharedHome == nil {
+		return homeDir, nil
+	}
 	sharedHome := d.getMobileSharedHome()
 	if sharedHome != "" {
 		return sharedHome, nil


### PR DESCRIPTION
Config.HomeFinder() constructs the Darwin home resolver with a nil
getMobileSharedHome callback on iOS. Darwin.sharedHome() then calls it
unconditionally, so any iOS caller that reaches the shared-container
branch crashes with a nil-pointer dereference.

Return the plain home directory when no mobile shared-home provider is
wired up, matching the behavior on platforms that never set one.
