### PR TITLE
chat(1d): implement rtPollInbox with an in-process wake hub

### DIFF
--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -895,6 +895,35 @@ func (d *Minder) GetChangedThreads(
 	return &res, nil
 }
 
+// PollInbox long-polls the server: it blocks until the caller's inbox version
+// advances past since, or the timeout (0 = server default) elapses, returning
+// the current head with Bumped saying which happened. Re-issue on return,
+// running a GetChangedThreads sync first when Bumped. A stand-in for real
+// server push (Stage 2c).
+func (d *Minder) PollInbox(
+	m MetaContext,
+	appID proto.RTAppID,
+	since proto.RTInboxVersion,
+	timeout time.Duration,
+) (
+	*proto.RTInboxPollRes,
+	error,
+) {
+	_, cli, err := d.clientLocal(m.Base(), d.au)
+	if err != nil {
+		return nil, err
+	}
+	res, err := cli.RtPollInbox(m.Ctx(), rem.RTPollInboxArg{
+		AppID:   appID,
+		Since:   since,
+		Timeout: proto.ExportDurationMilli(timeout),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
 func (d *Minder) cacheMsgID(
 	q proto.RTMsgSeq,
 	i proto.RTMsgID,

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/client/librt"
@@ -1153,6 +1154,58 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, proto.RTInboxVersion(5), delta.InboxVersion)
 	require.Empty(t, delta.Channels)
+
+	// --- long poll ---
+
+	// A poll from the current head parks and, with nothing arriving, reports
+	// no bump when its timeout lapses. The duration only bounds how long the
+	// server holds the call -- the deadline path fires regardless of how slow
+	// the machine is -- so keep it small.
+	pres, err := minderBluey.PollInbox(mb, proto.RTAppID_Chat, 6, 100*time.Millisecond)
+	require.NoError(t, err)
+	require.False(t, pres.Bumped)
+	require.Equal(t, proto.RTInboxVersion(6), pres.InboxVersion)
+
+	// A stale since returns immediately: the head is already past it.
+	pres, err = minderBluey.PollInbox(mb, proto.RTAppID_Chat, 5, 10*time.Second)
+	require.NoError(t, err)
+	require.True(t, pres.Bumped)
+	require.Equal(t, proto.RTInboxVersion(6), pres.InboxVersion)
+
+	// A parked poller is woken by a delivery. The wake comes from the
+	// in-process hub after the send's transaction commits -- not DB polling --
+	// so this returns promptly rather than at the 10s timeout. The test env
+	// shares the realtime server's GlobalContext, so we can watch the hub
+	// directly and hold the send until the poller has actually subscribed:
+	// this deterministically exercises the parked-wake path with no fixed
+	// sleep. (Every interleaving asserts identically anyway -- a poll arriving
+	// after the send returns Bumped off its initial read -- but that path is
+	// already covered by the stale-since case above.)
+	type pollOut struct {
+		res *proto.RTInboxPollRes
+		err error
+	}
+	pollCh := make(chan pollOut, 1)
+	go func() {
+		r, e := minderBluey.PollInbox(mb, proto.RTAppID_Chat, 6, 10*time.Second)
+		pollCh <- pollOut{res: r, err: e}
+	}()
+	hub := m.G().RTInboxHub()
+	hubKey := shared.RTInboxHubKey{
+		HostID: m.ShortHostID(),
+		Uid:    bluey.uid,
+		App:    proto.RTAppID_Chat,
+	}
+	require.Eventually(t,
+		func() bool { return hub.NumWaiters(hubKey) > 0 },
+		10*time.Second, 5*time.Millisecond)
+	_, err = minderBluey.Send(mb, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("watercooler"), []byte("wake up"))
+	require.NoError(t, err)
+	out := <-pollCh
+	require.NoError(t, out.err)
+	require.True(t, out.res.Bumped)
+	require.Equal(t, proto.RTInboxVersion(7), out.res.InboxVersion)
 }
 
 // TestRTSendEncryptionRole checks that the server rejects a message encrypted

--- a/proto/lib/extras.go
+++ b/proto/lib/extras.go
@@ -5286,6 +5286,21 @@ func (v RTAppID) ExportToDB() (string, error) {
 	return "", DataError(fmt.Sprintf("bad RTAppID (%d) for DB", v))
 }
 
+// ImportFromDB is the inverse of RTAppID.ExportToDB.
+func (v *RTAppID) ImportFromDB(s string) error {
+	switch s {
+	case "chat":
+		*v = RTAppID_Chat
+	case "crdt":
+		*v = RTAppID_Crdt
+	case "notif":
+		*v = RTAppID_Notif
+	default:
+		return DataError(fmt.Sprintf("bad app_id (%q) from DB", s))
+	}
+	return nil
+}
+
 func (t RTMsgType) ExportToDB() (string, error) {
 	switch t {
 	case RTMsgType_Basic:

--- a/server/realtime/channels.go
+++ b/server/realtime/channels.go
@@ -353,6 +353,10 @@ type channelMaker struct {
 	userdb  *pgxpool.Conn
 	rtdbtx  pgx.Tx
 	dstRole *core.RoleKey
+
+	// members whose inbox versions the fanout bumped; the caller wakes their
+	// parked long-pollers after the transaction commits.
+	wakeUIDs []proto.UID
 }
 
 func (c *channelMaker) checkPerms(m shared.MetaContext) error {
@@ -627,6 +631,7 @@ func (c *channelMaker) fanoutUsers(m shared.MetaContext) error {
 			return err
 		}
 	}
+	c.wakeUIDs = uids
 	return nil
 }
 
@@ -721,25 +726,24 @@ func MakeChannel(
 	}
 	defer userdb.Release()
 
-	err = shared.RetryTx(m,
+	return shared.RetryTx2(m,
 		rtdb,
 		"realtime.MakeChannel",
-		func(m shared.MetaContext, tx pgx.Tx) error {
+		func(m shared.MetaContext, tx pgx.Tx) (func(shared.MetaContext), error) {
 			mk := channelMaker{
 				md:     md,
 				vers:   vers,
 				rtdbtx: tx,
 				userdb: userdb,
 			}
-			err = mk.run(m)
-			if err != nil {
-				return err
+			if err := mk.run(m); err != nil {
+				return nil, err
 			}
-			return nil
+			// Once the fan-in bumps commit, wake the members' parked
+			// long-pollers so the channel surfaces immediately.
+			return func(m shared.MetaContext) {
+				wakeInboxPollers(m, md.AppID, mk.wakeUIDs)
+			}, nil
 		},
 	)
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/server/realtime/inbox.go
+++ b/server/realtime/inbox.go
@@ -1,6 +1,8 @@
 package realtime
 
 import (
+	"time"
+
 	"github.com/foks-proj/go-foks/lib/core"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/proto/rem"
@@ -12,6 +14,24 @@ import (
 // doesn't ask for a specific size (max=0).
 const defaultInboxPage = 100
 const maxInboxPage = 1000
+
+const (
+	// Timeout default (when the client passes 0) and cap: keep well under
+	// typical LB idle timeouts. The client immediately re-issues on return.
+	defaultPollInboxTimeout = 25 * time.Second
+	maxPollInboxTimeout     = 55 * time.Second
+)
+
+func cappedPollTimeout(d proto.DurationMilli) time.Duration {
+	ret := d.Duration()
+	if ret == 0 {
+		return defaultPollInboxTimeout
+	}
+	if ret > maxPollInboxTimeout {
+		return maxPollInboxTimeout
+	}
+	return ret
+}
 
 func cappedInboxPage(max uint64) uint64 {
 	if max == 0 {
@@ -255,4 +275,89 @@ func readChangedChannels(
 		return nil, err
 	}
 	return ret, nil
+}
+
+// PollInbox blocks until the caller's inbox version for the app advances past
+// arg.Since, the (capped) timeout elapses, or the caller disconnects. It
+// returns the current head either way, with Bumped saying which happened; a
+// stale Since (head already past it) returns immediately. The client is
+// expected to re-issue the poll as soon as it returns (after running a
+// rtGetChangedThreads sync on a bump).
+//
+// Parked pollers are woken by the in-process RTInboxHub, which writers signal
+// after their transactions commit. The subscribe-BEFORE-read order below is
+// what makes the park race-free: a bump landing between our version read and
+// the select still closes the channel we already hold. Wakes carry no data,
+// so we always re-read the version after one -- a spurious wake just loops.
+func PollInbox(
+	m shared.MetaContext,
+	arg rem.RTPollInboxArg,
+) (
+	*proto.RTInboxPollRes,
+	error,
+) {
+	hub := m.G().RTInboxHub()
+	key := shared.RTInboxHubKey{
+		HostID: m.ShortHostID(),
+		Uid:    m.UID(),
+		App:    arg.AppID,
+	}
+	deadline := time.Now().Add(cappedPollTimeout(arg.Timeout))
+
+	// oneRound runs a single subscribe/read/park round, with the subscription
+	// (and the park timer) released via defer on every exit path. A nil, nil
+	// return means "go around again" -- after a wake or the final deadline
+	// tick -- and the next round re-subscribes before re-reading.
+	oneRound := func() (*proto.RTInboxPollRes, error) {
+		ch := hub.Subscribe(key)
+		defer hub.Unsubscribe(key, ch)
+
+		vers, err := pollInboxOnce(m, arg.AppID)
+		if err != nil {
+			return nil, err
+		}
+		if vers > arg.Since {
+			return &proto.RTInboxPollRes{Bumped: true, InboxVersion: vers}, nil
+		}
+		remain := time.Until(deadline)
+		if remain <= 0 {
+			return &proto.RTInboxPollRes{Bumped: false, InboxVersion: vers}, nil
+		}
+		timer := time.NewTimer(remain)
+		defer timer.Stop()
+		select {
+		case <-ch:
+			// Woken; the next round re-reads.
+		case <-m.Ctx().Done():
+			return nil, m.Ctx().Err()
+		case <-timer.C:
+			// Deadline; the next round's read returns not-bumped.
+		}
+		return nil, nil
+	}
+
+	for {
+		res, err := oneRound()
+		if res != nil || err != nil {
+			return res, err
+		}
+	}
+}
+
+// pollInboxOnce reads the caller's current head, acquiring and releasing the
+// pooled connection around the single query: a parked poller must not pin a
+// connection for its whole (potentially ~minute-long) wait.
+func pollInboxOnce(
+	m shared.MetaContext,
+	app proto.RTAppID,
+) (
+	proto.RTInboxVersion,
+	error,
+) {
+	db, err := m.Db(shared.DbTypeRealTime)
+	if err != nil {
+		return 0, err
+	}
+	defer db.Release()
+	return readInboxVersion(m, db, m.UID(), app)
 }

--- a/server/realtime/messages.go
+++ b/server/realtime/messages.go
@@ -32,6 +32,11 @@ type messageSender struct {
 	writeRole  proto.Role
 	readRole   proto.Role
 	prevSeq    int64
+	appID      proto.RTAppID
+
+	// members whose inbox versions the fanout bumped; the caller wakes their
+	// parked long-pollers after the transaction commits.
+	wakeUIDs []proto.UID
 }
 
 func (s *messageSender) channelID() int64 { return int64(s.arg.Chid) }
@@ -43,16 +48,17 @@ func (s *messageSender) lockChannel(m shared.MetaContext) error {
 	var teamRaw []byte
 	var wrt, wvl, rrt, rvl int
 	var prevSeq *int64
+	var appRaw string
 	err := s.tx.QueryRow(
 		m.Ctx(),
 		`SELECT parent_team_id, write_role_type, write_role_viz_level,
-		        read_role_type, read_role_viz_level, last_msg_seq
+		        read_role_type, read_role_viz_level, last_msg_seq, app_id
 		 FROM channels
 		 WHERE short_host_id=$1 AND channel_id=$2
 		 FOR UPDATE`,
 		m.ShortHostID(),
 		s.channelID(),
-	).Scan(&teamRaw, &wrt, &wvl, &rrt, &rvl, &prevSeq)
+	).Scan(&teamRaw, &wrt, &wvl, &rrt, &rvl, &prevSeq, &appRaw)
 	if err == pgx.ErrNoRows {
 		return core.RowNotFoundError{}
 	}
@@ -68,6 +74,10 @@ func (s *messageSender) lockChannel(m shared.MetaContext) error {
 		return err
 	}
 	err = s.readRole.ImportFromDB(rrt, rvl)
+	if err != nil {
+		return err
+	}
+	err = s.appID.ImportFromDB(appRaw)
 	if err != nil {
 		return err
 	}
@@ -252,8 +262,9 @@ func (s *messageSender) fanoutInboxVersions(
 	// user_channels -- but keeps a missing row self-healing. The ORDER BY
 	// makes concurrent sends into different channels with overlapping
 	// membership acquire user_inbox row locks in a consistent order, avoiding
-	// deadlocks.
-	_, err := s.tx.Exec(
+	// deadlocks. RETURNING collects the bumped members so the caller can wake
+	// their parked long-pollers once this transaction commits.
+	rows, err := s.tx.Query(
 		m.Ctx(),
 		`INSERT INTO user_inbox (short_host_id, uid, app_id, inbox_version, mtime)
 		 SELECT uc.short_host_id, uc.uid, uc.app_id, 1, NOW()
@@ -261,13 +272,32 @@ func (s *messageSender) fanoutInboxVersions(
 		  WHERE uc.short_host_id=$1 AND uc.channel_id=$2
 		  ORDER BY uc.uid
 		 ON CONFLICT (short_host_id, uid, app_id)
-		 DO UPDATE SET inbox_version = user_inbox.inbox_version + 1, mtime = NOW()`,
+		 DO UPDATE SET inbox_version = user_inbox.inbox_version + 1, mtime = NOW()
+		 RETURNING uid`,
 		m.ShortHostID(),
 		s.channelID(),
 	)
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+	for rows.Next() {
+		var uidRaw []byte
+		err = rows.Scan(&uidRaw)
+		if err != nil {
+			return err
+		}
+		var uid proto.UID
+		err = uid.ImportFromDB(uidRaw)
+		if err != nil {
+			return err
+		}
+		s.wakeUIDs = append(s.wakeUIDs, uid)
+	}
+	if err = rows.Err(); err != nil {
+		return err
+	}
+	rows.Close()
 
 	// Stamp each membership row at its owner's just-bumped global version, and
 	// refresh the denormalized last-message time for inbox ordering. Reads the
@@ -341,6 +371,8 @@ func SendMessage(
 	defer userdb.Release()
 
 	var res *rem.RTSendRes
+	var wakeUIDs []proto.UID
+	var appID proto.RTAppID
 	err = shared.RetryTx(m,
 		rtdb,
 		"realtime.SendMessage",
@@ -356,13 +388,33 @@ func SendMessage(
 				return err
 			}
 			res = tmp
+			wakeUIDs = s.wakeUIDs
+			appID = s.appID
 			return nil
 		},
 	)
 	if err != nil {
 		return nil, err
 	}
+	// The bumps are committed; wake the members' parked long-pollers. (If a
+	// wake is ever lost -- say the commit's ack was -- pollers catch up at
+	// their poll timeout.)
+	wakeInboxPollers(m, appID, wakeUIDs)
 	return res, nil
+}
+
+// wakeInboxPollers wakes the given users' parked rtPollInbox calls. Call only
+// after the transaction that bumped their inbox versions has committed; see
+// shared.RTInboxHub.
+func wakeInboxPollers(m shared.MetaContext, app proto.RTAppID, uids []proto.UID) {
+	hub := m.G().RTInboxHub()
+	for _, uid := range uids {
+		hub.Wake(shared.RTInboxHubKey{
+			HostID: m.ShortHostID(),
+			Uid:    uid,
+			App:    app,
+		})
+	}
 }
 
 // readThroughMarker advances the calling user's read pointer in one channel
@@ -382,6 +434,12 @@ type readThroughMarker struct {
 	readRole   proto.Role
 	lastSeq    *int64
 	appID      string
+	app        proto.RTAppID
+
+	// bumped records whether the pointer actually advanced (and hence the
+	// caller's inbox version was bumped); a stale mark leaves it false and
+	// must not wake any pollers.
+	bumped bool
 }
 
 func (r *readThroughMarker) channelID() int64 { return r.arg.ChannelID.Short().Int64() }
@@ -412,7 +470,11 @@ func (r *readThroughMarker) loadChannel(m shared.MetaContext) error {
 	if err != nil {
 		return err
 	}
-	return r.readRole.ImportFromDB(rrt, rvl)
+	err = r.readRole.ImportFromDB(rrt, rvl)
+	if err != nil {
+		return err
+	}
+	return r.app.ImportFromDB(r.appID)
 }
 
 // authorize applies the same check as a thread read: the caller's team role
@@ -488,6 +550,7 @@ func (r *readThroughMarker) run(m shared.MetaContext) error {
 	// The pointer moved: bump the caller's global inbox version and stamp this
 	// row at it, "like a send would do" (chat-server-design.md), so the
 	// caller's other devices pick the read state up on their next sync.
+	r.bumped = true
 	var vers int64
 	err = r.tx.QueryRow(
 		m.Ctx(),
@@ -533,7 +596,9 @@ func MarkReadThrough(
 	}
 	defer userdb.Release()
 
-	return shared.RetryTx(m,
+	var bumped bool
+	var app proto.RTAppID
+	err = shared.RetryTx(m,
 		rtdb,
 		"realtime.MarkReadThrough",
 		func(m shared.MetaContext, tx pgx.Tx) error {
@@ -543,9 +608,24 @@ func MarkReadThrough(
 				userdb: userdb,
 				tx:     tx,
 			}
-			return r.run(m)
+			err := r.run(m)
+			if err != nil {
+				return err
+			}
+			bumped = r.bumped
+			app = r.app
+			return nil
 		},
 	)
+	if err != nil {
+		return err
+	}
+	// Wake the caller's own parked pollers (their other devices) -- but only
+	// if the pointer actually advanced; a stale mark bumps nothing.
+	if bumped {
+		wakeInboxPollers(m, app, []proto.UID{m.UID()})
+	}
+	return nil
 }
 
 // loadChannelForRead returns the channel's parent team and read role, for

--- a/server/realtime/server.go
+++ b/server/realtime/server.go
@@ -107,7 +107,12 @@ func (c *ClientConn) RtReadThrough(ctx context.Context, arg rem.RTReadThroughArg
 	return MarkReadThrough(m, arg)
 }
 func (c *ClientConn) RtPollInbox(ctx context.Context, arg rem.RTPollInboxArg) (res proto.RTInboxPollRes, err error) {
-	return res, core.NotImplementedError{}
+	m := shared.NewMetaContextConn(ctx, c)
+	ret, err := PollInbox(m, arg)
+	if err != nil {
+		return res, err
+	}
+	return *ret, nil
 }
 func (c *ClientConn) RtSelectVHost(ctx context.Context, arg proto.HostID) error {
 	return shared.SelectVHost(ctx, c, arg)

--- a/server/shared/globals.go
+++ b/server/shared/globals.go
@@ -73,6 +73,9 @@ type GlobalContext struct {
 	// each host ID. We keep track of this here.
 	ahtMgr *AdHocTeamNamesManager
 
+	// Wakes parked rtPollInbox long-pollers on committed inbox bumps.
+	rtInboxHub *RTInboxHub
+
 	// A lot of services might need to poll the Merkle Query service. Available here
 	merkleGCli *BackendClient
 
@@ -152,6 +155,7 @@ func NewGlobalContext(opts *GlobalContextOpts) *GlobalContext {
 		testing:         testing,
 		oauth2ConfigSet: sso.NewOAuth2ConfigSet(),
 		ahtMgr:          NewAdHocTeamNamesManager(),
+		rtInboxHub:      NewRTInboxHub(),
 	}
 }
 
@@ -180,6 +184,12 @@ func (g *GlobalContext) AdHocTeamNamesManager() *AdHocTeamNamesManager {
 	g.RLock()
 	defer g.RUnlock()
 	return g.ahtMgr
+}
+
+func (g *GlobalContext) RTInboxHub() *RTInboxHub {
+	g.RLock()
+	defer g.RUnlock()
+	return g.rtInboxHub
 }
 
 func (g *GlobalContext) SetVanityHelper(v VanityHelper) {

--- a/server/shared/rt_inbox_hub.go
+++ b/server/shared/rt_inbox_hub.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package shared
+
+import (
+	"sync"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+// RTInboxHubKey identifies one user's per-app inbox version stream.
+type RTInboxHubKey struct {
+	HostID core.ShortHostID
+	Uid    proto.UID
+	App    proto.RTAppID
+}
+
+// RTInboxHub wakes parked inbox long-pollers (rtPollInbox) when a write bumps
+// a user's inbox version. Wakes carry no data -- a woken poller re-reads the
+// version from the DB -- so spurious wakes are harmless; what matters is that
+// wakes are never missed. Two rules keep that true:
+//
+//   - Pollers must Subscribe BEFORE reading the version they compare against,
+//     so a bump landing between the read and the park still wakes them.
+//   - Writers must Wake only AFTER their transaction commits (i.e., after
+//     RetryTx returns success). A pre-commit wake sends the poller to a read
+//     that can't yet see the bump, and no second wake follows.
+//
+// In-process only: a poller parked on one realtime server won't get an
+// instant wake for a bump handled by another; it catches up at its poll
+// timeout. The waiter registry is the durable part of this design -- Stage 2c
+// replaces the wake *source* with Redis pub/sub (and thus cross-process
+// wakes) without changing pollers or writers.
+type RTInboxHub struct {
+	sync.Mutex
+	waiters map[RTInboxHubKey]map[chan struct{}]bool
+}
+
+func NewRTInboxHub() *RTInboxHub {
+	return &RTInboxHub{
+		waiters: make(map[RTInboxHubKey]map[chan struct{}]bool),
+	}
+}
+
+// Subscribe registers a waiter and returns its one-shot wake channel, which
+// is closed by the next Wake for this key. Always pair with Unsubscribe (a
+// no-op if a Wake already retired the channel).
+func (h *RTInboxHub) Subscribe(k RTInboxHubKey) chan struct{} {
+	h.Lock()
+	defer h.Unlock()
+	ch := make(chan struct{})
+	set := h.waiters[k]
+	if set == nil {
+		set = make(map[chan struct{}]bool)
+		h.waiters[k] = set
+	}
+	set[ch] = true
+	return ch
+}
+
+func (h *RTInboxHub) Unsubscribe(k RTInboxHubKey, ch chan struct{}) {
+	h.Lock()
+	defer h.Unlock()
+	set := h.waiters[k]
+	if set == nil {
+		return
+	}
+	delete(set, ch)
+	if len(set) == 0 {
+		delete(h.waiters, k)
+	}
+}
+
+// Wake retires and closes all current waiters for the key. Call only after
+// the bump's transaction has committed; see the type doc.
+func (h *RTInboxHub) Wake(k RTInboxHubKey) {
+	h.Lock()
+	defer h.Unlock()
+	for ch := range h.waiters[k] {
+		close(ch)
+	}
+	delete(h.waiters, k)
+}
+
+// NumWaiters reports how many pollers are currently subscribed on k. For
+// metrics and tests (e.g., deterministically waiting for a poller to park
+// before triggering the bump that should wake it).
+func (h *RTInboxHub) NumWaiters(k RTInboxHubKey) int {
+	h.Lock()
+	defer h.Unlock()
+	return len(h.waiters[k])
+}


### PR DESCRIPTION
Implements the last stub in the `rem.RealTime` protocol: the long-poll stand-in for server push (per the protocol comment; Stage 2c replaces it with ChatPush + Redis). Follows #299/#300/#302.

## What

**`rtPollInbox`** blocks until the caller's per-(user, app) inbox version advances past `since`, the timeout elapses (default 25s, capped 55s — under typical LB idle timeouts), or the caller disconnects. Returns the current head either way, with `Bumped` saying which; a stale `since` returns immediately. Clients re-issue on return, running a `rtGetChangedThreads` sync first on a bump.

**`RTInboxHub`** (`server/shared/rt_inbox_hub.go`, a `GlobalContext` singleton): a waiter registry keyed `(shortHostID, uid, app)` with one-shot close-based wake channels — no database polling. Wakes carry no data (a woken poller re-reads the version), so spurious wakes are harmless; two rules make wakes **never missed**:

1. **Pollers subscribe *before* reading** the version they compare against — a bump landing between the read and the park still closes the channel they already hold.
2. **Writers wake only *after* their transaction commits** — a pre-commit wake would send the poller into a read that can't see the bump yet, with no second wake coming. All three inbox writers wake in their wrappers after `RetryTx` succeeds: the send fanout now `RETURNING`-collects the members it bumped, read receipts wake only when the pointer actually advanced (stale marks wake nobody), and channel creation wakes its fan-in set.

A parked poller **holds no DB connection** — the pooled conn is acquired and released around each version read, so many parked pollers can't drain the pool.

**Scaling seam**: the hub is in-process only (a poller parked on one realtime server catches up at its poll timeout if the bump lands on another). The waiter registry is the durable piece — Stage 2c swaps the wake *source* for Redis pub/sub, gaining cross-process wakes without touching pollers or writers.

**Client**: `Minder.PollInbox`. Also adds `RTAppID.ImportFromDB` (inverse of the existing `ExportToDB`) for writers that read the app off the channel row.

## Testing

`TestRTSendReadPermissions` extends through the poll flow, with **no fixed sleeps**:

- timeout park: no bump at the deadline (100ms — the deadline path fires regardless of machine speed, so the duration stays small);
- stale `since`: immediate `Bumped` return;
- parked wake: the test env shares the realtime server's `GlobalContext`, so the test watches `RTInboxHub.NumWaiters` and holds the wake-up send until the poller has *actually subscribed* — deterministically exercising the parked-wake path, event-driven in ~1ms.

Clean under `-race` (repeated runs), CLI `TestRT*` green, build/vet/gofmt clean.

With this, every RPC in the realtime protocol is implemented.

Co-authored-by: Claude Code