### PR TITLE
chat(1d): implement rtGetInboxVersion and rtGetChangedThreads inbox sync

### DIFF
--- a/.claude/skills/add-sql-patch/SKILL.md
+++ b/.claude/skills/add-sql-patch/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: add-sql-patch
+description: Add a new SQL schema patch (pN.sql) to a FOKS server database. Use whenever changing server-side DDL (new table/index/column/type) on an existing database — the patch must be registered in THREE files or it silently never applies.
+---
+
+# Adding a SQL schema patch
+
+Server DDL changes ship two ways at once: a **patch** (`pN.sql`) upgrades
+existing deployments via `foks-tool patch-db`, and the **base schema file**
+gives fresh installs the same end state directly. Both must be updated, and
+the patch must be registered in the Go embed map — **a pN.sql file on disk
+that isn't in `embed.go` is dead: the patch engine never sees it.**
+
+## The checklist — 3 files, 4 touches
+
+For a new patch `N` on database `D` (e.g. `foks_realtime`):
+
+1. **The patch file** — `server/sql/patches/D/pN.sql`
+   - `N` = next integer for that DB (check both the directory and the
+     `Patches` map). Numbering is per-database.
+   - Include a comment explaining the change; write it for the deployment
+     operator reading it before applying.
+
+2. **The embed registry** — `server/sql/embed.go` (the always-forgotten one)
+   - Add the embed directive + var:
+     ```go
+     //go:embed patches/D/pN.sql
+     var dPatchN string
+     ```
+   - Add `N: dPatchN,` to `Patches["D"]`.
+   - The engine (`server/shared/patch.go`) applies exactly the entries of
+     this map that aren't recorded in the DB's `schema_patches` table.
+
+3. **The base schema file** — `server/sql/D.sql` (two touches)
+   - **Incorporate the DDL**: apply the same change to the base definitions,
+     so a fresh install lands in the identical end state (e.g., if the patch
+     is `DROP INDEX x; CREATE UNIQUE INDEX x ...`, the base file's
+     `CREATE INDEX x` becomes `CREATE UNIQUE INDEX x`).
+   - **Register the patch**: append at the bottom
+     ```sql
+     INSERT INTO schema_patches (id, ctime) VALUES (N, NOW());
+     ```
+     Without this, a fresh install (which already has the end state) would
+     re-apply pN via the patch engine and typically fail (duplicate
+     index/column). This registration has been forgotten before — verify the
+     bottom of the base file lists every incorporated patch id contiguously.
+
+## Verify
+
+- `go build ./server/sql/` — a typo'd embed path fails the build.
+- Run an integration test that stands up the affected DB fresh from the base
+  file (they create all tables at startup), plus tests exercising the
+  affected writers — e.g. `go test ./integration-tests/lib/ -run TestRT...`
+  for `foks_realtime`. This validates the base-file DDL and that live code
+  satisfies any new constraint.
+- The patch path itself (`pN.sql` against a pre-patch DB) can be validated
+  with an ephemeral `postgres:17-alpine` via Docker: create the old schema,
+  apply pN, compare. Existing deployments apply it with `foks-tool patch-db`.
+
+## Consistency rule
+
+Patch DDL and base-file DDL must converge to byte-equivalent schemas. When
+reviewing, diff what a fresh install produces against what old-schema + all
+patches produces — indexes, constraints, enum values, defaults.

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -850,6 +850,51 @@ func (d *Minder) ReadThrough(
 	})
 }
 
