### PR TITLE
chat(1c): first stab at adhoc teams

### DIFF
--- a/client/agent/signup.go
+++ b/client/agent/signup.go
@@ -451,7 +451,7 @@ func (s *SignupSession) primeKey(m libclient.MetaContext) error {
 	if err != nil {
 		return err
 	}
-	uidEntity, err := pukEntity.Persistent()
+	uidEntity, err := pukEntity.Persistent(proto.PartyType_User)
 	if err != nil {
 		return err
 	}

--- a/client/agent/team.go
+++ b/client/agent/team.go
@@ -30,6 +30,19 @@ func (c *AgentConn) TeamCreate(ctx context.Context, nm proto.NameUtf8) (lcl.Team
 	return lcl.TeamCreateRes{Id: *ret}, nil
 }
 
+func (c *AgentConn) TeamCreateAdHoc(ctx context.Context, members []lcl.FQPartyParsedAndRole) (lcl.TeamCreateRes, error) {
+	var zed lcl.TeamCreateRes
+	m, tm, err := c.teamInit(ctx)
+	if err != nil {
+		return zed, err
+	}
+	ret, err := tm.CreateAdHoc(m, members)
+	if err != nil {
+		return zed, err
+	}
+	return lcl.TeamCreateRes{Id: *ret}, nil
+}
+
 func (c *AgentConn) TeamList(ctx context.Context, fqtp proto.FQTeamParsed) (lcl.TeamRoster, error) {
 	var zed lcl.TeamRoster
 	m, tm, err := c.teamInit(ctx)

--- a/client/libclient/team_loader.go
+++ b/client/libclient/team_loader.go
@@ -835,7 +835,10 @@ func (l *TeamLoader) loadTeamFromServer(m MetaContext) error {
 		Start: proto.ChainEldestSeqno,
 	}
 
-	if l.Arg.Keys != nil && (l.existing == nil || l.existing.RemovalKey == nil) {
+	// Ad-hoc teams have fixed membership and no removal keys, so don't ask the
+	// server for one (it would error with "removal key not found").
+	if l.Arg.Keys != nil && (l.existing == nil || l.existing.RemovalKey == nil) &&
+		!l.TeamID().Type().IsAdHocTeam() {
 		arg.LoadRemovalKey = true
 	}
 
@@ -966,7 +969,26 @@ func (l *TeamLoader) addIndexRangeEldest(rng *core.RationalRange) error {
 	return nil
 }
 
+// rejectAdHocMembershipChange enforces, during chain replay, that an ad-hoc
+// team's membership is fixed at creation: any non-eldest link that carries
+// roster changes is rejected. This is the team player's defense-in-depth behind
+// the client and server edit guards -- even a malicious server cannot smuggle a
+// membership change into an ad-hoc team's chain past the player.
+func rejectAdHocMembershipChange(teamID proto.TeamID, seqno proto.Seqno, nChanges int) error {
+	if !teamID.Type().IsAdHocTeam() || seqno.IsEldest() || nChanges == 0 {
+		return nil
+	}
+	return core.ChainLoaderError{Err: core.TeamError(team.AdHocTeamImmutableMsg)}
+}
+
 func (l *TeamLoader) playLink(m MetaContext, link *proto.LinkOuter, otlr team.OpenTeamLinkRes) error {
+
+	err := rejectAdHocMembershipChange(
+		l.TeamID(), otlr.Gc.Chainer.Base.Seqno, len(otlr.Gc.Changes),
+	)
+	if err != nil {
+		return err
+	}
 
 	// Hold onto all team names
 	if otlr.Tnc != nil {
@@ -1006,7 +1028,7 @@ func (l *TeamLoader) playLink(m MetaContext, link *proto.LinkOuter, otlr team.Op
 			return err
 		}
 	}
-	err := l.addIndexRange(otlr.Range, otlr.Gc.Chainer.Base.Seqno)
+	err = l.addIndexRange(otlr.Range, otlr.Gc.Chainer.Base.Seqno)
 	if err != nil {
 		return err
 	}
@@ -1701,9 +1723,15 @@ func (l *TeamLoader) saveState(m MetaContext) error {
 		return core.InternalError("no links in team sigchain")
 	}
 
-	unb, err := core.NewNameBundle(l.raw.TeamnameUtf8)
-	if err != nil {
-		return err
+	// Ad-hoc teams are nameless; the server sends a "-" placeholder that isn't a
+	// normalizable name, so use an empty bundle rather than trying to normalize.
+	var unb proto.NameBundle
+	var err error
+	if !l.TeamID().Type().IsAdHocTeam() {
+		unb, err = core.NewNameBundle(l.raw.TeamnameUtf8)
+		if err != nil {
+			return err
+		}
 	}
 
 	if n == 0 && len(l.raw.RemoteViewTokens) == 0 {
@@ -1856,6 +1884,12 @@ func (l *TeamLoader) unboxRemovalKey(m MetaContext) error {
 	if l.Arg.Keys == nil {
 		return nil
 	}
+	// Ad-hoc teams have fixed membership and therefore no removal keys, so
+	// there's nothing to unbox (mirrors TeamCreator.makeRemovalKey skipping
+	// them on creation).
+	if l.TeamID().Type().IsAdHocTeam() {
+		return nil
+	}
 	rkb := l.RemovalKeyBox()
 	if rkb == nil {
 		return core.ChainLoaderError{
@@ -1902,6 +1936,12 @@ func (l *TeamLoader) runUnbox(m MetaContext) error {
 }
 
 func (l *TeamLoader) checkTeamname(m MetaContext) error {
+	// Ad-hoc teams have no real teamname -- the eldest link carries no teamname
+	// commitment, and the server's "-" placeholder is host-wide bookkeeping, not
+	// a per-team merkle leaf. So there's nothing to verify here.
+	if l.TeamID().Type().IsAdHocTeam() {
+		return nil
+	}
 	var existingName *proto.NameAndSeqnoBundle
 	if l.existing != nil {
 		existingName = &l.existing.Name

--- a/client/libclient/team_loader_test.go
+++ b/client/libclient/team_loader_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package libclient
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/team"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/stretchr/testify/require"
+)
+
+func mkTestTeamID(t *testing.T, et proto.EntityType) proto.TeamID {
+	eid, err := et.MakeEntityID(make([]byte, et.Len()-1))
+	require.NoError(t, err)
+	tid, err := eid.ToTeamID()
+	require.NoError(t, err)
+	return tid
+}
+
+// TestRejectAdHocMembershipChange exercises the team player's defense-in-depth
+// guard: an ad-hoc team's membership is fixed in the eldest link, so any later
+// link carrying roster changes must be rejected during replay, while named
+// teams and changeless/eldest links pass through.
+func TestRejectAdHocMembershipChange(t *testing.T) {
+	adHoc := mkTestTeamID(t, proto.EntityType_AdHocTeam)
+	named := mkTestTeamID(t, proto.EntityType_NamedTeam)
+	immutable := core.ChainLoaderError{Err: core.TeamError(team.AdHocTeamImmutableMsg)}
+
+	type tc struct {
+		name     string
+		team     proto.TeamID
+		seqno    proto.Seqno
+		nChanges int
+		want     error
+	}
+	cases := []tc{
+		{"adhoc eldest founding members ok", adHoc, proto.ChainEldestSeqno, 4, nil},
+		{"adhoc non-eldest membership change rejected", adHoc, proto.Seqno(2), 1, immutable},
+		{"adhoc non-eldest no changes ok", adHoc, proto.Seqno(2), 0, nil},
+		{"named non-eldest membership change ok", named, proto.Seqno(2), 2, nil},
+		{"named eldest ok", named, proto.ChainEldestSeqno, 3, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := rejectAdHocMembershipChange(c.team, c.seqno, c.nChanges)
+			require.Equal(t, c.want, err)
+		})
+	}
+}

--- a/client/libclient/team_minder.go
+++ b/client/libclient/team_minder.go
@@ -18,6 +18,20 @@ import (
 
 type TeamMinderTestHooks struct {
 	PostChainHook func() error
+
+	// AllowAdHocTeamEdits disables the client-side guard that forbids editing
+	// ad-hoc teams, so tests can confirm the server rejects such edits on its
+	// own. Production code never sets this.
+	AllowAdHocTeamEdits bool
+}
+
+// teamEditorTestOpts returns the test-only overrides to apply to TeamEditors
+// constructed by this minder, or nil in production (the common case).
+func (t *TeamMinder) teamEditorTestOpts() *teamEditorTestOpts {
+	if t.TestHooks == nil || !t.TestHooks.AllowAdHocTeamEdits {
+		return nil
+	}
+	return &teamEditorTestOpts{allowAdHocEdit: t.TestHooks.AllowAdHocTeamEdits}
 }
 
 type teamCert struct {
@@ -1208,219 +1222,33 @@ func (t *TeamMinder) Create(
 	*proto.TeamID,
 	error,
 ) {
-	var hepks core.HEPKSet
-	au, err := t.activeUser(m)
+	creator := TeamCreator{
+		tm: t,
+		nm: nm,
+	}
+	err := creator.Run(m)
 	if err != nil {
 		return nil, err
 	}
-	cli, err := au.TeamAdminClient(m)
+	return creator.TeamID(), nil
+}
+
+func (t *TeamMinder) CreateAdHoc(
+	m MetaContext,
+	otherFoundingMembers []lcl.FQPartyParsedAndRole,
+) (
+	*proto.TeamID,
+	error,
+) {
+	creator := TeamCreator{
+		tm:    t,
+		membs: otherFoundingMembers,
+	}
+	err := creator.Run(m)
 	if err != nil {
 		return nil, err
 	}
-
-	nmn, err := core.NormalizeName(nm)
-	if err != nil {
-		return nil, err
-	}
-
-	rtr, err := cli.ReserveTeamname(m.Ctx(), nmn)
-	if err != nil {
-		return nil, err
-	}
-
-	// For now, only possible to have the user's owner PUK as the time creator, but
-	// thhat is an artificial limitation, can potentially relax it.
-	srcRole := team.UserSrcRole
-	puk := au.PrivKeys.LatestPuk()
-	if puk == nil {
-		return nil, core.KeyNotFoundError{Which: "puk"}
-	}
-	dstRole := proto.OwnerRole
-
-	hostid := au.HostID()
-
-	skb, err := core.NewSharedKeyBoxer(hostid, puk)
-	if err != nil {
-		return nil, err
-	}
-	mePub, err := core.PublicizeToSPSBoxer(puk, au.FQU().FQParty())
-	if err != nil {
-		return nil, err
-	}
-
-	var ptks []core.SharedPrivateSuiter
-	ptkMap := make(map[core.RoleKey]core.SharedPrivateSuiter)
-
-	roles := team.EldestRoles()
-
-	for _, role := range roles {
-		ss := core.RandomSecretSeed32()
-		ptk, err := core.NewSharedPrivateSuite25519(
-			proto.EntityType_Team,
-			role,
-			ss,
-			proto.FirstGeneration, // == 1, not 0.
-			hostid,
-		)
-		if err != nil {
-			return nil, err
-		}
-		err = hepks.AddHEPKExporter(ptk)
-		if err != nil {
-			return nil, err
-		}
-
-		ptks = append(ptks, ptk)
-		err = skb.Box(ptk, mePub)
-		if err != nil {
-			return nil, err
-		}
-		rk, err := core.ImportRole(role)
-		if err != nil {
-			return nil, err
-		}
-		ptkMap[*rk] = ptk
-	}
-
-	boxes, err := skb.Finish()
-	if err != nil {
-		return nil, err
-	}
-
-	ma, err := au.MerkleAgent(m)
-	if err != nil {
-		return nil, err
-	}
-
-	tr, err := ma.GetLatestTreeRootFromServer(m.Ctx())
-	if err != nil {
-		return nil, err
-	}
-
-	nc := rem.NameCommitment{
-		Name: nmn,
-		Seq:  rtr.Seq,
-	}
-
-	rmkey, err := team.NewTeamRemovalKey()
-	if err != nil {
-		return nil, err
-	}
-	comm, err := core.ComputeKeyCommitment(rmkey)
-	if err != nil {
-		return nil, err
-	}
-
-	mlr, err := team.MakeEldestLink(
-		hostid,
-		nc,
-		proto.KeyOwner{
-			Party:   au.UID().ToPartyID(),
-			SrcRole: srcRole,
-		},
-		puk,
-		ptks,
-		tr,
-		*comm,
-	)
-	seqno := mlr.Seqno
-	if err != nil {
-		return nil, err
-	}
-
-	tid, err := mlr.TeamID.ToTeamID()
-	if err != nil {
-		return nil, err
-	}
-
-	fqt := proto.FQTeam{
-		Team: tid,
-		Host: hostid,
-	}
-
-	adminPtk, found := ptkMap[core.AdminRole]
-	if !found {
-		return nil, core.KeyNotFoundError{Which: "admin PTK"}
-	}
-
-	adminPtkPub, err := core.PublicizeToSPSBoxer(adminPtk, fqt.FQParty())
-	if err != nil {
-		return nil, err
-	}
-
-	trkbp, err := team.BoxTeamRemovalKey(
-		puk,
-		adminPtkPub,
-		mePub,
-		rem.TeamRemovalKeyMetadata{
-			Tm:     fqt,
-			Member: au.FQU().FQParty(),
-			Dst: proto.RoleAndSeqno{
-				Seqno: seqno,
-				Role:  dstRole,
-			},
-			SrcRole: srcRole,
-		},
-		rmkey,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	glp := proto.NewGenericLinkPayloadWithTeammembership(
-		proto.TeamMembershipLink{
-			Team:    fqt,
-			SrcRole: srcRole,
-			State: proto.NewTeamMembershipDetailsWithApproved(
-				proto.TeamMembershipApprovedDetails{
-					Dst: proto.RoleAndSeqno{
-						Seqno: seqno,
-						Role:  dstRole,
-					},
-					KeyComm: trkbp.Comm,
-				},
-			),
-		},
-	)
-
-	glink, err := t.makeMembershipChainLink(
-		m, nil, glp, &tr,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	arg := rem.CreateTeamArg{
-		NameUtf8:                 nm,
-		TeamnameCommitmentKey:    *mlr.TeamnameCommitmentKey,
-		SubchainTreeLocationSeed: *mlr.SubchainTreeLocationSeed,
-		Rnr:                      rtr,
-		Eta: rem.EditTeamArg{
-			Link:             *mlr.Link,
-			NextTreeLocation: *mlr.NextTreeLocation,
-			Obd: rem.OffchainBoxData{
-				PtkBoxes:    *boxes,
-				RemovalKeys: []rem.TeamRemovalBoxData{*trkbp},
-				Hepks:       hepks.Export(),
-			},
-		},
-		TeamMembershipLink: rem.PostGenericLinkArg{
-			Link:             glink.Link,
-			NextTreeLocation: glink.NextTreeLocation,
-		},
-	}
-
-	err = cli.CreateTeam(m.Ctx(), arg)
-	if err != nil {
-		return nil, err
-	}
-
-	teamID, err := mlr.TeamID.ToTeamID()
-	if err != nil {
-		return nil, err
-	}
-
-	return &teamID, nil
+	return creator.TeamID(), nil
 }
 
 // makeKeyRingRefesher returns a function that is used to reload the team with the same args,

--- a/client/libclient/team_minder_add.go
+++ b/client/libclient/team_minder_add.go
@@ -156,6 +156,7 @@ func (t *teamAdder) post(m MetaContext) error {
 	ed.changes = t.mrs
 	ed.hepks = t.hepks
 	ed.cfg = cfg
+	ed.testOpts = t.tm.teamEditorTestOpts()
 
 	for _, mr := range t.mrs {
 		pid, err := mr.Member.Id.Entity.ToPartyID()

--- a/client/libclient/team_minder_change.go
+++ b/client/libclient/team_minder_change.go
@@ -110,15 +110,16 @@ func (t *TeamMinder) TeamChangeRoles(
 			defer tr.Unlock()
 
 			editor := TeamEditor{
-				tl:      tr.ldr,
-				tw:      tr.tw,
-				id:      tr.ldr.TeamID(),
-				tok:     tok,
-				pre:     tr.ldr.rosterPost,
-				cp:      tr.member,
-				hepks:   hepks,
-				changes: rows,
-				cfg:     cfg,
+				tl:       tr.ldr,
+				tw:       tr.tw,
+				id:       tr.ldr.TeamID(),
+				tok:      tok,
+				pre:      tr.ldr.rosterPost,
+				cp:       tr.member,
+				hepks:    hepks,
+				changes:  rows,
+				cfg:      cfg,
+				testOpts: t.teamEditorTestOpts(),
 			}
 
 			return editor.Run(m)

--- a/client/libclient/team_minder_create.go
+++ b/client/libclient/team_minder_create.go
@@ -1,0 +1,597 @@
+package libclient
+
+import (
+	"slices"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/team"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+)
+
+type TeamCreator struct {
+	// params passed in from caller
+	tm *TeamMinder
+	nm proto.NameUtf8 // or empty if ad-hoc team
+
+	// param only needed for ad-hoc teams, which can have multiple
+	// founding members. for now, they most be users, and cannot be teams,
+	// though we can relax this in the future. Cannot include the owner.
+	membs []lcl.FQPartyParsedAndRole
+
+	hepks  core.HEPKSet
+	cli    *rem.TeamAdminClient
+	au     *UserContext
+	rtr    *rem.ReserveNameRes
+	nnm    proto.Name // normalized name
+	nc     *rem.NameCommitment
+	puk    core.SharedPrivateSuiter
+	skb    *core.SharedKeyBoxer
+	mePub  *core.SPSBoxer
+	boxes  *proto.SharedKeyBoxSet
+	hostid proto.HostID
+	ptks   []core.SharedPrivateSuiter
+	ptkMap map[core.RoleKey]core.SharedPrivateSuiter
+	tr     *proto.TreeRoot
+	rmkey  *rem.TeamRemovalKey
+	comm   *proto.KeyCommitment
+	mlr    *team.MakeLinkRes
+	seqno  proto.Seqno
+	tid    proto.TeamID
+	fqt    proto.FQTeam
+	trkbp  *rem.TeamRemovalBoxData
+	glink  *rem.PostGenericLinkArg
+
+	// loaded members for ad-hoc teams, and their public keys
+	otherMrs  []proto.MemberRole
+	otherPubs []*core.SPSBoxer
+
+	adminPtk    core.SharedPrivateSuiter
+	adminPtkPub *core.SPSBoxer
+
+	srcRole proto.Role
+	dstRole proto.Role
+}
+
+func (t *TeamCreator) TeamID() *proto.TeamID {
+	return &t.tid
+}
+
+func (t *TeamCreator) setup(m MetaContext) error {
+	au, err := t.tm.activeUser(m)
+	if err != nil {
+		return err
+	}
+	cli, err := au.TeamAdminClient(m)
+	if err != nil {
+		return err
+	}
+	t.au = au
+	t.cli = cli
+	t.hostid = au.HostID()
+	return nil
+}
+
+func (t *TeamCreator) setupRoles(m MetaContext) error {
+	// For now, only possible to have the user's owner PUK as the time creator, but
+	// that is an artificial limitation, can potentially relax it.
+	t.srcRole = team.UserSrcRole
+	t.dstRole = proto.OwnerRole
+	return nil
+}
+
+func (t *TeamCreator) reserveTeamname(m MetaContext) error {
+	if t.nm.IsZero() {
+		return nil
+	}
+	nnm, err := core.NormalizeName(t.nm)
+	if err != nil {
+		return err
+	}
+	rtr, err := t.cli.ReserveTeamname(m.Ctx(), nnm)
+	if err != nil {
+		return err
+	}
+	t.rtr = &rtr
+	t.nnm = nnm
+	t.nc = &rem.NameCommitment{
+		Name: nnm,
+		Seq:  rtr.Seq,
+	}
+	return nil
+}
+
+func (t *TeamCreator) setupKeys(m MetaContext) error {
+	puk := t.au.PrivKeys.LatestPuk()
+	if puk == nil {
+		return core.KeyNotFoundError{Which: "puk"}
+	}
+	skb, err := core.NewSharedKeyBoxer(t.hostid, puk)
+	if err != nil {
+		return err
+	}
+	mePub, err := core.PublicizeToSPSBoxer(puk, t.au.FQU().FQParty())
+	if err != nil {
+		return err
+	}
+	t.puk = puk
+	t.skb = skb
+	t.mePub = mePub
+	return nil
+}
+
+// sortPubsLikeSchedule reorders pubs in place to match the order the server
+// computes for the KeySchedule's per-role member buckets (MemberID.Cmp), so
+// that MatchBoxes lines up box i with member i.
+func sortPubsLikeSchedule(pubs []*core.SPSBoxer) error {
+	type pubWithID struct {
+		pub *core.SPSBoxer
+		mid team.MemberID
+	}
+	keyed := make([]pubWithID, len(pubs))
+	for i, pub := range pubs {
+		fqef, err := pub.Parent.FQEntity().Fixed()
+		if err != nil {
+			return err
+		}
+		rk, err := core.ImportRole(pub.Role)
+		if err != nil {
+			return err
+		}
+		keyed[i] = pubWithID{pub: pub, mid: team.MemberID{Fqe: *fqef, SrcRole: *rk}}
+	}
+	slices.SortFunc(keyed, func(a, b pubWithID) int {
+		return a.mid.Cmp(b.mid)
+	})
+	for i, k := range keyed {
+		pubs[i] = k.pub
+	}
+	return nil
+}
+
+func (t *TeamCreator) makeBoxes(m MetaContext) error {
+	var ptks []core.SharedPrivateSuiter
+	ptkMap := make(map[core.RoleKey]core.SharedPrivateSuiter)
+	roles := team.EldestRoles()
+	allPubs := []*core.SPSBoxer{t.mePub}
+	allPubs = append(allPubs, t.otherPubs...)
+
+	// The server canonicalizes the KeySchedule by sorting the members in each
+	// role bucket by MemberID.Cmp (see team.KeySchedule / planChangesLocked),
+	// and MatchBoxes then checks the boxes positionally against that sorted
+	// order. So we must emit boxes in the same order. Note we sort only the
+	// boxes here, not the chain-link changes: the server re-derives and sorts
+	// the schedule from the changes, so their order in the link is irrelevant
+	// (this mirrors how the edit path's runBoxes follows t.sched).
+	if err := sortPubsLikeSchedule(allPubs); err != nil {
+		return err
+	}
+
+	for _, role := range roles {
+		ss := core.RandomSecretSeed32()
+		ptk, err := core.NewSharedPrivateSuite25519(
+			proto.EntityType_NamedTeam,
+			role,
+			ss,
+			proto.FirstGeneration,
+			t.hostid,
+		)
+		if err != nil {
+			return err
+		}
+		err = t.hepks.AddHEPKExporter(ptk)
+		if err != nil {
+			return err
+		}
+		ptks = append(ptks, ptk)
+		for _, pub := range allPubs {
+			err = t.skb.Box(ptk, pub)
+			if err != nil {
+				return err
+			}
+		}
+		rk, err := core.ImportRole(role)
+		if err != nil {
+			return err
+		}
+		ptkMap[*rk] = ptk
+	}
+	boxes, err := t.skb.Finish()
+	if err != nil {
+		return err
+	}
+	t.boxes = boxes
+	t.ptks = ptks
+	t.ptkMap = ptkMap
+	return nil
+}
+
+func (t *TeamCreator) getTreeRoot(m MetaContext) error {
+	ma, err := t.au.MerkleAgent(m)
+	if err != nil {
+		return err
+	}
+	tr, err := ma.GetLatestTreeRootFromServer(m.Ctx())
+	if err != nil {
+		return err
+	}
+	t.tr = &tr
+	return nil
+}
+
+func (t *TeamCreator) makeRemovalKey(m MetaContext) error {
+	// For adhoc teams, no removal key is needed:
+	if t.nm.IsZero() {
+		return nil
+	}
+	rmkey, err := team.NewTeamRemovalKey()
+	if err != nil {
+		return err
+	}
+	comm, err := core.ComputeKeyCommitment(rmkey)
+	if err != nil {
+		return err
+	}
+	t.rmkey = rmkey
+	t.comm = comm
+	return nil
+}
+
+func (t *TeamCreator) makeEldestLink(m MetaContext) error {
+
+	mlr, err := team.MakeEldestLink(
+		t.hostid,
+		t.nc,
+		proto.KeyOwner{
+			Party:   t.au.UID().ToPartyID(),
+			SrcRole: team.UserSrcRole,
+		},
+		t.puk,
+		t.ptks,
+		*t.tr,
+		t.comm,
+		t.otherMrs,
+	)
+	if err != nil {
+		return err
+	}
+	t.mlr = mlr
+	t.seqno = mlr.Seqno
+	t.tid, err = mlr.TeamID.ToTeamID()
+	if err != nil {
+		return err
+	}
+	t.fqt = proto.FQTeam{
+		Team: t.tid,
+		Host: t.hostid,
+	}
+	return nil
+}
+
+func (t *TeamCreator) findAdminPtk(m MetaContext) error {
+	adminPtk, found := t.ptkMap[core.AdminRole]
+	if !found {
+		return core.KeyNotFoundError{Which: "admin PTK"}
+	}
+	adminPtkPub, err := core.PublicizeToSPSBoxer(adminPtk, t.fqt.FQParty())
+	if err != nil {
+		return err
+	}
+	t.adminPtk = adminPtk
+	t.adminPtkPub = adminPtkPub
+	return nil
+}
+
+func (t *TeamCreator) makeRemovalKeyBox(m MetaContext) error {
+	// Will be nil for adhoc teams.
+	if t.rmkey == nil {
+		return nil
+	}
+	trkbp, err := team.BoxTeamRemovalKey(
+		t.puk,
+		t.adminPtkPub,
+		t.mePub,
+		rem.TeamRemovalKeyMetadata{
+			Tm:     t.fqt,
+			Member: t.au.FQU().FQParty(),
+			Dst: proto.RoleAndSeqno{
+				Seqno: t.seqno,
+				Role:  t.dstRole,
+			},
+			SrcRole: t.srcRole,
+		},
+		t.rmkey,
+	)
+	if err != nil {
+		return err
+	}
+	t.trkbp = trkbp
+	return nil
+}
+
+func (t *TeamCreator) makeTeamMembershipLink(m MetaContext) error {
+	tad := proto.TeamMembershipApprovedDetails{
+		Dst: proto.RoleAndSeqno{
+			Seqno: t.seqno,
+			Role:  t.dstRole,
+		},
+	}
+	if t.trkbp != nil {
+		tad.KeyComm = t.trkbp.Comm
+	}
+	tml := proto.TeamMembershipLink{
+		Team:    t.fqt,
+		SrcRole: t.srcRole,
+		State: proto.NewTeamMembershipDetailsWithApproved(
+			tad,
+		),
+	}
+	glp := proto.NewGenericLinkPayloadWithTeammembership(
+		tml,
+	)
+	glink, err := t.tm.makeMembershipChainLink(
+		m, nil, glp, t.tr,
+	)
+	if err != nil {
+		return err
+	}
+	t.glink = glink
+	return nil
+}
+
+func (t *TeamCreator) postAdhoc(m MetaContext) error {
+	if t.rtr != nil {
+		return core.InternalError("unexpected non-nil reserve name result")
+	}
+	if t.mlr == nil {
+		return core.InternalError("unexpected nil make link result")
+	}
+	if t.mlr.TeamnameCommitmentKey != nil {
+		return core.InternalError("unexpected non-nil teamname commitment key")
+	}
+	if t.boxes == nil {
+		return core.InternalError("unexpected nil boxes")
+	}
+	if t.trkbp != nil {
+		return core.InternalError("unexpected non-nil removal key box")
+	}
+	if t.glink == nil {
+		return core.InternalError("unexpected non-nil team membership link")
+	}
+	arg := rem.CreateTeamCommonArg{
+		SubchainTreeLocationSeed: *t.mlr.SubchainTreeLocationSeed,
+		Eta:                      t.makeEditTeamArg(m),
+		TeamMembershipLink:       t.makePostGenericLinkArg(m),
+	}
+	err := t.cli.CreateTeamAdHoc(m.Ctx(), arg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *TeamCreator) post(m MetaContext) error {
+	if t.nm.IsZero() {
+		return t.postAdhoc(m)
+	}
+	return t.postNamed(m)
+}
+
+func (t *TeamCreator) makeEditTeamArg(m MetaContext) rem.EditTeamArg {
+	ret := rem.EditTeamArg{
+		Link:             *t.mlr.Link,
+		NextTreeLocation: *t.mlr.NextTreeLocation,
+		Obd: rem.OffchainBoxData{
+			PtkBoxes: *t.boxes,
+			Hepks:    t.hepks.Export(),
+		},
+	}
+	if t.trkbp != nil {
+		ret.Obd.RemovalKeys = []rem.TeamRemovalBoxData{*t.trkbp}
+	}
+	return ret
+}
+
+func (t *TeamCreator) makePostGenericLinkArg(m MetaContext) rem.PostGenericLinkArg {
+	return rem.PostGenericLinkArg{
+		Link:             t.glink.Link,
+		NextTreeLocation: t.glink.NextTreeLocation,
+	}
+}
+
+func (t *TeamCreator) postNamed(m MetaContext) error {
+	if t.rtr == nil {
+		return core.InternalError("unexpected nil reserve name result")
+	}
+	if t.mlr == nil {
+		return core.InternalError("unexpected nil make link result")
+	}
+	if t.mlr.TeamnameCommitmentKey == nil {
+		return core.InternalError("unexpected nil teamname commitment key")
+	}
+	if t.boxes == nil {
+		return core.InternalError("unexpected nil boxes")
+	}
+	if t.trkbp == nil {
+		return core.InternalError("unexpected nil removal key box")
+	}
+	if t.glink == nil {
+		return core.InternalError("unexpected nil team membership link")
+	}
+
+	eta := t.makeEditTeamArg(m)
+	glp := t.makePostGenericLinkArg(m)
+
+	arg := rem.CreateTeamArg{
+		NameUtf8:                 t.nm,
+		TeamnameCommitmentKey:    *t.mlr.TeamnameCommitmentKey,
+		SubchainTreeLocationSeed: *t.mlr.SubchainTreeLocationSeed,
+		Rnr:                      *t.rtr,
+		Eta:                      eta,
+		TeamMembershipLink:       glp,
+	}
+	err := t.cli.CreateTeam(m.Ctx(), arg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *TeamCreator) adHocLoadOthers(
+	m MetaContext,
+) error {
+	for _, party := range t.membs {
+		err := t.adHocLoadOther(m, party)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *TeamCreator) adHocLoadOther(
+	m MetaContext,
+	party lcl.FQPartyParsedAndRole,
+) error {
+	user, team, err := party.Fqp.Party.Select()
+	if err != nil {
+		return err
+	}
+	if team != nil {
+		return core.BadArgsError("can only include users as founding members in adhoc teams")
+	}
+	if user == nil {
+		return core.InternalError("unexpected nil user in addHocLoadOther")
+	}
+	if party.Role != nil && !party.Role.SimpleEq(proto.OwnerRole) {
+		return core.BadArgsError("can only include the owner as a founding member in adhoc teams")
+	}
+	uw, err := LoadUserByFQUserParsed(m,
+		proto.FQUserParsed{
+			User: *user,
+			Host: party.Fqp.Host,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if !uw.fqu.HostID.Eq(t.hostid) {
+		return core.HostMismatchError{}
+	}
+	id := uw.fqu.ToFQEntity().AtHost(t.hostid)
+	rk, err := core.ImportRole(t.srcRole)
+	if err != nil {
+		return err
+	}
+	tmk, hepk, err := uw.TeamMemberKeys(*rk)
+	if err != nil {
+		return err
+	}
+	err = t.hepks.Add(*hepk)
+	if err != nil {
+		return err
+	}
+	mr := proto.MemberRole{
+		DstRole: t.dstRole,
+		Member: proto.Member{
+			Id:      id,
+			SrcRole: t.srcRole,
+		},
+	}
+	fqe := mr.Member.Id.WithHost(t.hostid)
+	creator := t.au.FQU().ToFQEntity()
+	if fqe.Eq(creator) {
+		return core.BadArgsError("cannot include the owner in the list of other founding members")
+	}
+
+	ps, err := core.ImportSPSBoxer(
+		fqe,
+		&t.hepks,
+		*tmk,
+		t.srcRole,
+	)
+	if err != nil {
+		return err
+	}
+
+	mr.Member.Keys = proto.NewMemberKeysWithTeam(*tmk)
+
+	t.otherPubs = append(t.otherPubs, ps)
+	t.otherMrs = append(t.otherMrs, mr)
+	return nil
+}
+
+func (t *TeamCreator) adHocPrepareOtherMembers(m MetaContext) error {
+
+	if len(t.membs) == 0 {
+		return nil
+	}
+
+	if !t.nm.IsZero() {
+		return core.InternalError("can only add other founding members to ad-hoc teams")
+	}
+
+	err := t.adHocLoadOthers(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *TeamCreator) Run(m MetaContext) error {
+
+	err := t.setup(m)
+	if err != nil {
+		return err
+	}
+	err = t.setupRoles(m)
+	if err != nil {
+		return err
+	}
+	err = t.reserveTeamname(m)
+	if err != nil {
+		return err
+	}
+	err = t.setupKeys(m)
+	if err != nil {
+		return err
+	}
+	err = t.adHocPrepareOtherMembers(m)
+	if err != nil {
+		return err
+	}
+	err = t.makeBoxes(m)
+	if err != nil {
+		return err
+	}
+	err = t.getTreeRoot(m)
+	if err != nil {
+		return err
+	}
+	err = t.makeRemovalKey(m)
+	if err != nil {
+		return err
+	}
+	err = t.makeEldestLink(m)
+	if err != nil {
+		return err
+	}
+	err = t.findAdminPtk(m)
+	if err != nil {
+		return err
+	}
+	err = t.makeRemovalKeyBox(m)
+	if err != nil {
+		return err
+	}
+	err = t.makeTeamMembershipLink(m)
+	if err != nil {
+		return err
+	}
+	err = t.post(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/client/libclient/team_minder_edit.go
+++ b/client/libclient/team_minder_edit.go
@@ -56,6 +56,9 @@ type TeamEditor struct {
 	rtps    []RemoteTokenPackage
 	cmd     []proto.ChangeMetadata
 
+	// testOpts bundles test-only overrides; production code leaves it nil.
+	testOpts *teamEditorTestOpts
+
 	// state updated along the way
 	signPriv       core.SharedPrivateSuiter // the private key of the actor
 	encryptPriv    core.SharedPrivateSuiter // the private key of the actor for sending DH encryptions
@@ -547,7 +550,7 @@ func (t *TeamEditor) makeTeamID(m MetaContext) error {
 	if err != nil {
 		return err
 	}
-	peid, err := eid.Persistent()
+	peid, err := eid.Persistent(proto.PartyType_NamedTeam)
 	if err != nil {
 		return err
 	}
@@ -742,7 +745,11 @@ func (t *TeamEditor) post(m MetaContext) error {
 }
 
 func (t *TeamEditor) RunMetadataOnly(m MetaContext) error {
-	err := t.checkArgs(m, true)
+	err := t.checkAdHocImmutable(m)
+	if err != nil {
+		return err
+	}
+	err = t.checkArgs(m, true)
 	if err != nil {
 		return err
 	}
@@ -772,12 +779,38 @@ func (t *TeamEditor) checkKeyLimits(m MetaContext) error {
 	return nil
 }
 
+// teamEditorTestOpts bundles test-only overrides for a TeamEditor. Production
+// code never constructs this; tests inject it via TeamMinderTestHooks.
+type teamEditorTestOpts struct {
+	// allowAdHocEdit disables the client-side guard that forbids editing ad-hoc
+	// teams, so tests can confirm the server independently rejects such edits.
+	allowAdHocEdit bool
+}
+
+// checkAdHocImmutable rejects edits to ad-hoc teams, which have a fixed
+// membership set at creation. Tests can disable it via testOpts.allowAdHocEdit
+// to confirm the server independently enforces the same rule.
+func (t *TeamEditor) checkAdHocImmutable(m MetaContext) error {
+	if t.testOpts != nil && t.testOpts.allowAdHocEdit {
+		return nil
+	}
+	if t.id.Type().IsAdHocTeam() {
+		return core.TeamError(team.AdHocTeamImmutableMsg)
+	}
+	return nil
+}
+
 func (t *TeamEditor) Run(m MetaContext) error {
 
 	m = m.WithLogTag("team-edit")
 	m.Infow("team-edit", "team", t.fqTeam(), "changes", t.changes)
 
-	err := t.checkArgs(m, false)
+	err := t.checkAdHocImmutable(m)
+	if err != nil {
+		return err
+	}
+
+	err = t.checkArgs(m, false)
 	if err != nil {
 		return err
 	}
@@ -840,4 +873,8 @@ func (t *TeamEditor) Run(m MetaContext) error {
 	}
 
 	return nil
+}
+
+func (t *TeamEditor) RunInTeamCreate(m MetaContext) error {
+	return core.NotImplementedError{}
 }

--- a/docs/chat-server-design.md
+++ b/docs/chat-server-design.md
@@ -761,6 +761,10 @@ CLI-only in the core FOKS repository.
 - Complementary client features
 
 ### Stage 1d
+- build inbox fan-out machinery
+- `rt inbox` command to query inbox state
+
+### Stage 1e
 
 - potentially build signatures for KV-store, and messages
     - ward off misattribution attacks

--- a/integration-tests/lib/reg_test.go
+++ b/integration-tests/lib/reg_test.go
@@ -667,7 +667,7 @@ func (u *TestUser) SignupWithOptsAndError(
 
 	pukid, err := puk.EntityID()
 	require.NoError(t, err)
-	uid, err := pukid.Persistent()
+	uid, err := pukid.Persistent(proto.PartyType_User)
 	require.NoError(t, err)
 
 	devicePub, err := device.Publicize(&hostID)
@@ -757,6 +757,19 @@ func (u *TestUser) GetCertWithErr(ctx context.Context, cli *rem.RegClient) error
 func (u *TestUser) GetCert(ctx context.Context, t *testing.T, cli *rem.RegClient) {
 	err := u.GetCertWithErr(ctx, cli)
 	require.NoError(t, err)
+}
+
+func (u *TestUser) addPUKsToMetaContext(
+	t *testing.T,
+	m libclient.MetaContext,
+) {
+	puks := u.puks
+	puksList := make([]core.SharedPrivateSuiter, 0, len(puks))
+	for _, puk := range puks {
+		puksList = append(puksList, &puk)
+	}
+	pukSet := libclient.NewPUKSet(puksList, u.host)
+	m.G().ActiveUser().PrivKeys.SetPUKs(pukSet)
 }
 
 func GenerateNewTestUser(t *testing.T) *TestUser {

--- a/integration-tests/lib/team_adhoc_test.go
+++ b/integration-tests/lib/team_adhoc_test.go
@@ -1,0 +1,142 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/integration-tests/common"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/team"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/stretchr/testify/require"
+)
+
+// adHocTeamFixture holds the pieces a test needs to operate on a freshly
+// created ad-hoc team.
+type adHocTeamFixture struct {
+	tew    *TestEnvWrapper
+	vhost  *core.HostIDAndName
+	alice  *TestUser
+	others []*TestUser
+	ma     libclient.MetaContext
+	tma    *libclient.TeamMinder
+	fqtp   proto.FQTeamParsed
+	tid    proto.TeamID
+}
+
+// createAdHocTeamForTest builds an ad-hoc team on a fresh open vhost, owned by
+// alice with nOthers additional founding owners.
+func createAdHocTeamForTest(t *testing.T, nOthers int) *adHocTeamFixture {
+	tew := testEnvBeta(t)
+	vhost := tew.openVHost(t)
+
+	alice := tew.NewTestUserAtVHost(t, vhost)
+	others := make([]*TestUser, nOthers)
+	othersFqpp := make([]lcl.FQPartyParsedAndRole, nOthers)
+	for i := range nOthers {
+		others[i] = tew.NewTestUserAtVHost(t, vhost)
+		othersFqpp[i] = toFQParsedPartyAndRole(others[i])
+		othersFqpp[i].Role = &proto.OwnerRole
+	}
+
+	// since we're writing to a secondary chain (in create), we need to poke merkle
+	// so that the signing key is fully provisioned.
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	ma := tew.NewClientMetaContext(t, alice)
+	alice.addPUKsToMetaContext(t, ma)
+
+	tma, err := ma.G().TeamMinder()
+	require.NoError(t, err)
+
+	tid, err := tma.CreateAdHoc(ma, othersFqpp)
+	require.NoError(t, err)
+
+	// Now watch the team get committed to the tree, so subsequent loads can
+	// verify the eldest link's merkle inclusion path.
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	hn := proto.NewParsedHostnameWithFalse(vhost.HostID.Id)
+	return &adHocTeamFixture{
+		tew:    tew,
+		vhost:  vhost,
+		alice:  alice,
+		others: others,
+		ma:     ma,
+		tma:    tma,
+		fqtp: proto.FQTeamParsed{
+			Team: proto.NewParsedTeamWithFalse(*tid),
+			Host: &hn,
+		},
+		tid: *tid,
+	}
+}
+
+func TestSimpleCreateTeamAdHoc(t *testing.T) {
+	defer common.DebugEntryAndExit()()
+
+	f := createAdHocTeamForTest(t, 3)
+
+	// Assert that alice can load the team
+	_, _, err := libclient.LoadTeamReturnLoader(f.ma, libclient.LoadTeamArg{
+		Team: proto.FQTeam{
+			Team: f.tid,
+			Host: f.ma.G().ActiveUser().HostID(),
+		},
+		As:      f.alice.FQUser().FQParty(),
+		Keys:    f.alice.KeySeq(t, proto.OwnerRole),
+		SrcRole: proto.OwnerRole,
+	})
+	require.NoError(t, err)
+}
+
+// TestAdHocTeamRejectsMemberEdits checks that ad-hoc teams are immutable: both
+// adding and removing members are rejected. The client refuses on its own; and
+// with the client guard disabled via a test hook, the server independently
+// rejects the edit too.
+func TestAdHocTeamRejectsMemberEdits(t *testing.T) {
+	defer common.DebugEntryAndExit()()
+
+	f := createAdHocTeamForTest(t, 3)
+	expErr := core.TeamError(team.AdHocTeamImmutableMsg)
+
+	// A fresh user we'll attempt to add.
+	dave := f.tew.NewTestUserAtVHost(t, f.vhost)
+	f.tew.DirectDoubleMerklePokeInTest(t)
+
+	addNewMember := func() error {
+		return f.tma.Add(f.ma, lcl.TeamAddArg{
+			Team:    f.fqtp,
+			Members: []lcl.FQPartyParsedAndRole{toFQParsedPartyAndRole(dave)},
+			DstRole: &proto.DefaultRole,
+		})
+	}
+
+	// Attempt a remove by changing a member's role to NONE. We target the owner
+	// (alice) since her wrapper is always loaded; the lookup of an arbitrary
+	// founder is a separate concern, and the guard fires regardless of who the
+	// target is.
+	removeMember := func() error {
+		victim := toFQParsedPartyAndRole(f.alice)
+		victim.Role = &proto.OwnerRole
+		return f.tma.TeamChangeRoles(f.ma, lcl.TeamChangeRolesArg{
+			Team: f.fqtp,
+			Changes: []lcl.RoleChange{{
+				Member:  victim,
+				NewRole: proto.NewRoleDefault(proto.RoleType_NONE),
+			}},
+		})
+	}
+
+	// With the guard on (production default), the client refuses both an add and
+	// a remove before anything hits the wire.
+	require.Equal(t, expErr, addNewMember())
+	require.Equal(t, expErr, removeMember())
+
+	// Disable the client-side guard and confirm the server rejects on its own.
+	// We drive this with an add: a remove would fail client-side fetching the
+	// (nonexistent) removal key before ever reaching the server.
+	f.tma.TestHooks = &libclient.TeamMinderTestHooks{AllowAdHocTeamEdits: true}
+	require.Equal(t, expErr, addNewMember())
+}

--- a/integration-tests/lib/team_common_test.go
+++ b/integration-tests/lib/team_common_test.go
@@ -276,7 +276,7 @@ func (te *TestEnvWrapper) makeTeamForOwnerEvil(t *testing.T, u *TestUser, opts m
 	for _, role := range roles {
 		ss := core.RandomSecretSeed32()
 		ptk, err := core.NewSharedPrivateSuite25519(
-			proto.EntityType_Team,
+			proto.EntityType_NamedTeam,
 			role,
 			ss,
 			proto.FirstGeneration,
@@ -326,12 +326,13 @@ func (te *TestEnvWrapper) makeTeamForOwnerEvil(t *testing.T, u *TestUser, opts m
 
 	mlr, err := team.MakeEldestLink(
 		u.host,
-		nc,
+		&nc,
 		ko,
 		puk,
 		ptks,
 		tr,
-		*comm,
+		comm,
+		nil,
 	)
 	if err != nil {
 		return nil, err
@@ -529,12 +530,13 @@ func (te *TestEnvWrapper) makeTeamForOwner(t *testing.T, u *TestUser) *teamObj {
 
 	mlr, err := team.MakeEldestLink(
 		u.host,
-		nc,
+		&nc,
 		ko,
 		&puk,
 		ptks,
 		tr,
-		*comm,
+		comm,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/integration-tests/lib/user_loader_test.go
+++ b/integration-tests/lib/user_loader_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
+	"github.com/foks-proj/go-foks/server/shared"
 	"github.com/stretchr/testify/require"
 )
 
@@ -147,6 +148,17 @@ func testEnvBeta(t *testing.T) *TestEnvWrapper {
 	ret.DirectMerklePokeInTest(t)
 	ret.BeaconRegister(t)
 	return ret
+}
+
+func (w *TestEnvWrapper) openVHost(t *testing.T) *core.HostIDAndName {
+	// by convention, we use vhost 4 for open viewership
+	vHostID := w.VHostMakeI(t, 4)
+	require.NotNil(t, vHostID)
+	m := w.MetaContext()
+	m = m.WithHostID(&vHostID.HostID)
+	err := shared.VHostSetUserViewership(m, proto.ViewershipMode_Open)
+	require.NoError(t, err)
+	return vHostID
 }
 
 func TestSimpleUserLoads(t *testing.T) {

--- a/lib/core/chain.go
+++ b/lib/core/chain.go
@@ -949,7 +949,7 @@ func MakeEldestLink(
 	if err != nil {
 		return nil, err
 	}
-	user, err := ske.VerifyKey.Persistent()
+	user, err := ske.VerifyKey.Persistent(proto.PartyType_User)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/core/hepk.go
+++ b/lib/core/hepk.go
@@ -182,6 +182,16 @@ func (h *HEPKSet) Merge(o *HEPKSet) *HEPKSet {
 	return h
 }
 
+func (h *HEPKSet) MergeInto(o *HEPKSet) {
+	if o == nil {
+		return
+	}
+	for k, v := range h.m {
+		v := v
+		o.m[k] = v
+	}
+}
+
 func (h *HEPKSet) Export() proto.HEPKSet {
 	ret := proto.HEPKSet{
 		V: make([]proto.HEPK, 0, len(h.m)),

--- a/lib/core/keysuite.go
+++ b/lib/core/keysuite.go
@@ -446,7 +446,7 @@ func importPublicSuiteHelper(
 		return nil, HostMismatchError{}
 	}
 	switch eid.Type() {
-	case proto.EntityType_Device, proto.EntityType_User, proto.EntityType_Team,
+	case proto.EntityType_Device, proto.EntityType_User, proto.EntityType_NamedTeam,
 		proto.EntityType_BackupKey, proto.EntityType_PassphraseKey,
 		proto.EntityType_BotTokenKey:
 		if dhtyp != proto.DHType_Curve25519 {

--- a/lib/team/chain.go
+++ b/lib/team/chain.go
@@ -4,6 +4,8 @@
 package team
 
 import (
+	"fmt"
+
 	"github.com/foks-proj/go-foks/lib/core"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
@@ -84,51 +86,67 @@ func OpenEldestLinkWithOTLR(
 		OpenTeamLinkRes: *otlr,
 	}
 
-	if len(otlr.Gc.Metadata) < 3 {
+	nNeededMetadata := 2
+	isNamed := otlr.Gc.Entity.Entity.Type().IsNamedTeam()
+	if isNamed {
+		nNeededMetadata++
+	}
+
+	if len(otlr.Gc.Metadata) < nNeededMetadata {
 		return nil, core.LinkError("eldest link must have at least three metadata entries")
 	}
 
-	typ, err := otlr.Gc.Metadata[0].GetT()
-	if err != nil {
-		return nil, err
+	i := 0
+	if isNamed {
+		typ, err := otlr.Gc.Metadata[0].GetT()
+		if err != nil {
+			return nil, err
+		}
+		if typ != proto.ChangeType_Teamname {
+			return nil, core.LinkError("first metadata entry must be a teamname commitment")
+		}
+		if otlr.Tnc == nil {
+			return nil, core.LinkError("eldest link must have a teamname commitment")
+		}
+		i++
 	}
-	if typ != proto.ChangeType_Teamname {
-		return nil, core.LinkError("first metadata entry must be a teamname commitment")
-	}
-	if otlr.Tnc == nil {
-		return nil, core.LinkError("eldest link must have a teamname commitment")
-	}
-	typ, err = otlr.Gc.Metadata[1].GetT()
+
+	typ, err := otlr.Gc.Metadata[i].GetT()
 	if err != nil {
 		return nil, err
 	}
 	if typ != proto.ChangeType_Eldest {
 		return nil, core.LinkError("second metadata entry must be an eldest metadata")
 	}
-	ret.Stltc = otlr.Gc.Metadata[1].Eldest().SubchainTreeLocationSeedCommitment
+	ret.Stltc = otlr.Gc.Metadata[i].Eldest().SubchainTreeLocationSeedCommitment
 
-	typ, err = otlr.Gc.Metadata[2].GetT()
+	i++
+
+	typ, err = otlr.Gc.Metadata[i].GetT()
 	if err != nil {
 		return nil, err
 	}
 	if typ != proto.ChangeType_TeamIndexRange {
 		return nil, core.LinkError("third metadata entry must be a team index range")
 	}
-	tmp := core.NewRationalRange(otlr.Gc.Metadata[2].Teamindexrange())
+	tmp := core.NewRationalRange(otlr.Gc.Metadata[i].Teamindexrange())
 	ret.Range = &tmp
+	i++
 
 	// Prior to v0.0.20, there were only 3 metadata entries for teams.
 	// At v0.0.20 and above, the fourth metadata entry is the member load floor.
-	if len(otlr.Gc.Metadata) > 3 {
-		md3 := otlr.Gc.Metadata[3]
-		typ, err = md3.GetT()
+	// Note that for adhoc teams, the whole shebang is shifted
+	// left by one, since there is no teamname commitment.
+	if i < len(otlr.Gc.Metadata) {
+		md := otlr.Gc.Metadata[i]
+		typ, err = md.GetT()
 		if err != nil {
 			return nil, err
 		}
 		if typ != proto.ChangeType_MemberLoadFloor {
 			return nil, core.LinkError("fourth metadata entry must be a member load floor")
 		}
-		tmp := md3.Memberloadfloor()
+		tmp := md.Memberloadfloor()
 		ret.MemberLoadFloor = &tmp
 	}
 
@@ -198,7 +216,7 @@ func OpenTeamLink(
 	if err != nil {
 		return nil, err
 	}
-	if gc.Entity.Entity.Type() != proto.EntityType_Team {
+	if !gc.Entity.Entity.Type().IsTeam() {
 		return nil, core.LinkError("expected a link for a Team entity")
 	}
 	if !hostID.Eq(gc.Entity.Host) {
@@ -297,10 +315,10 @@ func exportToMemberRole(
 	host proto.HostID,
 	fqe proto.FQEntity,
 	sk proto.SharedKey,
-	removalKeyCommitment proto.KeyCommitment,
+	removalKeyCommitment *proto.KeyCommitment,
 ) proto.MemberRole {
 	tmk := sk.ToTeamMemberKeys(nil)
-	tmk.Trkc = &removalKeyCommitment
+	tmk.Trkc = removalKeyCommitment
 	return proto.MemberRole{
 		DstRole: role,
 		Member: proto.Member{
@@ -320,20 +338,70 @@ func EldestRoles() []proto.Role {
 	}
 }
 
+// otherFoundingMembers will be non-empty in the case of adhoc teams,
+// and maybe, in the future, for standard teams too.
+func melCheckArgs(
+	name *rem.NameCommitment,
+	otherFoundingMembers []proto.MemberRole,
+	host proto.HostID,
+	owner proto.KeyOwner,
+	removalKeyCommitment *proto.KeyCommitment,
+) error {
+
+	switch {
+	case name == nil:
+		if removalKeyCommitment != nil {
+			return core.LinkError("removal key commitment is not allowed for adhoc teams")
+		}
+	default:
+		if len(otherFoundingMembers) > 0 {
+			return core.LinkError("other founding members are not allowed for named teams")
+		}
+		if removalKeyCommitment == nil {
+			return core.LinkError("removal key commitment is required for named teams")
+		}
+	}
+
+	for _, mr := range otherFoundingMembers {
+		isNone, err := mr.DstRole.IsNone()
+		if err != nil {
+			return err
+		}
+		if isNone {
+			return core.LinkError("cannot have a NONE role as a founding member")
+		}
+		if mr.Member.Id.WithHost(host).Eq(owner.Party.EntityID().ScopeToHost(host)) {
+			return core.LinkError("owner must not be a founding member")
+		}
+	}
+	return nil
+}
+
 func MakeEldestLink(
 	host proto.HostID,
-	name rem.NameCommitment,
+	name *rem.NameCommitment,
 	owner proto.KeyOwner, // can be either a team or a user
 	uotKey core.SharedPrivateSuiter, // for users, the current PUK; for teams, the current PTK (uot = user or team)
 	teamKeys []core.SharedPrivateSuiter,
 	root proto.TreeRoot,
-	removalKeyCommitment proto.KeyCommitment,
+	removalKeyCommitment *proto.KeyCommitment, // not used for adhoc teams
+	otherFoundingMembers []proto.MemberRole,
 ) (*MakeLinkRes, error) {
 
-	teamRck, teamCom, err := core.Commit(&name)
+	err := melCheckArgs(name, otherFoundingMembers, host, owner, removalKeyCommitment)
 	if err != nil {
 		return nil, err
 	}
+
+	var teamRck *proto.RandomCommitmentKey
+	var teamCom *proto.Commitment
+	if name != nil {
+		teamRck, teamCom, err = core.Commit(name)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	signerID, err := uotKey.EntityID()
 	if err != nil {
 		return nil, err
@@ -356,12 +424,16 @@ func MakeEldestLink(
 		}
 	}
 	if len(teamKeys) != len(EldestRoles()) {
-		return nil, core.LinkError("need 3 PTKs for a new team")
+		return nil, core.LinkError(
+			fmt.Sprintf("need %d PTKs for a new team", len(EldestRoles())),
+		)
 	}
 	if adminTke == nil {
 		return nil, core.LinkError("need an ADMIN PTK for a new team")
 	}
-	team, err := adminTke.VerifyKey.Persistent()
+
+	pt := core.Sel(name != nil, proto.PartyType_NamedTeam, proto.PartyType_AdHocTeam)
+	team, err := adminTke.VerifyKey.Persistent(pt)
 	if err != nil {
 		return nil, err
 	}
@@ -389,6 +461,30 @@ func MakeEldestLink(
 		removalKeyCommitment,
 	)
 
+	// Always include the owner as a founding member.
+	changes := []proto.MemberRole{ownerChange}
+	if len(otherFoundingMembers) > 0 {
+		changes = append(changes, otherFoundingMembers...)
+	}
+
+	var md []proto.ChangeMetadata
+	if teamCom != nil {
+		md = append(md, proto.NewChangeMetadataWithTeamname(*teamCom))
+	}
+	md = append(md, []proto.ChangeMetadata{
+		proto.NewChangeMetadataWithEldest(
+			proto.EldestMetadata{
+				SubchainTreeLocationSeedCommitment: *sctlc,
+			},
+		),
+		proto.NewChangeMetadataWithTeamindexrange(
+			core.NewDefaultRange().RationalRange,
+		),
+		proto.NewChangeMetadataWithMemberloadfloor(
+			proto.DefaultMemberLoadFloor,
+		),
+	}...)
+
 	gc := proto.GroupChange{
 		Chainer: proto.HidingChainer{
 			Base: proto.BaseChainer{
@@ -406,22 +502,9 @@ func MakeEldestLink(
 			Key:      signerID,
 			KeyOwner: &owner,
 		},
-		Changes:    []proto.MemberRole{ownerChange},
+		Changes:    changes,
 		SharedKeys: tkes,
-		Metadata: []proto.ChangeMetadata{
-			proto.NewChangeMetadataWithTeamname(*teamCom),
-			proto.NewChangeMetadataWithEldest(
-				proto.EldestMetadata{
-					SubchainTreeLocationSeedCommitment: *sctlc,
-				},
-			),
-			proto.NewChangeMetadataWithTeamindexrange(
-				core.NewDefaultRange().RationalRange,
-			),
-			proto.NewChangeMetadataWithMemberloadfloor(
-				proto.DefaultMemberLoadFloor,
-			),
-		},
+		Metadata:   md,
 	}
 
 	li := proto.NewLinkInnerWithGroupChange(gc)

--- a/lib/team/const.go
+++ b/lib/team/const.go
@@ -6,3 +6,9 @@ package team
 import proto "github.com/foks-proj/go-foks/proto/lib"
 
 var UserSrcRole = proto.OwnerRole
+var AdHocTeamName = proto.Name("-")
+
+// AdHocTeamImmutableMsg is returned (wrapped in core.TeamError) by both the
+// client and the server when something tries to edit an ad-hoc team. Ad-hoc
+// teams have a fixed membership set at creation time and admit no later edits.
+const AdHocTeamImmutableMsg = "ad-hoc teams have fixed membership and cannot be edited"

--- a/lib/team/core.go
+++ b/lib/team/core.go
@@ -495,7 +495,7 @@ func (d ChangeSet) Gameplan(
 
 	var create bool
 	if (rPre == nil) != (keysPre == nil) {
-		return nil, nil, nil, core.TeamRosterError("must supply both roster and keys, or both nil for create ")
+		return nil, nil, nil, core.TeamRosterError("must supply both roster and keys, or both nil for create")
 	}
 
 	var forcedNewKeyGens []core.RoleKey

--- a/proto-src/lcl/team.snowp
+++ b/proto-src/lcl/team.snowp
@@ -200,4 +200,11 @@ protocol Team
     // used largely in testing and in debugging
     teamDumpMembershipChain @15 (
     ) -> TeamMembershipChainList;
+
+    // Create a team with no name; can include other founding members,
+    // even at different roles (but should like all be owners, too).
+    teamCreateAdHoc @16 (
+        members @0 : List(FQPartyParsedAndRole)
+    ) -> TeamCreateRes;
+
 }

--- a/proto-src/lib/common.snowp
+++ b/proto-src/lib/common.snowp
@@ -27,7 +27,7 @@ typedef EntityID33 = Blob(33);
 typedef EntityID34 = Blob(34);
 
 typedef UID = EntityID33;                // Leading byte 0x1 -- 33 bytes (EdDSA)
-typedef TeamID = EntityID33;             // Leading byte 0x3 -- 33 Bytes (EdDSA)
+typedef NamedTeamID = EntityID33;        // Leading byte 0x3 -- 33 Bytes (EdDSA)
 typedef DeviceID = EntityID;             // Leading byte 0x4 -- 33 bytes (EdDSA)
 typedef X509CertID = EntityID;           // Leading byte 0x5 -- 33 bytes (EdDSA) -- for X509 certs (not CAs)
 typedef LocationVRFID = EntityID;        // Leading byte 0x6 -- 33 bytes (EdDSA)
@@ -44,6 +44,9 @@ typedef BackupKeyID = EntityID;          // Leading byte 0x10 -- 33 Bytes (EdDSA
 typedef PassphraseKeyID = EntityID;      // Leading byte 0x11 -- 33 Bytes (EdDSA, derived from passphrase)
 typedef PKIXCertID = EntityID;           // Leading byte 0x12 -- 33 Bytes (ECDSA or RSA) - Unspecified PKIX key from crypto.Public
 typedef BotTokenKeyID = EntityID;        // Leading byte 0x13 -- 33 Bytes (EdDSA) -- for bot tokens
+typedef AdHocTeamID = EntityID33;        // Leading byte 0x14 -- 33 Bytes (EdDSA) -- for adhoc teams
+
+typedef TeamID = EntityID33;             // can be a NamedTeamID or an AdHocTeamID
 
 // HostID has a type ID since sometimes we store it directly as a value
 // in local client DBs. (See Probe::checkPin).
@@ -58,7 +61,7 @@ typedef EntityIDString = Text;
 enum EntityType {
     User @1;
     Host @2;
-    Team @3;
+    NamedTeam @3; // Specifically a NamedTeam
     Device @4;
     X509Cert @5;
     LocationVRF @6;
@@ -75,6 +78,7 @@ enum EntityType {
     PassphraseKey @17;
     PKIXCert @18;
     BotTokenKey @19;
+    AdHocTeam @20; // Specifically an AdHocTeam; note there is no Team type, since it can be either a NamedTeam or an AdHocTeam
 }
 
 enum DHType {
@@ -348,7 +352,9 @@ struct PartyName {
 
 enum PartyType {
     User @0;
-    Team @1;
+    Team @1; // can be a NamedTeam or an AdHocTeam
+    NamedTeam @2; // Specifically a NamedTeam
+    AdHocTeam @3; // Specifically an AdHocTeam
 }
 
 variant ParsedParty switch (s : bool) {

--- a/proto-src/rem/team.snowp
+++ b/proto-src/rem/team.snowp
@@ -327,6 +327,14 @@ struct TeamConfig {
     maxRoles @0 : Uint; // max number of roles a team can have
 }
 
+// Used for creation of adhoc and real teams; no
+// naming fields used or needed.
+struct CreateTeamCommonArg {
+    subchainTreeLocationSeed @0 : lib.TreeLocation;
+    eta @1 : EditTeamArg;
+    teamMembershipLink @2 : PostGenericLinkArg;
+}
+
 // TeamAdmin protocol happens on the same machine that a user is logged into.
 // So we use the same auth mechanism as we do for the User protocol.
 protocol TeamAdmin errors lib.Status @0xdbe1ddbe {
@@ -422,6 +430,12 @@ protocol TeamAdmin errors lib.Status @0xdbe1ddbe {
     // TeamConfig applies to all teams on this server/vhost
     getTeamConfig @14 (
     ) -> TeamConfig;
+
+    // create an adhoc team; a lot like createTeam, but no name is needed;
+    // and we have a different teamID.
+    createTeamAdHoc @15 (
+        carg @0 : CreateTeamCommonArg
+    );
 }
 
 protocol TeamGuest errors lib.Status @0xf6d7585c {

--- a/proto/lcl/team.go
+++ b/proto/lcl/team.go
@@ -2012,6 +2012,66 @@ func (t *TeamDumpMembershipChainArg) Decode(dec rpc.Decoder) error {
 
 func (t *TeamDumpMembershipChainArg) Bytes() []byte { return nil }
 
+type TeamCreateAdHocArg struct {
+	Members []FQPartyParsedAndRole
+}
+type TeamCreateAdHocArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Members *[](*FQPartyParsedAndRoleInternal__)
+}
+
+func (t TeamCreateAdHocArgInternal__) Import() TeamCreateAdHocArg {
+	return TeamCreateAdHocArg{
+		Members: (func(x *[](*FQPartyParsedAndRoleInternal__)) (ret []FQPartyParsedAndRole) {
+			if x == nil || len(*x) == 0 {
+				return nil
+			}
+			ret = make([]FQPartyParsedAndRole, len(*x))
+			for k, v := range *x {
+				if v == nil {
+					continue
+				}
+				ret[k] = (func(x *FQPartyParsedAndRoleInternal__) (ret FQPartyParsedAndRole) {
+					if x == nil {
+						return ret
+					}
+					return x.Import()
+				})(v)
+			}
+			return ret
+		})(t.Members),
+	}
+}
+func (t TeamCreateAdHocArg) Export() *TeamCreateAdHocArgInternal__ {
+	return &TeamCreateAdHocArgInternal__{
+		Members: (func(x []FQPartyParsedAndRole) *[](*FQPartyParsedAndRoleInternal__) {
+			if len(x) == 0 {
+				return nil
+			}
+			ret := make([](*FQPartyParsedAndRoleInternal__), len(x))
+			for k, v := range x {
+				ret[k] = v.Export()
+			}
+			return &ret
+		})(t.Members),
+	}
+}
+func (t *TeamCreateAdHocArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(t.Export())
+}
+
+func (t *TeamCreateAdHocArg) Decode(dec rpc.Decoder) error {
+	var tmp TeamCreateAdHocArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*t = tmp.Import()
+	return nil
+}
+
+func (t *TeamCreateAdHocArg) Bytes() []byte { return nil }
+
 type TeamInterface interface {
 	TeamCreate(context.Context, lib.NameUtf8) (TeamCreateRes, error)
 	TeamList(context.Context, lib.FQTeamParsed) (TeamRoster, error)
@@ -2029,6 +2089,7 @@ type TeamInterface interface {
 	TeamAdd(context.Context, TeamAddArg) error
 	TeamChangeRoles(context.Context, TeamChangeRolesArg) error
 	TeamDumpMembershipChain(context.Context) (TeamMembershipChainList, error)
+	TeamCreateAdHoc(context.Context, []FQPartyParsedAndRole) (TeamCreateRes, error)
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h Header) error
 	MakeResHeader() Header
@@ -2418,6 +2479,30 @@ func (c TeamClient) TeamDumpMembershipChain(ctx context.Context) (res TeamMember
 	}
 	var tmp rpc.DataWrap[Header, TeamMembershipChainListInternal__]
 	err = c.Cli.Call2(ctx, rpc.NewMethodV2(TeamProtocolID, 15, "Team.teamDumpMembershipChain"), warg, &tmp, 0*time.Millisecond, teamErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	res = tmp.Data.Import()
+	return
+}
+func (c TeamClient) TeamCreateAdHoc(ctx context.Context, members []FQPartyParsedAndRole) (res TeamCreateRes, err error) {
+	arg := TeamCreateAdHocArg{
+		Members: members,
+	}
+	warg := &rpc.DataWrap[Header, *TeamCreateAdHocArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[Header, TeamCreateResInternal__]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(TeamProtocolID, 16, "Team.teamCreateAdHoc"), warg, &tmp, 0*time.Millisecond, teamErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
 	if err != nil {
 		return
 	}
@@ -2893,6 +2978,35 @@ func TeamProtocol(i TeamInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "teamDumpMembershipChain",
+			},
+			16: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[Header, *TeamCreateAdHocArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *TeamCreateAdHocArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[Header, *TeamCreateAdHocArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						tmp, err := i.TeamCreateAdHoc(ctx, (typedArg.Import()).Members)
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[Header, *TeamCreateResInternal__]{
+							Data:   tmp.Export(),
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "teamCreateAdHoc",
 			},
 		},
 		WrapError: TeamMakeGenericErrorWrapper(i.ErrorWrapper()),

--- a/proto/lib/common.go
+++ b/proto/lib/common.go
@@ -149,16 +149,16 @@ func (u UID) Bytes() []byte {
 	return ((EntityID33)(u)).Bytes()
 }
 
-type TeamID EntityID33
-type TeamIDInternal__ EntityID33Internal__
+type NamedTeamID EntityID33
+type NamedTeamIDInternal__ EntityID33Internal__
 
-func (t TeamID) Export() *TeamIDInternal__ {
-	tmp := ((EntityID33)(t))
-	return ((*TeamIDInternal__)(tmp.Export()))
+func (n NamedTeamID) Export() *NamedTeamIDInternal__ {
+	tmp := ((EntityID33)(n))
+	return ((*NamedTeamIDInternal__)(tmp.Export()))
 }
-func (t TeamIDInternal__) Import() TeamID {
-	tmp := (EntityID33Internal__)(t)
-	return TeamID((func(x *EntityID33Internal__) (ret EntityID33) {
+func (n NamedTeamIDInternal__) Import() NamedTeamID {
+	tmp := (EntityID33Internal__)(n)
+	return NamedTeamID((func(x *EntityID33Internal__) (ret EntityID33) {
 		if x == nil {
 			return ret
 		}
@@ -166,22 +166,22 @@ func (t TeamIDInternal__) Import() TeamID {
 	})(&tmp))
 }
 
-func (t *TeamID) Encode(enc rpc.Encoder) error {
-	return enc.Encode(t.Export())
+func (n *NamedTeamID) Encode(enc rpc.Encoder) error {
+	return enc.Encode(n.Export())
 }
 
-func (t *TeamID) Decode(dec rpc.Decoder) error {
-	var tmp TeamIDInternal__
+func (n *NamedTeamID) Decode(dec rpc.Decoder) error {
+	var tmp NamedTeamIDInternal__
 	err := dec.Decode(&tmp)
 	if err != nil {
 		return err
 	}
-	*t = tmp.Import()
+	*n = tmp.Import()
 	return nil
 }
 
-func (t TeamID) Bytes() []byte {
-	return ((EntityID33)(t)).Bytes()
+func (n NamedTeamID) Bytes() []byte {
+	return ((EntityID33)(n)).Bytes()
 }
 
 type DeviceID EntityID
@@ -744,6 +744,76 @@ func (b BotTokenKeyID) Bytes() []byte {
 	return ((EntityID)(b)).Bytes()
 }
 
+type AdHocTeamID EntityID33
+type AdHocTeamIDInternal__ EntityID33Internal__
+
+func (a AdHocTeamID) Export() *AdHocTeamIDInternal__ {
+	tmp := ((EntityID33)(a))
+	return ((*AdHocTeamIDInternal__)(tmp.Export()))
+}
+func (a AdHocTeamIDInternal__) Import() AdHocTeamID {
+	tmp := (EntityID33Internal__)(a)
+	return AdHocTeamID((func(x *EntityID33Internal__) (ret EntityID33) {
+		if x == nil {
+			return ret
+		}
+		return x.Import()
+	})(&tmp))
+}
+
+func (a *AdHocTeamID) Encode(enc rpc.Encoder) error {
+	return enc.Encode(a.Export())
+}
+
+func (a *AdHocTeamID) Decode(dec rpc.Decoder) error {
+	var tmp AdHocTeamIDInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*a = tmp.Import()
+	return nil
+}
+
+func (a AdHocTeamID) Bytes() []byte {
+	return ((EntityID33)(a)).Bytes()
+}
+
+type TeamID EntityID33
+type TeamIDInternal__ EntityID33Internal__
+
+func (t TeamID) Export() *TeamIDInternal__ {
+	tmp := ((EntityID33)(t))
+	return ((*TeamIDInternal__)(tmp.Export()))
+}
+func (t TeamIDInternal__) Import() TeamID {
+	tmp := (EntityID33Internal__)(t)
+	return TeamID((func(x *EntityID33Internal__) (ret EntityID33) {
+		if x == nil {
+			return ret
+		}
+		return x.Import()
+	})(&tmp))
+}
+
+func (t *TeamID) Encode(enc rpc.Encoder) error {
+	return enc.Encode(t.Export())
+}
+
+func (t *TeamID) Decode(dec rpc.Decoder) error {
+	var tmp TeamIDInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*t = tmp.Import()
+	return nil
+}
+
+func (t TeamID) Bytes() []byte {
+	return ((EntityID33)(t)).Bytes()
+}
+
 type HostID EntityID33
 type HostIDInternal__ EntityID33Internal__
 
@@ -929,7 +999,7 @@ type EntityType int
 const (
 	EntityType_User               EntityType = 1
 	EntityType_Host               EntityType = 2
-	EntityType_Team               EntityType = 3
+	EntityType_NamedTeam          EntityType = 3
 	EntityType_Device             EntityType = 4
 	EntityType_X509Cert           EntityType = 5
 	EntityType_LocationVRF        EntityType = 6
@@ -946,12 +1016,13 @@ const (
 	EntityType_PassphraseKey      EntityType = 17
 	EntityType_PKIXCert           EntityType = 18
 	EntityType_BotTokenKey        EntityType = 19
+	EntityType_AdHocTeam          EntityType = 20
 )
 
 var EntityTypeMap = map[string]EntityType{
 	"User":               1,
 	"Host":               2,
-	"Team":               3,
+	"NamedTeam":          3,
 	"Device":             4,
 	"X509Cert":           5,
 	"LocationVRF":        6,
@@ -968,11 +1039,12 @@ var EntityTypeMap = map[string]EntityType{
 	"PassphraseKey":      17,
 	"PKIXCert":           18,
 	"BotTokenKey":        19,
+	"AdHocTeam":          20,
 }
 var EntityTypeRevMap = map[EntityType]string{
 	1:  "User",
 	2:  "Host",
-	3:  "Team",
+	3:  "NamedTeam",
 	4:  "Device",
 	5:  "X509Cert",
 	6:  "LocationVRF",
@@ -989,6 +1061,7 @@ var EntityTypeRevMap = map[EntityType]string{
 	17: "PassphraseKey",
 	18: "PKIXCert",
 	19: "BotTokenKey",
+	20: "AdHocTeam",
 }
 
 type EntityTypeInternal__ EntityType
@@ -4961,17 +5034,23 @@ func (p *PartyName) Bytes() []byte { return nil }
 type PartyType int
 
 const (
-	PartyType_User PartyType = 0
-	PartyType_Team PartyType = 1
+	PartyType_User      PartyType = 0
+	PartyType_Team      PartyType = 1
+	PartyType_NamedTeam PartyType = 2
+	PartyType_AdHocTeam PartyType = 3
 )
 
 var PartyTypeMap = map[string]PartyType{
-	"User": 0,
-	"Team": 1,
+	"User":      0,
+	"Team":      1,
+	"NamedTeam": 2,
+	"AdHocTeam": 3,
 }
 var PartyTypeRevMap = map[PartyType]string{
 	0: "User",
 	1: "Team",
+	2: "NamedTeam",
+	3: "AdHocTeam",
 }
 
 type PartyTypeInternal__ PartyType

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -258,14 +258,14 @@ func (e EntityID) ToUID() (UID, error) {
 	return ret, nil
 }
 
-func (t TeamID) Type() EntityType { return EntityType_Team }
+func (t AdHocTeamID) Type() EntityType { return EntityType_AdHocTeam }
 
 func (e EntityID) ToTeamID() (TeamID, error) {
 	var ret TeamID
 	if len(e) != len(ret) {
 		return ret, EntityError("wrong length for team ID")
 	}
-	if e.Type() != ret.Type() {
+	if e.Type() != EntityType_NamedTeam && e.Type() != EntityType_AdHocTeam {
 		return ret, EntityError("wrong leading byte for team ID")
 	}
 	copy(ret[:], e)
@@ -574,8 +574,8 @@ func (t EntityType) IsEd25519() bool {
 	case EntityType_User, EntityType_Host, EntityType_Device,
 		EntityType_X509Cert, EntityType_LocationVRF, EntityType_Service,
 		EntityType_HostMerkleSigner, EntityType_HostMetadataSigner, EntityType_HostTLSCA,
-		EntityType_Subkey, EntityType_Team, EntityType_PTKVerify, EntityType_PUKVerify,
-		EntityType_BackupKey, EntityType_PassphraseKey, EntityType_BotTokenKey:
+		EntityType_Subkey, EntityType_NamedTeam, EntityType_PTKVerify, EntityType_PUKVerify,
+		EntityType_BackupKey, EntityType_PassphraseKey, EntityType_BotTokenKey, EntityType_AdHocTeam:
 		return true
 	default:
 		return false
@@ -2507,7 +2507,7 @@ func (t EntityType) RollingType() EntityType {
 	switch t {
 	case EntityType_User:
 		return EntityType_PUKVerify
-	case EntityType_Team:
+	case EntityType_NamedTeam, EntityType_AdHocTeam:
 		return EntityType_PTKVerify
 	default:
 		return t
@@ -2532,22 +2532,27 @@ func (e EntityID) ToRollingEntityID() (EntityID, error) {
 	return e.Type().RollingType().MakeEntityID(e.Data())
 }
 
-func (t EntityType) PersistentType() EntityType {
+func (t EntityType) PersistentType(p PartyType) EntityType {
 	switch t {
 	case EntityType_PUKVerify:
 		return EntityType_User
 	case EntityType_PTKVerify:
-		return EntityType_Team
+		switch p {
+		case PartyType_AdHocTeam:
+			return EntityType_AdHocTeam
+		default:
+			return EntityType_NamedTeam
+		}
 	default:
 		return t
 	}
 }
 
-func (e EntityID) Persistent() (EntityID, error) {
+func (e EntityID) Persistent(p PartyType) (EntityID, error) {
 	if len(e) < 2 {
 		return nil, DataError("entity ID too short")
 	}
-	return e.Type().PersistentType().MakeEntityID(e.Data())
+	return e.Type().PersistentType(p).MakeEntityID(e.Data())
 }
 
 func (f FQEntityFixed) Unfix() FQEntity {
@@ -2641,15 +2646,27 @@ func (p PartyID) Check() error {
 	switch p.EntityID().Type() {
 	case EntityType_User:
 		return nil
-	case EntityType_Team:
+	case EntityType_NamedTeam, EntityType_AdHocTeam:
 		return nil
 	default:
 		return DataError("bad principal id")
 	}
 }
 
+func (t EntityType) IsTeam() bool {
+	return t == EntityType_NamedTeam || t == EntityType_AdHocTeam
+}
+
+func (t EntityType) IsNamedTeam() bool {
+	return t == EntityType_NamedTeam
+}
+
+func (t EntityType) IsAdHocTeam() bool {
+	return t == EntityType_AdHocTeam
+}
+
 func (p PartyID) IsUser() bool { return len(p) > 2 && p.EntityID().Type() == EntityType_User }
-func (p PartyID) IsTeam() bool { return len(p) > 2 && p.EntityID().Type() == EntityType_Team }
+func (p PartyID) IsTeam() bool { return len(p) > 2 && p.EntityID().Type().IsTeam() }
 
 func (p PartyID) Select() (*UID, *TeamID, error) {
 	if len(p) != 33 {
@@ -2662,7 +2679,7 @@ func (p PartyID) Select() (*UID, *TeamID, error) {
 			return nil, nil, err
 		}
 		return &uid, nil, nil
-	case EntityType_Team:
+	case EntityType_NamedTeam, EntityType_AdHocTeam:
 		tid, err := p.TeamID()
 		if err != nil {
 			return nil, nil, err
@@ -2763,7 +2780,7 @@ func (e EntityID) ToPartyID() (PartyID, error) {
 		return nil, DataError("zero party")
 	}
 	switch e.Type() {
-	case EntityType_User, EntityType_Team:
+	case EntityType_User, EntityType_NamedTeam, EntityType_AdHocTeam:
 		return PartyID(e), nil
 	default:
 		return nil, DataError("bad party")
@@ -5337,3 +5354,31 @@ func (v KVVersion) GetVersion() Version {
 func (v RTChannelSetVersion) GetVersion() Version {
 	return Version(v)
 }
+
+func (t TeamID) Type() EntityType {
+	return t.EntityID().Type()
+}
+
+func (t TeamID) NamedTeamID() *NamedTeamID {
+	if t.Type() != EntityType_NamedTeam {
+		return nil
+	}
+	return (*NamedTeamID)(&t)
+}
+
+func (t TeamID) AdHocTeamID() *AdHocTeamID {
+	if t.Type() != EntityType_AdHocTeam {
+		return nil
+	}
+	return (*AdHocTeamID)(&t)
+}
+
+func (t TeamID) Select() (*NamedTeamID, *AdHocTeamID, error) {
+	if t.Type() != EntityType_NamedTeam && t.Type() != EntityType_AdHocTeam {
+		return nil, nil, DataError("bad team ID")
+	}
+	return t.NamedTeamID(), t.AdHocTeamID(), nil
+}
+
+func (t TeamID) IsNamedTeam() bool { return t.Type() == EntityType_NamedTeam }
+func (t TeamID) IsAdHocTeam() bool { return t.Type() == EntityType_AdHocTeam }

--- a/proto/rem/team.go
+++ b/proto/rem/team.go
@@ -4040,6 +4040,63 @@ func (t *TeamConfig) Decode(dec rpc.Decoder) error {
 
 func (t *TeamConfig) Bytes() []byte { return nil }
 
+type CreateTeamCommonArg struct {
+	SubchainTreeLocationSeed lib.TreeLocation
+	Eta                      EditTeamArg
+	TeamMembershipLink       PostGenericLinkArg
+}
+type CreateTeamCommonArgInternal__ struct {
+	_struct                  struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	SubchainTreeLocationSeed *lib.TreeLocationInternal__
+	Eta                      *EditTeamArgInternal__
+	TeamMembershipLink       *PostGenericLinkArgInternal__
+}
+
+func (c CreateTeamCommonArgInternal__) Import() CreateTeamCommonArg {
+	return CreateTeamCommonArg{
+		SubchainTreeLocationSeed: (func(x *lib.TreeLocationInternal__) (ret lib.TreeLocation) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(c.SubchainTreeLocationSeed),
+		Eta: (func(x *EditTeamArgInternal__) (ret EditTeamArg) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(c.Eta),
+		TeamMembershipLink: (func(x *PostGenericLinkArgInternal__) (ret PostGenericLinkArg) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(c.TeamMembershipLink),
+	}
+}
+func (c CreateTeamCommonArg) Export() *CreateTeamCommonArgInternal__ {
+	return &CreateTeamCommonArgInternal__{
+		SubchainTreeLocationSeed: c.SubchainTreeLocationSeed.Export(),
+		Eta:                      c.Eta.Export(),
+		TeamMembershipLink:       c.TeamMembershipLink.Export(),
+	}
+}
+func (c *CreateTeamCommonArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(c.Export())
+}
+
+func (c *CreateTeamCommonArg) Decode(dec rpc.Decoder) error {
+	var tmp CreateTeamCommonArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*c = tmp.Import()
+	return nil
+}
+
+func (c *CreateTeamCommonArg) Bytes() []byte { return nil }
+
 var TeamAdminProtocolID rpc.ProtocolUniqueID = rpc.ProtocolUniqueID(0xdbe1ddbe)
 
 type ReserveTeamnameArg struct {
@@ -4839,6 +4896,45 @@ func (g *GetTeamConfigArg) Decode(dec rpc.Decoder) error {
 
 func (g *GetTeamConfigArg) Bytes() []byte { return nil }
 
+type CreateTeamAdHocArg struct {
+	Carg CreateTeamCommonArg
+}
+type CreateTeamAdHocArgInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Carg    *CreateTeamCommonArgInternal__
+}
+
+func (c CreateTeamAdHocArgInternal__) Import() CreateTeamAdHocArg {
+	return CreateTeamAdHocArg{
+		Carg: (func(x *CreateTeamCommonArgInternal__) (ret CreateTeamCommonArg) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(c.Carg),
+	}
+}
+func (c CreateTeamAdHocArg) Export() *CreateTeamAdHocArgInternal__ {
+	return &CreateTeamAdHocArgInternal__{
+		Carg: c.Carg.Export(),
+	}
+}
+func (c *CreateTeamAdHocArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(c.Export())
+}
+
+func (c *CreateTeamAdHocArg) Decode(dec rpc.Decoder) error {
+	var tmp CreateTeamAdHocArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*c = tmp.Import()
+	return nil
+}
+
+func (c *CreateTeamAdHocArg) Bytes() []byte { return nil }
+
 type TeamAdminInterface interface {
 	ReserveTeamname(context.Context, lib.Name) (ReserveNameRes, error)
 	CreateTeam(context.Context, CreateTeamArg) error
@@ -4855,6 +4951,7 @@ type TeamAdminInterface interface {
 	LoadTeamRawInbox(context.Context, LoadTeamRawInboxArg) (TeamRawInbox, error)
 	RejectJoinReq(context.Context, RejectJoinReqArg) error
 	GetTeamConfig(context.Context) (TeamConfig, error)
+	CreateTeamAdHoc(context.Context, CreateTeamCommonArg) error
 	ErrorWrapper() func(error) lib.Status
 }
 
@@ -5059,6 +5156,17 @@ func (c TeamAdminClient) GetTeamConfig(ctx context.Context) (res TeamConfig, err
 		return
 	}
 	res = tmp.Import()
+	return
+}
+func (c TeamAdminClient) CreateTeamAdHoc(ctx context.Context, carg CreateTeamCommonArg) (err error) {
+	arg := CreateTeamAdHocArg{
+		Carg: carg,
+	}
+	warg := arg.Export()
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(TeamAdminProtocolID, 15, "TeamAdmin.createTeamAdHoc"), warg, nil, 0*time.Millisecond, teamAdminErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
 	return
 }
 func TeamAdminProtocol(i TeamAdminInterface) rpc.ProtocolV2 {
@@ -5390,6 +5498,27 @@ func TeamAdminProtocol(i TeamAdminInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "getTeamConfig",
+			},
+			15: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret CreateTeamAdHocArgInternal__
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedArg, ok := args.(*CreateTeamAdHocArgInternal__)
+						if !ok {
+							err := rpc.NewTypeError((*CreateTeamAdHocArgInternal__)(nil), args)
+							return nil, err
+						}
+						err := i.CreateTeamAdHoc(ctx, (typedArg.Import()).Carg)
+						if err != nil {
+							return nil, err
+						}
+						return nil, nil
+					},
+				},
+				Name: "createTeamAdHoc",
 			},
 		},
 		WrapError: TeamAdminMakeGenericErrorWrapper(i.ErrorWrapper()),

--- a/server/engine/team_admin.go
+++ b/server/engine/team_admin.go
@@ -41,10 +41,17 @@ type teamEditor struct {
 	tokTeamID *proto.TeamID
 }
 
+type teamCreatorNameArg struct {
+	NameUtf8              proto.NameUtf8
+	TeamnameCommitmentKey proto.RandomCommitmentKey
+	Rnr                   rem.ReserveNameRes
+}
+
 type teamCreator struct {
 	*teamEditor
 	openEldestRes *team.OpenEldestRes
-	arg           rem.CreateTeamArg
+	nameArg       *teamCreatorNameArg
+	commonArg     rem.CreateTeamCommonArg
 }
 
 type teamEditInterface interface {
@@ -72,9 +79,18 @@ func (c *UserClientConn) CreateTeam(
 	}
 	defer db.Release()
 
-	return shared.RetryTx(m, db, "signup", func(m shared.MetaContext, tx pgx.Tx) error {
+	return shared.RetryTx(m, db, "createTeam", func(m shared.MetaContext, tx pgx.Tx) error {
 		obj := &teamCreator{
-			arg: arg,
+			nameArg: &teamCreatorNameArg{
+				NameUtf8:              arg.NameUtf8,
+				TeamnameCommitmentKey: arg.TeamnameCommitmentKey,
+				Rnr:                   arg.Rnr,
+			},
+			commonArg: rem.CreateTeamCommonArg{
+				Eta:                      arg.Eta,
+				TeamMembershipLink:       arg.TeamMembershipLink,
+				SubchainTreeLocationSeed: arg.SubchainTreeLocationSeed,
+			},
 			teamEditor: &teamEditor{
 				UserClientConn: c,
 				arg:            arg.Eta,
@@ -92,11 +108,20 @@ func (c *teamCreator) handleNameReservation(
 	proto.Name,
 	error,
 ) {
-	expectedName, err := core.NormalizeName(proto.NameUtf8(c.arg.NameUtf8))
+
+	if c.nameArg == nil {
+		err := m.G().AdHocTeamNamesManager().InsertPlaceholderTeamName(m, c.tx)
+		if err != nil {
+			return "", err
+		}
+		return team.AdHocTeamName, nil
+	}
+
+	expectedName, err := core.NormalizeName(proto.NameUtf8(c.nameArg.NameUtf8))
 	if err != nil {
 		return "", err
 	}
-	err = shared.ClaimReservation(m, c.tx, m.HostID(), expectedName, c.arg.Rnr, rem.NameType_Team)
+	err = shared.ClaimReservation(m, c.tx, m.HostID(), expectedName, c.nameArg.Rnr, rem.NameType_Team)
 	if err != nil {
 		return "", err
 	}
@@ -190,29 +215,35 @@ func (c *teamEditor) editMembers(
 func (c *teamCreator) insertCreateTeam(
 	m shared.MetaContext,
 ) error {
-	err := shared.InsertName(
-		m,
-		c.tx,
-		c.teamID.EntityID(),
-		c.signer,
-		m.HostID(),
-		c.name,
-		c.arg.NameUtf8,
-		&c.arg.TeamnameCommitmentKey,
-		c.openEldestRes.Tnc,
-		c.arg.Rnr.Seq,
-		rem.NameType_Team,
-	)
-	if err != nil {
-		return err
+
+	// Ad-hoc teams don't have a name, so we don't need to insert a name.
+	// We use the default name "-" for all ad-hoc teams, which should already
+	// be in the database.
+	if c.nameArg != nil {
+		err := shared.InsertName(
+			m,
+			c.tx,
+			c.teamID.EntityID(),
+			c.signer,
+			m.HostID(),
+			c.name,
+			c.nameArg.NameUtf8,
+			&c.nameArg.TeamnameCommitmentKey,
+			c.openEldestRes.Tnc,
+			c.nameArg.Rnr.Seq,
+			rem.NameType_Team,
+		)
+		if err != nil {
+			return err
+		}
 	}
-	err = c.insertIntoTeams(m)
+	err := c.insertIntoTeams(m)
 	if err != nil {
 		return err
 	}
 
 	err = shared.InsertSubchainTreeLocationSeed(m, c.tx, c.teamID.ToPartyID(),
-		c.arg.SubchainTreeLocationSeed, c.openEldestRes.Stltc)
+		c.commonArg.SubchainTreeLocationSeed, c.openEldestRes.Stltc)
 	if err != nil {
 		return err
 	}
@@ -401,6 +432,18 @@ func (c *teamCreator) checkSigner(
 	return nil
 }
 
+func (c *teamCreator) checkArgs(m shared.MetaContext) error {
+
+	typ := c.teamID.Type()
+	if c.nameArg == nil && typ != proto.EntityType_AdHocTeam {
+		return core.BadArgsError("bad team ID type; expected AdHocTeam")
+	}
+	if c.nameArg != nil && typ != proto.EntityType_NamedTeam {
+		return core.BadArgsError("bad team ID type; expected NamedTeam")
+	}
+	return nil
+}
+
 func (c *teamCreator) run(
 	m shared.MetaContext,
 ) error {
@@ -412,11 +455,11 @@ func (c *teamCreator) run(
 	if err != nil {
 		return err
 	}
-	hepks, err := core.ImportHEPKSet(&c.arg.Eta.Obd.Hepks)
+	hepks, err := core.ImportHEPKSet(&c.commonArg.Eta.Obd.Hepks)
 	if err != nil {
 		return err
 	}
-	openRes, err := team.OpenEldestLink(&c.arg.Eta.Link, hepks, m.HostID().Id)
+	openRes, err := team.OpenEldestLink(&c.commonArg.Eta.Link, hepks, m.HostID().Id)
 	if err != nil {
 		return err
 	}
@@ -428,6 +471,11 @@ func (c *teamCreator) run(
 		return err
 	}
 	c.seqno = openRes.Gc.Chainer.Base.Seqno
+
+	err = c.checkArgs(m)
+	if err != nil {
+		return err
+	}
 
 	// Usually the signer is already in the chain, but for the first link,
 	// we need to check the signer against database.
@@ -441,7 +489,7 @@ func (c *teamCreator) run(
 		return err
 	}
 
-	err = shared.InsertTeamMembershipLink(m, c.tx, c.arg.TeamMembershipLink)
+	err = shared.InsertTeamMembershipLink(m, c.tx, c.commonArg.TeamMembershipLink)
 	if err != nil {
 		return err
 	}
@@ -471,6 +519,16 @@ func (e *teamEditor) runEdit(m shared.MetaContext) error {
 	}
 	e.teamID = *teamid
 	e.seqno = seqno
+
+	// Ad-hoc teams have a fixed membership set at creation; reject any later
+	// edit (add/remove/role-change/rotation). This is the authoritative guard --
+	// the client enforces the same rule, but a client can disable its check, so
+	// the server must independently refuse. Checked before any other validation
+	// so a malformed edit can't slip past.
+	if e.teamID.Type().IsAdHocTeam() {
+		return core.TeamError(team.AdHocTeamImmutableMsg)
+	}
+
 	return e.runEditCommon(m)
 }
 
@@ -971,6 +1029,32 @@ func (u *UserClientConn) GetTeamConfig(ctx context.Context) (rem.TeamConfig, err
 	}
 	ret.MaxRoles = uint64(tcfg.MaxRoles())
 	return ret, nil
+}
+
+func (c *UserClientConn) CreateTeamAdHoc(
+	ctx context.Context,
+	arg rem.CreateTeamCommonArg,
+) error {
+	m := shared.NewMetaContextConn(ctx, c)
+	db, err := m.Db(shared.DbTypeUsers)
+	if err != nil {
+		return err
+	}
+	defer db.Release()
+
+	return shared.RetryTx(m, db, "createTeamAdhoc", func(m shared.MetaContext, tx pgx.Tx) error {
+		obj := &teamCreator{
+			commonArg: arg,
+			teamEditor: &teamEditor{
+				UserClientConn: c,
+				arg:            arg.Eta,
+				tx:             tx,
+			},
+		}
+
+		obj.teamEditor.vtab = obj
+		return obj.run(m)
+	})
 }
 
 var _ rem.TeamAdminInterface = (*UserClientConn)(nil)

--- a/server/shared/globals.go
+++ b/server/shared/globals.go
@@ -69,6 +69,10 @@ type GlobalContext struct {
 	// On prod, might be Amazon SQS, etc. In test, it's the queue service.
 	qs QueueServer
 
+	// Only need to insert an ad-hoc team name placeholder once per
+	// each host ID. We keep track of this here.
+	ahtMgr *AdHocTeamNamesManager
+
 	// A lot of services might need to poll the Merkle Query service. Available here
 	merkleGCli *BackendClient
 
@@ -147,6 +151,7 @@ func NewGlobalContext(opts *GlobalContextOpts) *GlobalContext {
 		kvShardMgr:      NewKVShardMgr(),
 		testing:         testing,
 		oauth2ConfigSet: sso.NewOAuth2ConfigSet(),
+		ahtMgr:          NewAdHocTeamNamesManager(),
 	}
 }
 
@@ -169,6 +174,12 @@ func (g *GlobalContext) SetClock(c clockwork.Clock) {
 		c = clockwork.NewRealClock()
 	}
 	g.clock = c
+}
+
+func (g *GlobalContext) AdHocTeamNamesManager() *AdHocTeamNamesManager {
+	g.RLock()
+	defer g.RUnlock()
+	return g.ahtMgr
 }
 
 func (g *GlobalContext) SetVanityHelper(v VanityHelper) {

--- a/server/shared/name.go
+++ b/server/shared/name.go
@@ -13,6 +13,32 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
+func InsertNameInner(
+	m MetaContext,
+	tx pgx.Tx,
+	hostID core.HostID,
+	name proto.Name,
+	nameUtf8 proto.NameUtf8,
+	typ rem.NameType,
+	reuseId proto.NameSeqno,
+	maybeRepeat bool,
+) error {
+	tag, err := tx.Exec(m.Ctx(),
+		`INSERT INTO names(short_host_id,name_ascii,name_utf8,reuse_id,state,typ,ctime)
+		VALUES($1,$2,$3,$4,$5,$6,NOW())`+
+			core.Sel(maybeRepeat, " ON CONFLICT DO NOTHING", ""),
+		hostID.Short.ExportToDB(),
+		name, nameUtf8, reuseId, "in_use", typ.ExportToDB(),
+	)
+	if err != nil {
+		return err
+	}
+	if !maybeRepeat && tag.RowsAffected() != 1 {
+		return core.InsertError("names")
+	}
+	return nil
+}
+
 func InsertName(
 	m MetaContext,
 	tx pgx.Tx,
@@ -52,19 +78,9 @@ func InsertName(
 		return core.ReservationError("invalid name reuse_id")
 	}
 
-	tag, err := tx.Exec(m.Ctx(),
-		`INSERT INTO names(short_host_id,name_ascii,name_utf8,reuse_id,ctime,mtime,state,typ)
-	     VALUES($1,$2,$3,$4,NOW(),NOW(),'in_use',$5)`,
-		int(hostID.Short),
-		name, nameUtf8, reuseId,
-		typ.ExportToDB(),
-	)
+	err = InsertNameInner(m, tx, hostID, name, nameUtf8, typ, reuseId, false)
 	if err != nil {
-		m.Errorw("signup", "stage", "insert usernames", "err", err)
 		return err
-	}
-	if tag.RowsAffected() != 1 {
-		return core.InsertError("usernames")
 	}
 
 	pun := proto.Name(name).Normalize()

--- a/server/shared/team.go
+++ b/server/shared/team.go
@@ -5,6 +5,7 @@ package shared
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/lib/team"
@@ -573,7 +574,7 @@ func CheckLocalMembers(
 ) error {
 
 	checkTeamIndexRange := func(chng proto.MemberRole, keys proto.TeamMemberKeys) error {
-		if chng.Member.Id.Entity.Type() != proto.EntityType_Team {
+		if !chng.Member.Id.Entity.Type().IsTeam() {
 			return nil
 		}
 		tid, err := chng.Member.Id.Entity.ToTeamID()
@@ -1226,6 +1227,12 @@ func CheckAndInsertRemovalKeys(
 	rks []rem.TeamRemovalBoxData,
 	changes []proto.MemberRole,
 ) error {
+	if teamID.IsAdHocTeam() {
+		if len(rks) > 0 {
+			return core.TeamError("removal keys are not allowed for adhoc teams")
+		}
+		return nil
+	}
 
 	if len(rks) != len(sched.Additions) {
 		return core.TeamError("wrong number of removal keys; should equal number of new members")
@@ -1896,7 +1903,7 @@ func CheckMemberIndexRangesAgainstTeam(
 	}
 
 	return forAllTeamChanges(changes, func(chng proto.MemberRole, tmk proto.TeamMemberKeys) error {
-		if chng.Member.Id.Entity.Type() != proto.EntityType_Team {
+		if !chng.Member.Id.Entity.Type().IsTeam() {
 			return nil
 		}
 		if tmk.Tir == nil {
@@ -2148,4 +2155,40 @@ func LoadMemberLoadFloor(
 		return nil, err
 	}
 	return proto.ImportRoleFromDB(rk, vl)
+}
+
+type AdHocTeamNamesManager struct {
+	sync.Mutex
+	inserted map[core.ShortHostID]bool
+}
+
+func NewAdHocTeamNamesManager() *AdHocTeamNamesManager {
+	return &AdHocTeamNamesManager{
+		inserted: make(map[core.ShortHostID]bool),
+	}
+}
+
+func (a *AdHocTeamNamesManager) InsertPlaceholderTeamName(
+	m MetaContext, tx pgx.Tx,
+) error {
+	hostID := m.ShortHostID()
+
+	a.Lock()
+	defer a.Unlock()
+	ins := a.inserted[hostID]
+	if ins {
+		return nil
+	}
+	err := InsertNameInner(m, tx, m.HostID(),
+		team.AdHocTeamName,
+		proto.NameUtf8(team.AdHocTeamName),
+		rem.NameType_Team,
+		proto.FirstNameSeqno,
+		true,
+	)
+	if err != nil {
+		return err
+	}
+	a.inserted[hostID] = true
+	return nil
 }

--- a/server/sql/foks_users.sql
+++ b/server/sql/foks_users.sql
@@ -16,7 +16,7 @@ CREATE TABLE name_reservations (
 
 CREATE TABLE names (
     short_host_id SMALLINT NOT NULL,
-    name_ascii VARCHAR(255),
+    name_ascii VARCHAR(255), /* is unique per short_host_id via the primary key */
     reuse_id INT NOT NULL,
     name_utf8 VARCHAR(255),
     state name_state NOT NULL,


### PR DESCRIPTION
- one e2e test is working, but we need more testing
- refactor of args for CreateTeam machinery so we can split naming out from team internals
- we're going to leave the TeamID as is, and we can upcast to a
      NamedTeamID or an AdHocTeamID wheere necessary. This feels safest
- giant refactor of the team creation process
- allow for other founding members up into teams
- split the team creation system into multiple piecemeal steps
- start allowing for optional teamnames
- more progress on getting server-side support for this, which should be in decent shape
- we don't need team removal keys on adhoc teams because can't remove from an adhoc team
       - and we need to enforce this on the removal endpoint, too (todo)
- plumb through the optionality of team removal keys and boxes
- team removal keys are optional on the server side
- finish plumbing through to post() functions in teamCreator
- open viewership required at first, and maybe forever, i don't know of a better UI for it
- apply checks to both kinds of teams (fix bug in renaming Team -> NamedTeam)
- turn off editing of adhoc teams on client and server
- check that both codepaths are guided with tests
- reject team membership changes in adhoc teams in loader
