### PR TITLE
chat(1d): implement rtReadThrough, the read side of inbox versioning

### DIFF
--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -817,6 +817,39 @@ func (d *Minder) Send(
 	return d.SendWithTestHooks(m, team, appID, channel, body, nil)
 }
 
+// ReadThrough advances the caller's read pointer in a channel to seq, so
+// their other devices learn the read state via the resulting inbox-version
+// bump. The pointer is monotonic server-side: a stale or repeated mark is a
+// silent no-op (and bumps nothing).
+func (d *Minder) ReadThrough(
+	m MetaContext,
+	team lcl.ConfigTeam,
+	appID proto.RTAppID,
+	channel lcl.RTChannelSpecifier,
+	seq proto.RTMsgSeq,
+) error {
+	err := assertTeam(team)
+	if err != nil {
+		return err
+	}
+	rtp, err := d.base.GetParty(m.Base(), team)
+	if err != nil {
+		return err
+	}
+	ch, err := d.resolveChannel(m, rtp, appID, channel)
+	if err != nil {
+		return err
+	}
+	_, cli, err := d.clientLocal(m.Base(), d.au)
+	if err != nil {
+		return err
+	}
+	return cli.RtReadThrough(m.Ctx(), rem.RTReadThroughArg{
+		ChannelID: ch.Id,
+		Seq:       seq,
+	})
+}
+
 func (d *Minder) cacheMsgID(
 	q proto.RTMsgSeq,
 	i proto.RTMsgID,

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -1000,6 +1000,62 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.Equal(t, int64(3), ucVers(bluey, chBrass))
 	require.Equal(t, int64(4), ucVers(coco, chAnnounce))
 	require.Equal(t, int64(3), ucVers(coco, chWatercooler))
+
+	// --- read receipts ---
+
+	ucRead := func(u *TestUser, ch *proto.RTChannelID) int64 {
+		var v int64
+		err := rtdb.QueryRow(m.Ctx(),
+			`SELECT read_through FROM user_channels
+			 WHERE short_host_id=$1 AND channel_id=$2 AND uid=$3`,
+			m.ShortHostID(), ch.Short().Int64(), u.uid.ExportToDB()).Scan(&v)
+		require.NoError(t, err)
+		return v
+	}
+
+	// coco marks announce read through its one message: her read pointer
+	// advances, her global inbox version bumps, and the announce row is
+	// stamped at the new version -- just like a delivery -- so her other
+	// devices pick up the read state.
+	err = minderCoco.ReadThrough(mc, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("announce"), 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), uiVers(coco))
+	require.Equal(t, int64(5), ucVers(coco, chAnnounce))
+	require.Equal(t, int64(1), ucRead(coco, chAnnounce))
+
+	// Repeating the same mark (or any stale one) is a no-op: the pointer is
+	// monotonic and nothing bumps, so racing devices can't churn each other.
+	err = minderCoco.ReadThrough(mc, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("announce"), 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(5), uiVers(coco))
+	require.Equal(t, int64(5), ucVers(coco, chAnnounce))
+
+	// Marking past the last message is a client bug and is rejected.
+	err = minderCoco.ReadThrough(mc, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("announce"), 2)
+	require.Equal(t, core.BadArgsError("read-through seq exceeds last message"), err)
+
+	// A read receipt requires read permission, like the read itself; coco
+	// can't even address brass, so resolution fails client-side.
+	err = minderCoco.ReadThrough(mc, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("brass"), 1)
+	require.Error(t, err)
+
+	// brass has no messages at all, so there's nothing to mark read.
+	err = minderBluey.ReadThrough(mb, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("brass"), 1)
+	require.Equal(t, core.BadArgsError("read-through seq exceeds last message"), err)
+
+	// The owner's receipt bumps only her own inbox, not coco's.
+	err = minderBluey.ReadThrough(mb, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("watercooler"), 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(6), uiVers(bluey))
+	require.Equal(t, int64(6), ucVers(bluey, chWatercooler))
+	require.Equal(t, int64(1), ucRead(bluey, chWatercooler))
+	require.Equal(t, int64(5), uiVers(coco))
 }
 
 // TestRTSendEncryptionRole checks that the server rejects a message encrypted

--- a/server/realtime/messages.go
+++ b/server/realtime/messages.go
@@ -365,6 +365,189 @@ func SendMessage(
 	return res, nil
 }
 