+// GetInboxVersion returns the caller's current global inbox version for the
+// app -- the head that GetChangedThreads pages toward.
+func (d *Minder) GetInboxVersion(
+	m MetaContext,
+	appID proto.RTAppID,
+) (
+	proto.RTInboxVersion,
+	error,
+) {
+	_, cli, err := d.clientLocal(m.Base(), d.au)
+	if err != nil {
+		return 0, err
+	}
+	return cli.RtGetInboxVersion(m.Ctx(), rem.RTInboxKey{AppID: appID})
+}
+
+// GetChangedThreads fetches one page of the caller's inbox delta: channels
+// whose per-user inbox version bumped past since, oldest bump first, plus the
+// current head. Paginate by re-issuing with since = the highest inboxVersion
+// received, until it reaches the head. max=0 uses the server's default page
+// size.
+func (d *Minder) GetChangedThreads(
+	m MetaContext,
+	appID proto.RTAppID,
+	since proto.RTInboxVersion,
+	max uint64,
+) (
+	*rem.RTInboxDelta,
+	error,
+) {
+	_, cli, err := d.clientLocal(m.Base(), d.au)
+	if err != nil {
+		return nil, err
+	}
+	res, err := cli.RtGetChangedThreads(m.Ctx(), rem.RTGetChangedThreadsArg{
+		AppID: appID,
+		Since: since,
+		Max:   max,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
 func (d *Minder) cacheMsgID(
 	q proto.RTMsgSeq,
 	i proto.RTMsgID,

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -1056,6 +1056,103 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.Equal(t, int64(6), ucVers(bluey, chWatercooler))
 	require.Equal(t, int64(1), ucRead(bluey, chWatercooler))
 	require.Equal(t, int64(5), uiVers(coco))
+
+	// --- inbox sync ---
+
+	// The heads reported over RPC match the versions we asserted in the DB.
+	hv, err := minderBluey.GetInboxVersion(mb, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(6), hv)
+	hv, err = minderCoco.GetInboxVersion(mc, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(5), hv)
+
+	// One assertable summary per returned inbox channel.
+	type row struct {
+		id   proto.RTChannelID
+		vers proto.RTInboxVersion
+		read proto.RTMsgSeq
+		last bool // has a last-message preview
+	}
+	summarize := func(d *rem.RTInboxDelta) []row {
+		var out []row
+		for _, ch := range d.Channels {
+			require.False(t, ch.Hidden)
+			require.False(t, ch.Muted)
+			require.False(t, ch.Md.Unreadable)
+			out = append(out, row{
+				id:   ch.Md.Id,
+				vers: ch.InboxVersion,
+				read: ch.ReadThrough,
+				last: ch.Md.LastMsg != nil,
+			})
+		}
+		return out
+	}
+
+	// coco's full sync (since=0): both channels she's fanned into, oldest bump
+	// first; brass never appears (she was never fanned in, and it's admin-tier
+	// besides). Announce carries her read receipt.
+	delta, err := minderCoco.GetChangedThreads(mc, proto.RTAppID_Chat, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(5), delta.InboxVersion)
+	require.Equal(t, []row{
+		{id: *chWatercooler, vers: 3, read: 0, last: true},
+		{id: *chAnnounce, vers: 5, read: 1, last: true},
+	}, summarize(delta))
+
+	// Cursor pagination: advancing since past watercooler's bump leaves only
+	// announce; advancing to the head leaves nothing.
+	delta, err = minderCoco.GetChangedThreads(mc, proto.RTAppID_Chat, 3, 0)
+	require.NoError(t, err)
+	require.Equal(t, []row{
+		{id: *chAnnounce, vers: 5, read: 1, last: true},
+	}, summarize(delta))
+	delta, err = minderCoco.GetChangedThreads(mc, proto.RTAppID_Chat, 5, 0)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(5), delta.InboxVersion)
+	require.Empty(t, delta.Channels)
+
+	// bluey's full sync: all three channels, oldest bump first. brass has no
+	// messages, so no last-message preview.
+	delta, err = minderBluey.GetChangedThreads(mb, proto.RTAppID_Chat, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(6), delta.InboxVersion)
+	require.Equal(t, []row{
+		{id: *chBrass, vers: 3, read: 0, last: false},
+		{id: *chAnnounce, vers: 5, read: 0, last: true},
+		{id: *chWatercooler, vers: 6, read: 1, last: true},
+	}, summarize(delta))
+
+	// Paged: a max of 2 returns the two oldest bumps; re-issuing with since =
+	// the highest version received returns the rest. The head rides along on
+	// every page so the client knows when it has caught up.
+	delta, err = minderBluey.GetChangedThreads(mb, proto.RTAppID_Chat, 0, 2)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(6), delta.InboxVersion)
+	require.Equal(t, []row{
+		{id: *chBrass, vers: 3, read: 0, last: false},
+		{id: *chAnnounce, vers: 5, read: 0, last: true},
+	}, summarize(delta))
+	delta, err = minderBluey.GetChangedThreads(mb, proto.RTAppID_Chat, 5, 2)
+	require.NoError(t, err)
+	require.Equal(t, []row{
+		{id: *chWatercooler, vers: 6, read: 1, last: true},
+	}, summarize(delta))
+
+	// Stale membership rows must not leak: remove coco from the team, and her
+	// lingering user_channels rows (there's no un-fanout) stop appearing in
+	// her sync -- the delta re-authorizes against the current team roster. The
+	// head is her own per-user counter, so it still reports.
+	tm.makeChanges(t, m, bluey,
+		[]proto.MemberRole{
+			coco.toMemberRole(t, proto.NewRoleDefault(proto.RoleType_NONE), nil),
+		}, nil,
+	)
+	delta, err = minderCoco.GetChangedThreads(mc, proto.RTAppID_Chat, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(5), delta.InboxVersion)
+	require.Empty(t, delta.Channels)
 }
 
 // TestRTSendEncryptionRole checks that the server rejects a message encrypted

--- a/server/realtime/channels.go
+++ b/server/realtime/channels.go
@@ -125,20 +125,12 @@ func readAllChannels(
 	}
 	rows, err := db.Query(
 		m.Ctx(),
-		`SELECT c.channel_id_full, c.seqno, c.name_box, c.desc_box,
-		        c.read_role_type, c.read_role_viz_level,
-		        c.write_role_type, c.write_role_viz_level,
-		        c.last_msg_type, c.last_msg_seq, c.last_send_time,
-		        cp.party_id, cp.uid,
-		        c.ctime, c.mtime, c.updated_at_set_vers, c.tier
+		`SELECT `+channelMetadataCols+`
 		 FROM channels c
-		 LEFT JOIN channel_parties cp ON
-		     cp.short_host_id = c.short_host_id
-		     AND cp.channel_id = c.channel_id
-		     AND cp.party_no = c.last_sender_no
-		 WHERE c.short_host_id=$1 
-		 AND c.parent_team_id=$2 
-		 AND c.app_id=$3 
+		 `+lastSenderJoin+`
+		 WHERE c.short_host_id=$1
+		 AND c.parent_team_id=$2
+		 AND c.app_id=$3
 		 AND c.tier = ANY($4)
 		 AND c.updated_at_set_vers > $5
 		 ORDER BY c.channel_id ASC`,
@@ -153,165 +145,206 @@ func readAllChannels(
 	}
 	defer rows.Close()
 
-	importLastMessage := func(
-		msgType *string,
-		msgSeq *int64,
-		sendTime *time.Time,
-		partyIDRaw []byte,
-		uidRaw []byte,
-	) (
-		*rem.RTLastMsg,
-		error,
-	) {
-		var ret rem.RTLastMsg
-		if msgType == nil &&
-			msgSeq == nil &&
-			sendTime == nil &&
-			len(partyIDRaw) == 0 &&
-			len(uidRaw) == 0 {
-			return nil, nil
-		}
-		if msgType == nil {
-			return nil, core.BadServerDataError("nil last msgType unexpected")
-		}
-		err = ret.Typ.ImportFromDB(*msgType)
-		if err != nil {
-			return nil, err
-		}
-		if msgSeq == nil {
-			return nil, core.BadServerDataError("nil last msgSeq unexpected")
-		}
-		ret.Seq = proto.RTMsgSeq(*msgSeq)
-		if sendTime == nil {
-			return nil, core.BadServerDataError("nil last sendtime unexpected")
-		}
-
-		t := proto.ExportTime(*sendTime)
-		ret.InsertTime = t
-		if len(partyIDRaw) == 0 {
-			return nil, core.BadServerDataError("nil last sender unexpected")
-		}
-
-		var pid proto.PartyID
-		err = pid.ImportFromDB(partyIDRaw)
-		if err != nil {
-			return nil, err
-		}
-		ret.Sender = &pid
-
-		if uidRaw != nil {
-			var uid proto.UID
-			err = uid.ImportFromDB(uidRaw)
-			if err != nil {
-				return nil, err
-			}
-			ret.FurtherUserAttribution = &uid
-		}
-		return &ret, nil
-	}
-
 	var ret []rem.RTChannelMetadata
 	for rows.Next() {
-		var (
-			idRaw, nameBoxRaw, descBoxRaw []byte
-			partyIDRaw, uidRaw            []byte
-			seqno                         int
-			rrt, rvl, wrt, wvl            int
-			lastMsgType                   *string
-			lastMsgSeq                    *int64
-			lastSendTime                  *time.Time
-			ctime, mtime                  time.Time
-			updatedAtSetVers              int
-			tierRaw                       string
-		)
-		err := rows.Scan(
-			&idRaw, &seqno, &nameBoxRaw, &descBoxRaw,
-			&rrt, &rvl, &wrt, &wvl,
-			&lastMsgType, &lastMsgSeq, &lastSendTime,
-			&partyIDRaw, &uidRaw,
-			&ctime, &mtime, &updatedAtSetVers,
-			&tierRaw,
-		)
+		var raw channelMetadataRaw
+		err := rows.Scan(raw.scanDests()...)
 		if err != nil {
 			return nil, err
 		}
-
-		md := rem.RTChannelMetadata{
-			ParentTeam: team,
-			AppID:      app,
-			Seqno:      proto.RTChannelSeqno(seqno),
-			Ctime:      proto.ExportTime(ctime),
-			Mtime:      proto.ExportTime(mtime),
-			UpdatedAt:  proto.RTChannelSetVersion(updatedAtSetVers),
-		}
-		if len(idRaw) != len(md.Id) {
-			return nil, core.BadServerDataError("bad channel_id_full length")
-		}
-		copy(md.Id[:], idRaw)
-
-		err = core.DecodeFromBytes(&md.NameBox, nameBoxRaw)
+		md, err := raw.export(team, app)
 		if err != nil {
 			return nil, err
 		}
-		if len(descBoxRaw) > 0 {
-			var box proto.RTBoxRG
-			err = core.DecodeFromBytes(&box, descBoxRaw)
-			if err != nil {
-				return nil, err
-			}
-			md.DescBox = &box
-		}
-		err = md.Roles.Read.ImportFromDB(rrt, rvl)
+		err = applyReadRoleGate(md, role)
 		if err != nil {
 			return nil, err
 		}
-		err = md.Roles.Write.ImportFromDB(wrt, wvl)
-		if err != nil {
-			return nil, err
-		}
-
-		lm, err := importLastMessage(
-			lastMsgType,
-			lastMsgSeq,
-			lastSendTime,
-			partyIDRaw,
-			uidRaw,
-		)
-		if err != nil {
-			return nil, err
-		}
-		if lm != nil {
-			md.LastMsg = lm
-		}
-		err = md.Tier.ImportFromDB(tierRaw)
-		if err != nil {
-			return nil, err
-		}
-
-		// The channel name is sealed at the tier floor, so its name (and very
-		// existence) is visible to everyone the tier gate admits -- this is
-		// needed for name-collision detection at create time, since names are
-		// ciphertext the server can't dedupe itself. The description and
-		// last-message preview, however, are sealed at the finer read role: don't
-		// hand them to a caller whose team role is below it. They couldn't decrypt
-		// the description anyway (it would only panic/err on the client), and the
-		// last-message metadata would leak channel activity they can't read.
-		readRoleKey, err := core.ImportRole(md.Roles.Read)
-		if err != nil {
-			return nil, err
-		}
-		if role.LessThan(*readRoleKey) {
-			md.DescBox = nil
-			md.LastMsg = nil
-			md.Unreadable = true
-		}
-
-		ret = append(ret, md)
+		ret = append(ret, *md)
 	}
 	if err = rows.Err(); err != nil {
 		return nil, err
 	}
 	return ret, nil
+}
+
+// channelMetadataRaw holds one scanned row of channelMetadataCols, prior to
+// conversion into an rem.RTChannelMetadata. Shared by the channel-list read
+// (readAllChannels) and the inbox sync (GetChangedThreads), whose queries both
+// SELECT channelMetadataCols (the inbox query appends per-user columns of its
+// own after these).
+type channelMetadataRaw struct {
+	idRaw, nameBoxRaw, descBoxRaw []byte
+	partyIDRaw, uidRaw            []byte
+	seqno                         int
+	rrt, rvl, wrt, wvl            int
+	lastMsgType                   *string
+	lastMsgSeq                    *int64
+	lastSendTime                  *time.Time
+	ctime, mtime                  time.Time
+	updatedAtSetVers              int
+	tierRaw                       string
+}
+
+// channelMetadataCols is the column list matching channelMetadataRaw.scanDests,
+// against a query whose FROM clause binds c = channels and cp = the
+// channel_parties row of the channel's last sender.
+const channelMetadataCols = `c.channel_id_full, c.seqno, c.name_box, c.desc_box,
+	        c.read_role_type, c.read_role_viz_level,
+	        c.write_role_type, c.write_role_viz_level,
+	        c.last_msg_type, c.last_msg_seq, c.last_send_time,
+	        cp.party_id, cp.uid,
+	        c.ctime, c.mtime, c.updated_at_set_vers, c.tier`
+
+// lastSenderJoin attributes the channel's denormalized last message to its
+// sender; LEFT so channels with no messages still row.
+const lastSenderJoin = `LEFT JOIN channel_parties cp ON
+	     cp.short_host_id = c.short_host_id
+	     AND cp.channel_id = c.channel_id
+	     AND cp.party_no = c.last_sender_no`
+
+func (r *channelMetadataRaw) scanDests() []any {
+	return []any{
+		&r.idRaw, &r.seqno, &r.nameBoxRaw, &r.descBoxRaw,
+		&r.rrt, &r.rvl, &r.wrt, &r.wvl,
+		&r.lastMsgType, &r.lastMsgSeq, &r.lastSendTime,
+		&r.partyIDRaw, &r.uidRaw,
+		&r.ctime, &r.mtime, &r.updatedAtSetVers,
+		&r.tierRaw,
+	}
+}
+
+func (r *channelMetadataRaw) export(
+	team proto.TeamID,
+	app proto.RTAppID,
+) (
+	*rem.RTChannelMetadata,
+	error,
+) {
+	md := rem.RTChannelMetadata{
+		ParentTeam: team,
+		AppID:      app,
+		Seqno:      proto.RTChannelSeqno(r.seqno),
+		Ctime:      proto.ExportTime(r.ctime),
+		Mtime:      proto.ExportTime(r.mtime),
+		UpdatedAt:  proto.RTChannelSetVersion(r.updatedAtSetVers),
+	}
+	if len(r.idRaw) != len(md.Id) {
+		return nil, core.BadServerDataError("bad channel_id_full length")
+	}
+	copy(md.Id[:], r.idRaw)
+
+	err := core.DecodeFromBytes(&md.NameBox, r.nameBoxRaw)
+	if err != nil {
+		return nil, err
+	}
+	if len(r.descBoxRaw) > 0 {
+		var box proto.RTBoxRG
+		err = core.DecodeFromBytes(&box, r.descBoxRaw)
+		if err != nil {
+			return nil, err
+		}
+		md.DescBox = &box
+	}
+	err = md.Roles.Read.ImportFromDB(r.rrt, r.rvl)
+	if err != nil {
+		return nil, err
+	}
+	err = md.Roles.Write.ImportFromDB(r.wrt, r.wvl)
+	if err != nil {
+		return nil, err
+	}
+
+	lm, err := r.importLastMessage()
+	if err != nil {
+		return nil, err
+	}
+	if lm != nil {
+		md.LastMsg = lm
+	}
+	err = md.Tier.ImportFromDB(r.tierRaw)
+	if err != nil {
+		return nil, err
+	}
+	return &md, nil
+}
+
+func (r *channelMetadataRaw) hasLastMessage() bool {
+	return r.lastMsgType != nil &&
+		r.lastMsgSeq != nil &&
+		r.lastSendTime != nil &&
+		len(r.partyIDRaw) > 0 &&
+		len(r.uidRaw) > 0
+}
+
+func (r *channelMetadataRaw) importLastMessage() (
+	*rem.RTLastMsg,
+	error,
+) {
+	var ret rem.RTLastMsg
+	if !r.hasLastMessage() {
+		return nil, nil
+	}
+	if r.lastMsgType == nil {
+		return nil, core.BadServerDataError("nil last msgType unexpected")
+	}
+	err := ret.Typ.ImportFromDB(*r.lastMsgType)
+	if err != nil {
+		return nil, err
+	}
+	if r.lastMsgSeq == nil {
+		return nil, core.BadServerDataError("nil last msgSeq unexpected")
+	}
+	ret.Seq = proto.RTMsgSeq(*r.lastMsgSeq)
+	if r.lastSendTime == nil {
+		return nil, core.BadServerDataError("nil last sendtime unexpected")
+	}
+
+	t := proto.ExportTime(*r.lastSendTime)
+	ret.InsertTime = t
+	if len(r.partyIDRaw) == 0 {
+		return nil, core.BadServerDataError("nil last sender unexpected")
+	}
+
+	var pid proto.PartyID
+	err = pid.ImportFromDB(r.partyIDRaw)
+	if err != nil {
+		return nil, err
+	}
+	ret.Sender = &pid
+
+	if r.uidRaw != nil {
+		var uid proto.UID
+		err = uid.ImportFromDB(r.uidRaw)
+		if err != nil {
+			return nil, err
+		}
+		ret.FurtherUserAttribution = &uid
+	}
+	return &ret, nil
+}
+
+// applyReadRoleGate withholds the read-role-sealed portions of md from a
+// caller whose team role is below the channel's read role. The channel name is
+// sealed at the tier floor, so its name (and very existence) is visible to
+// everyone the tier gate admits -- this is needed for name-collision detection
+// at create time, since names are ciphertext the server can't dedupe itself.
+// The description and last-message preview, however, are sealed at the finer
+// read role: don't hand them to a caller whose team role is below it. They
+// couldn't decrypt the description anyway (it would only panic/err on the
+// client), and the last-message metadata would leak channel activity they
+// can't read.
+func applyReadRoleGate(md *rem.RTChannelMetadata, role core.RoleKey) error {
+	readRoleKey, err := core.ImportRole(md.Roles.Read)
+	if err != nil {
+		return err
+	}
+	if role.LessThan(*readRoleKey) {
+		md.DescBox = nil
+		md.LastMsg = nil
+		md.Unreadable = true
+	}
+	return nil
 }
 
 type channelMaker struct {
@@ -507,6 +540,12 @@ func (c *channelMaker) fanoutUsers(m shared.MetaContext) error {
 	// (transitive) membership is deferred to stage 1b. We match the
 	// device-membership convention used by AuthorizeUserForTeam: local host,
 	// source role Owner, most-recent active row.
+	//
+	// NOTE (issue #301): this is the ONLY writer of user_channels membership
+	// rows, so a user added to the team (or promoted past the read role) after
+	// channel creation never gets fanned in: no delivery bumps, invisible to
+	// rtGetChangedThreads, and rtReadThrough fails. The inverse (removal) is
+	// handled by re-authorizing at sync time.
 	readRole, err := core.ImportRole(c.md.Roles.Read)
 	if err != nil {
 		return err

--- a/server/realtime/inbox.go
+++ b/server/realtime/inbox.go
@@ -1,0 +1,258 @@
+package realtime
+
+import (
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+	"github.com/foks-proj/go-foks/server/shared"
+	"github.com/jackc/pgx/v5"
+)
+
+// defaultInboxPage bounds a single rtGetChangedThreads page when the client
+// doesn't ask for a specific size (max=0).
+const defaultInboxPage = 100
+const maxInboxPage = 1000
+
+func cappedInboxPage(max uint64) uint64 {
+	if max == 0 {
+		return defaultInboxPage
+	}
+	if max > maxInboxPage {
+		return maxInboxPage
+	}
+	return max
+}
+
+// GetInboxVersion returns the authenticated user's current global inbox
+// version for the app -- the head that rtGetChangedThreads pages toward. A
+// user with no inbox yet is at version 0, which is also what a client passes
+// as `since` for a full sync.
+func GetInboxVersion(
+	m shared.MetaContext,
+	arg rem.RTInboxKey,
+) (
+	proto.RTInboxVersion,
+	error,
+) {
+	rtdb, err := m.Db(shared.DbTypeRealTime)
+	if err != nil {
+		return 0, err
+	}
+	defer rtdb.Release()
+	return readInboxVersion(m, rtdb, m.UID(), arg.AppID)
+}
+
+func readInboxVersion(
+	m shared.MetaContext,
+	db shared.Querier,
+	uid proto.UID,
+	app proto.RTAppID,
+) (
+	proto.RTInboxVersion,
+	error,
+) {
+	appDB, err := app.ExportToDB()
+	if err != nil {
+		return 0, err
+	}
+	var v int64
+	err = db.QueryRow(
+		m.Ctx(),
+		`SELECT inbox_version FROM user_inbox
+		 WHERE short_host_id=$1 AND uid=$2 AND app_id=$3`,
+		m.ShortHostID().ExportToDB(),
+		uid.ExportToDB(),
+		appDB,
+	).Scan(&v)
+	if err == pgx.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return proto.RTInboxVersion(v), nil
+}
+
+// inboxChannelRaw is one scanned row of the changed-threads query: the shared
+// channel-metadata columns plus this user's per-channel state.
+type inboxChannelRaw struct {
+	md          channelMetadataRaw
+	teamRaw     []byte
+	inboxVers   int64
+	readThrough int64
+	hidden      bool
+	muted       bool
+}
+
+// scanDests matches the changed-threads SELECT: the shared channel-metadata
+// columns followed by the parent team and the caller's per-channel state.
+func (r *inboxChannelRaw) scanDests() []any {
+	return append(r.md.scanDests(),
+		&r.teamRaw, &r.inboxVers, &r.readThrough, &r.hidden, &r.muted)
+}
+
+// GetChangedThreads implements the inbox sync (see "Inbox View" in
+// chat-server-design.md): return metadata for every channel whose
+// user_channels row bumped past arg.Since, up to a page, plus the current
+// head. The client paginates by re-issuing with since = the highest
+// inboxVersion it has received, until it reaches the head.
+func GetChangedThreads(
+	m shared.MetaContext,
+	arg rem.RTGetChangedThreadsArg,
+) (
+	*rem.RTInboxDelta,
+	error,
+) {
+	rtdb, err := m.Db(shared.DbTypeRealTime)
+	if err != nil {
+		return nil, err
+	}
+	defer rtdb.Release()
+	udb, err := m.Db(shared.DbTypeUsers)
+	if err != nil {
+		return nil, err
+	}
+	defer udb.Release()
+
+	ret := rem.RTInboxDelta{
+		AppID:    arg.AppID,
+		Channels: []rem.RTInboxChannel{},
+	}
+
+	head, err := readInboxVersion(m, rtdb, m.UID(), arg.AppID)
+	if err != nil {
+		return nil, err
+	}
+	ret.InboxVersion = head
+
+	// Caught up (or the client is somehow ahead of us; it will full-sync with
+	// since=0 if the head it gets back confuses it).
+	if head <= arg.Since {
+		return &ret, nil
+	}
+
+	raws, err := readChangedChannels(m, rtdb, arg, head)
+	if err != nil {
+		return nil, err
+	}
+
+	// Authorize per parent team against the *current* team roster: a
+	// user_channels row is written at channel-creation/fan-in time and lingers
+	// if the user has since been removed from (or demoted in) the team, so
+	// membership rows alone must not leak channel activity. One check per
+	// distinct team in the page, memoized.
+	roles := make(map[proto.TeamID]*core.RoleKey)
+	for _, raw := range raws {
+		var team proto.TeamID
+		err = team.ImportFromDB(raw.teamRaw)
+		if err != nil {
+			return nil, err
+		}
+		role, seen := roles[team]
+		if !seen {
+			role, err = AuthorizeUserForTeam(m, udb, team)
+			if err != nil && !core.IsPermissionError(err) {
+				return nil, err
+			}
+			// nil role (permission error) = no longer a team member; the
+			// stale membership rows are skipped, but the sync proceeds for
+			// the user's other teams.
+			roles[team] = role
+		}
+		if role == nil {
+			continue
+		}
+
+		md, err := raw.md.export(team, arg.AppID)
+		if err != nil {
+			return nil, err
+		}
+		// Same visibility rules as the channel list: admin-tier channels
+		// disappear entirely for callers below admin, and the read-role gate
+		// withholds desc/last-message from callers below the read role.
+		if md.Tier == proto.RTChannelTier_Admin && !role.IsAdminOrAbove() {
+			continue
+		}
+		err = applyReadRoleGate(md, *role)
+		if err != nil {
+			return nil, err
+		}
+
+		ret.Channels = append(ret.Channels, rem.RTInboxChannel{
+			Md:           *md,
+			InboxVersion: proto.RTInboxVersion(raw.inboxVers),
+			ReadThrough:  proto.RTMsgSeq(raw.readThrough),
+			Hidden:       raw.hidden,
+			Muted:        raw.muted,
+		})
+	}
+	return &ret, nil
+}
+
+// readChangedChannels pages this user's user_channels rows in (since, head],
+// oldest bump first, joined against the channel metadata. The upper bound
+// keeps the page consistent with the head we already read: a bump that lands
+// between the two queries belongs to the next sync round. Driven by the
+// user_channels_inbox_idx hot index.
+//
+// The cursor (client re-issues with since = highest version received) is only
+// sound because no two of a user's rows can share an inbox version -- each
+// version is a serialized +1 bump of user_inbox stamping exactly one row --
+// so a LIMIT boundary can never split a version group. The UNIQUE
+// user_channels_inbox_idx enforces this; see its comment in foks_realtime.sql.
+func readChangedChannels(
+	m shared.MetaContext,
+	db shared.Querier,
+	arg rem.RTGetChangedThreadsArg,
+	head proto.RTInboxVersion,
+) (
+	[]inboxChannelRaw,
+	error,
+) {
+	appDB, err := arg.AppID.ExportToDB()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := db.Query(
+		m.Ctx(),
+		`SELECT `+channelMetadataCols+`,
+		        c.parent_team_id,
+		        uc.inbox_version, uc.read_through, uc.hidden, uc.muted
+		 FROM user_channels uc
+		 JOIN channels c ON
+		     c.short_host_id = uc.short_host_id
+		     AND c.channel_id = uc.channel_id
+		 `+lastSenderJoin+`
+		 WHERE uc.short_host_id=$1
+		 AND uc.uid=$2
+		 AND uc.app_id=$3
+		 AND uc.inbox_version > $4
+		 AND uc.inbox_version <= $5
+		 ORDER BY uc.inbox_version ASC
+		 LIMIT $6`,
+		m.ShortHostID().ExportToDB(),
+		m.UID().ExportToDB(),
+		appDB,
+		int64(arg.Since),
+		int64(head),
+		cappedInboxPage(arg.Max),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ret []inboxChannelRaw
+	for rows.Next() {
+		var raw inboxChannelRaw
+		err := rows.Scan(raw.scanDests()...)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, raw)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}

--- a/server/realtime/server.go
+++ b/server/realtime/server.go
@@ -91,10 +91,16 @@ func (c *ClientConn) RtGetThread(ctx context.Context, arg rem.RTThreadQuery) (re
 	return *ret, nil
 }
 func (c *ClientConn) RtGetInboxVersion(ctx context.Context, arg rem.RTInboxKey) (res proto.RTInboxVersion, err error) {
-	return res, core.NotImplementedError{}
+	m := shared.NewMetaContextConn(ctx, c)
+	return GetInboxVersion(m, arg)
 }
 func (c *ClientConn) RtGetChangedThreads(ctx context.Context, arg rem.RTGetChangedThreadsArg) (res rem.RTInboxDelta, err error) {
-	return res, core.NotImplementedError{}
+	m := shared.NewMetaContextConn(ctx, c)
+	ret, err := GetChangedThreads(m, arg)
+	if err != nil {
+		return res, err
+	}
+	return *ret, nil
 }
 func (c *ClientConn) RtReadThrough(ctx context.Context, arg rem.RTReadThroughArg) error {
 	m := shared.NewMetaContextConn(ctx, c)
@@ -104,7 +110,7 @@ func (c *ClientConn) RtPollInbox(ctx context.Context, arg rem.RTPollInboxArg) (r
 	return res, core.NotImplementedError{}
 }
 func (c *ClientConn) RtSelectVHost(ctx context.Context, arg proto.HostID) error {
-	return core.NotImplementedError{}
+	return shared.SelectVHost(ctx, c, arg)
 }
 func (c *ClientConn) RtGetThreadRecents(
 	ctx context.Context,

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -68,6 +68,9 @@ var realtimePatch1 string
 //go:embed patches/foks_realtime/p2.sql
 var realtimePatch2 string
 
+//go:embed patches/foks_realtime/p3.sql
+var realtimePatch3 string
+
 var Patches = map[string]map[int]string{
 	"foks_users": {
 		1: usersPatch1,
@@ -84,5 +87,6 @@ var Patches = map[string]map[int]string{
 	"foks_realtime": {
 		1: realtimePatch1,
 		2: realtimePatch2,
+		3: realtimePatch3,
 	},
 }

--- a/server/sql/foks_realtime.sql
+++ b/server/sql/foks_realtime.sql
@@ -181,8 +181,18 @@ CREATE TABLE user_channels (
     PRIMARY KEY(short_host_id, channel_id, uid),
     FOREIGN KEY(short_host_id, channel_id) REFERENCES channels(short_host_id, channel_id)
 );
-/* hot index: drives the get_changed_threads inbox sync */
-CREATE INDEX user_channels_inbox_idx ON user_channels(short_host_id, uid, app_id, inbox_version);
+/*
+ * Hot index: drives the get_changed_threads inbox sync. UNIQUE enforces the
+ * invariant that no two of a user's channel rows share an inbox version:
+ * every version number is allocated by a serialized +1 bump of the user's
+ * user_inbox row, and each allocation stamps exactly one user_channels row.
+ * get_changed_threads' cursor pagination (since = highest version received,
+ * LIMIT n) depends on this -- if a version could span rows, a page boundary
+ * could split the group and the client would skip the remainder forever. Any
+ * future batch writer (e.g., late-join backfill, issue #301) must allocate
+ * one version per stamped row, and this index makes violations fail loudly.
+ */
+CREATE UNIQUE INDEX user_channels_inbox_idx ON user_channels(short_host_id, uid, app_id, inbox_version);
 
 /*
  * user_inbox: per (user, app) global inbox version. Bumped on every
@@ -239,3 +249,5 @@ CREATE TABLE schema_patches (
     ctime TIMESTAMPTZ NOT NULL
 );
 INSERT INTO schema_patches (id, ctime) VALUES (1, NOW());
+INSERT INTO schema_patches (id, ctime) VALUES (2, NOW());
+INSERT INTO schema_patches (id, ctime) VALUES (3, NOW());

--- a/server/sql/patches/foks_realtime/p3.sql
+++ b/server/sql/patches/foks_realtime/p3.sql
@@ -1,0 +1,10 @@
+
+/*
+ * Upgrade the inbox-sync hot index to UNIQUE, enforcing the invariant that no
+ * two of a user's channel rows share an inbox version (each version is
+ * allocated by a serialized +1 bump of user_inbox and stamps exactly one
+ * user_channels row). get_changed_threads' cursor pagination depends on this;
+ * see the comment on the index in foks_realtime.sql.
+ */
+DROP INDEX user_channels_inbox_idx;
+CREATE UNIQUE INDEX user_channels_inbox_idx ON user_channels(short_host_id, uid, app_id, inbox_version);


### PR DESCRIPTION
Implements the two inbox-sync consumers of the version machinery from #299/#300, per "Inbox View" in `chat-server-design.md`. Also wires `RtSelectVHost` boilerplate.

## What

**`rtGetInboxVersion`** — the caller's per-(user, app) global inbox head from `user_inbox`; a user with no inbox yet is at 0, which doubles as the full-sync cursor.

**`rtGetChangedThreads`** (`server/realtime/inbox.go`) — the inbox sync:

- Reads the head first, then pages `user_channels` rows in `(since, head]` — the upper bound keeps the page consistent with the reported head, so a bump landing mid-request belongs to the next sync round.
- **Cursor pagination**: oldest bump first, `LIMIT` capped (100 default / 1000 max). Clients re-issue with `since` = the highest `inboxVersion` received until they reach the head, which rides along on every page. Driven by the `user_channels_inbox_idx` hot index.
- **Per-team re-authorization, memoized per page**: membership rows linger after a member leaves a team (there's no un-fanout), so each distinct parent team in the page is checked against the *current* roster; permission failures skip that team's rows without failing the rest of the sync.
- **Same visibility rules as the channel list**: admin-tier channels vanish entirely for callers below admin, and the read-role gate withholds desc/last-message below the channel's read role.

**Refactor**: the ~60-line channel-metadata row builder is lifted out of `readAllChannels` into shared pieces (`channelMetadataCols` const + `channelMetadataRaw.export()` + package-level `importLastMessage` + `applyReadRoleGate`), following the existing `threadMsgSelect` precedent, and used by both the channel-list and inbox queries instead of being duplicated.

**Client**: `Minder.GetInboxVersion` / `Minder.GetChangedThreads` passthroughs.

## The late-join gap (#301)

`fanoutUsers` is the only writer of `user_channels` rows, so a user added to the team (or promoted past a channel's read role) after channel creation is never fanned in: no delivery bumps, invisible to sync, failing `rtReadThrough`. That's the inverse of the removal case (which this PR handles via re-authorization) — analyzed and tracked in #301, with a NOTE at the fan-in site.

## Testing

`TestRTSendReadPermissions` extends its exact version matrix through the sync flow:

- full syncs for both members: coco sees watercooler (v3) → announce (v5, carrying her read receipt), never brass; bluey sees brass (v3, no last-message) → announce (v5) → watercooler (v6, her receipt);
- cursor pagination in pages of 2, head reported on every page;
- caught-up call (since == head) returns empty;
- **removed member**: coco's stale rows vanish from her delta while her own head still reports.

Full `TestRT*` lib suite passes under `-race` (no warnings), CLI `TestRT*` passes, build/vet/gofmt clean.

## Scope

`rtPollInbox` (@8) remains the last stub — the long-poll stand-in for server push.

Co-authored-by: Claude Code