### PR TITLE
feat(libclient): public Config setters for standalone + local-key encryption

### DIFF
--- a/client/libclient/config.go
+++ b/client/libclient/config.go
@@ -339,6 +339,27 @@ func (c *Config) TestSetHomeCLIFlag(h string) {
 	c.fl.home = h
 }
 
+// SetStandalone toggles standalone mode programmatically — equivalent
+// to passing --standalone on the CLI. Useful for long-running Go
+// processes that want to embed the FOKS agent in-process rather than
+// connect to an external foks-agent daemon.
+func (c *Config) SetStandalone(b bool) {
+	c.Lock()
+	defer c.Unlock()
+	c.fl.standalone = b
+}
+
+// SetLocalKeyDefaultEncryptionMode is equivalent to passing
+// --local-keyring-default-encryption-mode <mode> on the CLI. Empty
+// string = use the platform default. Valid modes are the same as
+// ParseSecretKeyStorageType accepts ("noise", "macos", "keychain",
+// "plaintext", "passphrase").
+func (c *Config) SetLocalKeyDefaultEncryptionMode(mode string) {
+	c.Lock()
+	defer c.Unlock()
+	c.fl.localKeyring.defaultEncryptionMode = mode
+}
+
 func (c *Config) TestSetHostsBeacon(b string) {
 	c.Lock()
 	defer c.Unlock()


### PR DESCRIPTION
Add two methods on *Config that mirror the existing TestSet* pattern but
target programmatic embedding rather than tests:

- SetStandalone(bool) -- equivalent to --standalone on the CLI.
- SetLocalKeyDefaultEncryptionMode(string) -- equivalent to
  --local-keyring-default-encryption-mode; empty string uses the platform
  default. Accepts the same modes as ParseSecretKeyStorageType ("noise",
  "macos", "keychain", "plaintext", "passphrase").

A long-running Go process that embeds the FOKS agent in-process otherwise
has no clean way to toggle standalone mode or choose the secret-key
encryption backend short of driving cmd.MainInner with CLI flags, which
forces a one-shot lifecycle. Both setters take the Config mutex, matching
the surrounding TestSet* convention.