+// readThroughMarker advances the calling user's read pointer in one channel
+// and, if the pointer actually moved, bumps the caller's global inbox version
+// and stamps their user_channels row at it -- exactly as a delivery would (see
+// "read_through" in chat-server-design.md). That's how the caller's *other*
+// devices learn the read state on their next inbox sync. Unlike the send
+// fanout, only the calling user's rows are touched.
+type readThroughMarker struct {
+	arg    rem.RTReadThroughArg
+	reader proto.UID
+	userdb shared.Querier
+	tx     pgx.Tx
+
+	// loaded from the channels row
+	parentTeam proto.TeamID
+	readRole   proto.Role
+	lastSeq    *int64
+	appID      string
+}
+
+func (r *readThroughMarker) channelID() int64 { return r.arg.ChannelID.Short().Int64() }
+
+// loadChannel reads the channel's team, read role, last seq, and app. No row
+// lock: an honest client only marks messages it has already received, which
+// are committed and thus visible to our snapshot, so last_msg_seq can't race
+// backwards under us.
+func (r *readThroughMarker) loadChannel(m shared.MetaContext) error {
+	var teamRaw []byte
+	var rrt, rvl int
+	err := r.tx.QueryRow(
+		m.Ctx(),
+		`SELECT parent_team_id, read_role_type, read_role_viz_level,
+		        last_msg_seq, app_id
+		 FROM channels
+		 WHERE short_host_id=$1 AND channel_id=$2`,
+		m.ShortHostID(),
+		r.channelID(),
+	).Scan(&teamRaw, &rrt, &rvl, &r.lastSeq, &r.appID)
+	if err == pgx.ErrNoRows {
+		return core.RowNotFoundError{}
+	}
+	if err != nil {
+		return err
+	}
+	err = r.parentTeam.ImportFromDB(teamRaw)
+	if err != nil {
+		return err
+	}
+	return r.readRole.ImportFromDB(rrt, rvl)
+}
+
+// authorize applies the same check as a thread read: the caller's team role
+// must be at or above the channel's read role.
+func (r *readThroughMarker) authorize(m shared.MetaContext) error {
+	role, err := AuthorizeUserForTeam(m, r.userdb, r.parentTeam)
+	if err != nil {
+		return err
+	}
+	readRole, err := core.ImportRole(r.readRole)
+	if err != nil {
+		return err
+	}
+	if role.LessThan(*readRole) {
+		return core.PermissionError("user role too low to read channel")
+	}
+	return nil
+}
+
+func (r *readThroughMarker) run(m shared.MetaContext) error {
+	err := r.loadChannel(m)
+	if err != nil {
+		return err
+	}
+	err = r.authorize(m)
+	if err != nil {
+		return err
+	}
+
+	seq := r.arg.Seq.Int64()
+	if seq <= 0 {
+		return core.BadArgsError("read-through seq must be positive")
+	}
+	if r.lastSeq == nil || seq > *r.lastSeq {
+		return core.BadArgsError("read-through seq exceeds last message")
+	}
+
+	// Advance monotonically. A stale or repeated mark (seq at or below the
+	// current pointer) is a no-op and must NOT bump the inbox version, or
+	// out-of-order marks from racing devices would churn every device's sync.
+	tag, err := r.tx.Exec(
+		m.Ctx(),
+		`UPDATE user_channels
+		 SET read_through=$4, mtime=NOW()
+		 WHERE short_host_id=$1 AND channel_id=$2 AND uid=$3
+		   AND read_through < $4`,
+		m.ShortHostID(),
+		r.channelID(),
+		r.reader.ExportToDB(),
+		seq,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		// Distinguish a stale mark (no-op success) from a missing membership
+		// row (the user was never fanned into this channel).
+		var one int
+		err = r.tx.QueryRow(
+			m.Ctx(),
+			`SELECT 1 FROM user_channels
+			 WHERE short_host_id=$1 AND channel_id=$2 AND uid=$3`,
+			m.ShortHostID(),
+			r.channelID(),
+			r.reader.ExportToDB(),
+		).Scan(&one)
+		if err == pgx.ErrNoRows {
+			return core.RowNotFoundError{}
+		}
+		return err
+	}
+
+	// The pointer moved: bump the caller's global inbox version and stamp this
+	// row at it, "like a send would do" (chat-server-design.md), so the
+	// caller's other devices pick the read state up on their next sync.
+	var vers int64
+	err = r.tx.QueryRow(
+		m.Ctx(),
+		`INSERT INTO user_inbox (short_host_id, uid, app_id, inbox_version, mtime)
+		 VALUES ($1, $2, $3, 1, NOW())
+		 ON CONFLICT (short_host_id, uid, app_id)
+		 DO UPDATE SET inbox_version = user_inbox.inbox_version + 1, mtime = NOW()
+		 RETURNING inbox_version`,
+		m.ShortHostID(),
+		r.reader.ExportToDB(),
+		r.appID,
+	).Scan(&vers)
+	if err != nil {
+		return err
+	}
+	_, err = r.tx.Exec(
+		m.Ctx(),
+		`UPDATE user_channels
+		 SET inbox_version=$4
+		 WHERE short_host_id=$1 AND channel_id=$2 AND uid=$3`,
+		m.ShortHostID(),
+		r.channelID(),
+		r.reader.ExportToDB(),
+		vers,
+	)
+	return err
+}
+
+// MarkReadThrough advances the authenticated user's (m.UID()) read pointer in
+// a channel.
+func MarkReadThrough(
+	m shared.MetaContext,
+	arg rem.RTReadThroughArg,
+) error {
+	rtdb, err := m.Db(shared.DbTypeRealTime)
+	if err != nil {
+		return err
+	}
+	defer rtdb.Release()
+	userdb, err := m.Db(shared.DbTypeUsers)
+	if err != nil {
+		return err
+	}
+	defer userdb.Release()
+
+	return shared.RetryTx(m,
+		rtdb,
+		"realtime.MarkReadThrough",
+		func(m shared.MetaContext, tx pgx.Tx) error {
+			r := readThroughMarker{
+				arg:    arg,
+				reader: m.UID(),
+				userdb: userdb,
+				tx:     tx,
+			}
+			return r.run(m)
+		},
+	)
+}
+
 // loadChannelForRead returns the channel's parent team and read role, for
 // authorizing a thread fetch.
 func loadChannelForRead(

--- a/server/realtime/server.go
+++ b/server/realtime/server.go
@@ -97,7 +97,8 @@ func (c *ClientConn) RtGetChangedThreads(ctx context.Context, arg rem.RTGetChang
 	return res, core.NotImplementedError{}
 }
 func (c *ClientConn) RtReadThrough(ctx context.Context, arg rem.RTReadThroughArg) error {
-	return core.NotImplementedError{}
+	m := shared.NewMetaContextConn(ctx, c)
+	return MarkReadThrough(m, arg)
 }
 func (c *ClientConn) RtPollInbox(ctx context.Context, arg rem.RTPollInboxArg) (res proto.RTInboxPollRes, err error) {
 	return res, core.NotImplementedError{}


### PR DESCRIPTION
Implements the read side of the inbox-version machinery, replacing the `NotImplementedError` stub for `rtReadThrough` with the semantics from `chat-server-design.md` ("read_through"). Follows up on #299 (the write side).

## What

**Server** (`server/realtime/messages.go`, wired in `server.go`): a new `readThroughMarker` runs in one realtime-DB transaction:

1. **Authorize like a thread read** — the caller's team role must be at or above the channel's read role, same check as `GetThread`.
2. **Validate the seq** — must be positive and at most the channel's `last_msg_seq`; past-end is a client bug, rejected as `BadArgsError`. No channel row lock is taken: an honest client only marks messages it has already received, which are committed and therefore visible to our snapshot, so `last_msg_seq` can't race backwards under us.
3. **Advance monotonically** — `UPDATE ... WHERE read_through < $seq`. A stale or repeated mark is a **silent no-op that bumps nothing**: without this, out-of-order receipts from a user's racing devices would bump each other's inbox versions indefinitely. Zero rows updated distinguishes a stale mark (no-op success) from a missing membership row (`RowNotFoundError`).
4. **Bump + stamp** — on a real advance, the caller's per-(user, app) `user_inbox` version increments and their `user_channels` row is stamped at the new version, *"like a send would do"* per the design doc — that's how the caller's **other devices** learn the read state on their next inbox sync. Unlike the send fanout, only the calling user's rows are touched.

**Client**: new `Minder.ReadThrough(m, team, appID, channel, seq)` resolves the channel specifier exactly like `Send` and issues the RPC.

## Testing

`TestRTSendReadPermissions` extends its exact inbox-version matrix through the receipt flow:

- advance: coco's global version bumps (4→5), her announce row is stamped, pointer lands at 1;
- no-op repeat / stale mark: nothing bumps;
- past-end seq: rejected;
- no read permission (brass): rejected;
- empty channel: rejected (nothing to mark);
- isolation: bluey's receipt bumps her own inbox (5→6) and leaves coco's untouched.

Full `TestRT*` lib suite passes under `-race` (no warnings), CLI `TestRT*` passes, build/vet/gofmt clean.

## Scope

The sync consumers — `RtGetInboxVersion`, `RtGetChangedThreads`, `RtPollInbox` — remain stubs for a later stage.

Co-authored-by: Claude Code