### PR TITLE
chat(1d): fan out user inbox version bumps on message send

### DIFF
--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
+	"github.com/foks-proj/go-foks/server/shared"
 	"github.com/stretchr/testify/require"
 )
 
@@ -901,20 +902,20 @@ func TestRTSendReadPermissions(t *testing.T) {
 
 	// "announce": a bottom channel (so coco can see it and read it) that only
 	// admins+ may write to.
-	_, err := minderBluey.MakeChannel(mb, team.WrapNamedPtr(fqt),
+	chAnnounce, err := minderBluey.MakeChannel(mb, team.WrapNamedPtr(fqt),
 		proto.RTAppID_Chat, "announce",
 		"admins post here",
 		proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.AdminRole})
 	require.NoError(t, err)
 
 	// "watercooler": a bottom channel any member may write to (positive control).
-	_, err = minderBluey.MakeChannel(mb, team.WrapNamedPtr(fqt), proto.RTAppID_Chat, "watercooler",
+	chWatercooler, err := minderBluey.MakeChannel(mb, team.WrapNamedPtr(fqt), proto.RTAppID_Chat, "watercooler",
 		"anyone posts",
 		proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.DefaultRole})
 	require.NoError(t, err)
 
 	// "brass": an admin-tier channel coco shouldn't even be able to see.
-	_, err = minderBluey.MakeChannel(mb, team.WrapNamedPtr(fqt), proto.RTAppID_Chat, "brass",
+	chBrass, err := minderBluey.MakeChannel(mb, team.WrapNamedPtr(fqt), proto.RTAppID_Chat, "brass",
 		"admins only",
 		proto.RolePairOpt{Read: &proto.AdminRole, Write: &proto.AdminRole})
 	require.NoError(t, err)
@@ -957,6 +958,48 @@ func TestRTSendReadPermissions(t *testing.T) {
 	_, err = minderCoco.GetThreadRecentMsgs(mc, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
 		makeChannelSpecifierWithString("brass"), 0)
 	require.Equal(t, core.RTNotFoundError("channel 'brass'"), err)
+
+	// --- inbox fanout ---
+
+	// Every successful send fans out inbox-version bumps to all channel
+	// members (see user_channels/user_inbox in foks_realtime.sql). Tally:
+	// channel-creation fanouts hit announce {bluey, coco}, watercooler {bluey,
+	// coco}, and brass {bluey} (coco is below its read role); then coco's
+	// watercooler send bumps both members, coco's rejected announce send bumps
+	// no one, and bluey's announce send bumps both members. Reads bump nothing.
+	// So bluey has taken 5 bumps and coco 4, and each user_channels row is
+	// stamped at its owner's global version as of the last delivery into that
+	// channel (or its creation, for brass).
+	rtdb, err := m.Db(shared.DbTypeRealTime)
+	require.NoError(t, err)
+	defer rtdb.Release()
+
+	uiVers := func(u *TestUser) int64 {
+		var v int64
+		err := rtdb.QueryRow(m.Ctx(),
+			`SELECT inbox_version FROM user_inbox
+			 WHERE short_host_id=$1 AND uid=$2 AND app_id='chat'`,
+			m.ShortHostID(), u.uid.ExportToDB()).Scan(&v)
+		require.NoError(t, err)
+		return v
+	}
+	ucVers := func(u *TestUser, ch *proto.RTChannelID) int64 {
+		var v int64
+		err := rtdb.QueryRow(m.Ctx(),
+			`SELECT inbox_version FROM user_channels
+			 WHERE short_host_id=$1 AND channel_id=$2 AND uid=$3`,
+			m.ShortHostID(), ch.Short().Int64(), u.uid.ExportToDB()).Scan(&v)
+		require.NoError(t, err)
+		return v
+	}
+
+	require.Equal(t, int64(5), uiVers(bluey))
+	require.Equal(t, int64(4), uiVers(coco))
+	require.Equal(t, int64(5), ucVers(bluey, chAnnounce))
+	require.Equal(t, int64(4), ucVers(bluey, chWatercooler))
+	require.Equal(t, int64(3), ucVers(bluey, chBrass))
+	require.Equal(t, int64(4), ucVers(coco, chAnnounce))
+	require.Equal(t, int64(3), ucVers(coco, chWatercooler))
 }
 
 // TestRTSendEncryptionRole checks that the server rejects a message encrypted

--- a/server/realtime/channels.go
+++ b/server/realtime/channels.go
@@ -1,6 +1,8 @@
 package realtime
 
 import (
+	"bytes"
+	"slices"
 	"time"
 
 	"github.com/foks-proj/go-foks/lib/core"
@@ -573,6 +575,13 @@ func (c *channelMaker) fanoutUsers(m shared.MetaContext) error {
 		return err
 	}
 
+	// Deterministic order: fanoutToUser takes user_inbox row locks, so sorting
+	// by UID keeps the lock order consistent with the message-send fanout
+	// (messageSender.fanoutInboxVersions, which ORDERs BY uid), avoiding
+	// deadlocks between concurrent transactions over overlapping member sets.
+	slices.SortFunc(uids, func(a, b proto.UID) int {
+		return bytes.Compare(a[:], b[:])
+	})
 	for _, uid := range uids {
 		err = c.fanoutToUser(m, uid)
 		if err != nil {

--- a/server/realtime/messages.go
+++ b/server/realtime/messages.go
@@ -234,6 +234,59 @@ func (s *messageSender) insertMessage(
 	return proto.ExportTime(insertTime), nil
 }
 
+// fanoutInboxVersions bumps each channel member's per-(user, app) global inbox
+// version and stamps their user_channels membership row at that new version --
+// the fan-out-on-write described for user_channels/user_inbox in
+// foks_realtime.sql. The stamped row is what the (uid, app_id, inbox_version)
+// index scans to answer "which threads changed since version X" on the
+// member's next inbox sync. Membership is the set of user_channels rows for
+// this channel (written by the channel-creation fanout); both statements are
+// set-based and run in the send transaction, so the fanout commits or rolls
+// back atomically with the message itself.
+func (s *messageSender) fanoutInboxVersions(
+	m shared.MetaContext,
+	insertTime time.Time,
+) error {
+	// Bump each member's (uid, app) global inbox version. The insert arm is
+	// paranoia -- the channel-creation fanout writes user_inbox before
+	// user_channels -- but keeps a missing row self-healing. The ORDER BY
+	// makes concurrent sends into different channels with overlapping
+	// membership acquire user_inbox row locks in a consistent order, avoiding
+	// deadlocks.
+	_, err := s.tx.Exec(
+		m.Ctx(),
+		`INSERT INTO user_inbox (short_host_id, uid, app_id, inbox_version, mtime)
+		 SELECT uc.short_host_id, uc.uid, uc.app_id, 1, NOW()
+		   FROM user_channels uc
+		  WHERE uc.short_host_id=$1 AND uc.channel_id=$2
+		  ORDER BY uc.uid
+		 ON CONFLICT (short_host_id, uid, app_id)
+		 DO UPDATE SET inbox_version = user_inbox.inbox_version + 1, mtime = NOW()`,
+		m.ShortHostID(),
+		s.channelID(),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Stamp each membership row at its owner's just-bumped global version, and
+	// refresh the denormalized last-message time for inbox ordering. Reads the
+	// user_inbox rows written above in the same transaction.
+	_, err = s.tx.Exec(
+		m.Ctx(),
+		`UPDATE user_channels uc
+		 SET inbox_version = ui.inbox_version, last_msg_time = $3, mtime = NOW()
+		 FROM user_inbox ui
+		 WHERE ui.short_host_id = uc.short_host_id
+		   AND ui.uid = uc.uid AND ui.app_id = uc.app_id
+		   AND uc.short_host_id=$1 AND uc.channel_id=$2`,
+		m.ShortHostID(),
+		s.channelID(),
+		insertTime,
+	)
+	return err
+}
+
 func (s *messageSender) run(m shared.MetaContext) (*rem.RTSendRes, error) {
 	err := s.lockChannel(m)
 	if err != nil {
@@ -254,6 +307,10 @@ func (s *messageSender) run(m shared.MetaContext) (*rem.RTSendRes, error) {
 		return nil, err
 	}
 	insertTime, err := s.insertMessage(m, senderNo, seq)
+	if err != nil {
+		return nil, err
+	}
+	err = s.fanoutInboxVersions(m, insertTime.Import())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Implements the fan-out-on-write described for `user_channels`/`user_inbox` in `foks_realtime.sql`, which was designed but never wired up.

## What

On every successful message send (`server/realtime/messages.go`), a new `messageSender.fanoutInboxVersions` step runs inside the send transaction:

1. **Bump `user_inbox`** — every member with a `user_channels` row on the channel gets their per-(user, app) global inbox version incremented, via one set-based `INSERT ... SELECT ... ON CONFLICT DO UPDATE`. The insert arm is self-healing paranoia (channel-creation fanout normally seeds the row).
2. **Stamp `user_channels`** — a set-based `UPDATE ... FROM user_inbox` sets each membership row's `inbox_version` to its owner's just-bumped global version, and refreshes the denormalized `last_msg_time` (server insert time) and `mtime`. This is the write that the `user_channels_inbox_idx` hot index consumes to answer "which threads changed since version X" on the next inbox sync.

Both statements are set-based (no per-member loop) and commit atomically with the message itself.

## Deadlock hygiene

Two paths now take `user_inbox` row locks: the channel-creation fanout (per-user loop in `channels.go`) and this send fanout. The send fanout `ORDER`s `BY uid`, and the channel-creation loop now sorts its members the same way, so concurrent transactions over overlapping member sets acquire row locks in one consistent order.

## Testing

`TestRTSendReadPermissions` (which already had the ideal fixture: two users, three channels with mixed membership) now asserts the exact inbox-version matrix:

- creation fanouts hit only members at/above the channel's read role (brass excludes coco);
- each successful send bumps every member's global version and stamps that channel's rows;
- a permission-rejected send bumps nothing (fails in `authorize`, tx rolls back);
- reads bump nothing (read-receipt bumping is not yet implemented).

Full `TestRT*` lib suite passes under `-race` (no warnings), CLI `TestRT*` passes, build/vet/gofmt clean.

## Scope

This is the write half only. The read half (`read_through` updates bumping versions) and the `get_changed_threads` sync endpoint that consumes these versions remain for a later stage.

Co-authored-by: Claude Code