### PR TITLE
chat(1d): fan late-joining members into user_channels, gated by a membership-change marker

### DIFF
--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -1206,6 +1206,91 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.NoError(t, out.err)
 	require.True(t, out.res.Bumped)
 	require.Equal(t, proto.RTInboxVersion(7), out.res.InboxVersion)
+
+	// --- late-join fan-in (issue #301) ---
+
+	// dave joins the team long after every channel was created, so the
+	// creation fanout never saw him. His first poll runs the reconcile pass:
+	// it fans him into the two member-readable channels (one fresh version
+	// bump per row, per the unique-index invariant), so the poll's first read
+	// sees head 2 > since 0 and returns immediately.
+	dave := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+	tm.makeChanges(t, m, bluey,
+		[]proto.MemberRole{
+			dave.toMemberRole(t, proto.DefaultRole, tm.hepks),
+		}, nil,
+	)
+	mdv := librt.NewMetaContext(tew.NewClientMetaContextWithEracer(t, dave))
+	minderDave := librt.NewMinder(mdv.G().ActiveUser())
+
+	pres, err = minderDave.PollInbox(mdv, proto.RTAppID_Chat, 0, 10*time.Second)
+	require.NoError(t, err)
+	require.True(t, pres.Bumped)
+	require.Equal(t, proto.RTInboxVersion(2), pres.InboxVersion)
+
+	// The sync (which also reconciles, idempotently) shows the two
+	// member-readable channels at distinct backfill versions, unread, with
+	// their last-message previews; brass stays invisible (admin read role).
+	// The backfill allocates versions in channel-ID order, and channel IDs
+	// are random, so compute the expected order rather than assuming it.
+	first, second := chAnnounce, chWatercooler
+	if chWatercooler.Short().Int64() < chAnnounce.Short().Int64() {
+		first, second = chWatercooler, chAnnounce
+	}
+	delta, err = minderDave.GetChangedThreads(mdv, proto.RTAppID_Chat, 0, 0)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(2), delta.InboxVersion)
+	require.Equal(t, []row{
+		{id: *first, vers: 1, read: 0, last: true},
+		{id: *second, vers: 2, read: 0, last: true},
+	}, summarize(delta))
+
+	// Caught up: nothing new, and the reconcile doesn't re-fan-in.
+	delta, err = minderDave.GetChangedThreads(mdv, proto.RTAppID_Chat, 2, 0)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(2), delta.InboxVersion)
+	require.Empty(t, delta.Channels)
+
+	// Before the fan-in, dave's read receipt would have failed on the missing
+	// membership row; now it lands and bumps him like any member.
+	err = minderDave.ReadThrough(mdv, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("announce"), 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), uiVers(dave))
+	require.Equal(t, int64(3), ucVers(dave, chAnnounce))
+	require.Equal(t, int64(1), ucRead(dave, chAnnounce))
+
+	// A role change re-triggers the fan-in via the membership-version marker
+	// (bumped in the same transaction as the team_members change): promoting
+	// dave to admin puts brass within his read role, and his next sync
+	// discovers it -- no fixed reconcile cadence involved.
+	tm.makeChanges(t, m, bluey,
+		[]proto.MemberRole{
+			dave.toMemberRole(t, proto.AdminRole, tm.hepks),
+		}, nil,
+	)
+	delta, err = minderDave.GetChangedThreads(mdv, proto.RTAppID_Chat, 3, 0)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(4), delta.InboxVersion)
+	require.Equal(t, []row{
+		{id: *chBrass, vers: 4, read: 0, last: false},
+	}, summarize(delta))
+
+	// The persistent tier of the reconciled-through cursor tracks dave's
+	// membership-change marker: one bump for his add, one for his promotion.
+	// (The in-memory tier fronts this row; it's what a process restart -- or
+	// another realtime server -- would warm from instead of re-reconciling.)
+	var cursorVers int64
+	err = rtdb.QueryRow(m.Ctx(),
+		`SELECT vers FROM fanin_cursors
+		 WHERE short_host_id=$1 AND uid=$2 AND app_id='chat'`,
+		m.ShortHostID(), dave.uid.ExportToDB()).Scan(&cursorVers)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), cursorVers)
+
+	// And nobody else's inbox moved.
+	require.Equal(t, int64(7), uiVers(bluey))
 }
 
 // TestRTSendEncryptionRole checks that the server rejects a message encrypted

--- a/server/realtime/channels.go
+++ b/server/realtime/channels.go
@@ -545,10 +545,9 @@ func (c *channelMaker) fanoutUsers(m shared.MetaContext) error {
 	// device-membership convention used by AuthorizeUserForTeam: local host,
 	// source role Owner, most-recent active row.
 	//
-	// NOTE (issue #301): this is the ONLY writer of user_channels membership
-	// rows, so a user added to the team (or promoted past the read role) after
-	// channel creation never gets fanned in: no delivery bumps, invisible to
-	// rtGetChangedThreads, and rtReadThrough fails. The inverse (removal) is
+	// Users added to the team (or promoted past the read role) after channel
+	// creation are fanned in lazily by reconcileUserChannels (fanin.go), which
+	// runs on inbox sync and poll; see issue #301. The inverse (removal) is
 	// handled by re-authorizing at sync time.
 	readRole, err := core.ImportRole(c.md.Roles.Read)
 	if err != nil {
@@ -644,9 +643,37 @@ func (c *channelMaker) fanoutToUser(m shared.MetaContext, uid proto.UID) error {
 	if err != nil {
 		return err
 	}
+	inserted, err := fanUserIntoChannel(m, c.rtdbtx, uid, app, c.md.Id.Short())
+	if err != nil {
+		return err
+	}
+	if !inserted {
+		// The channel is brand new inside this very transaction, so an
+		// existing membership row can only be a bug.
+		return core.InsertError("failed insert into user_channels, unexpected")
+	}
+	return nil
+}
 
+// fanUserIntoChannel bumps the user's per-app inbox version and writes their
+// denormalized user_channels membership row at that fresh version -- one
+// version allocation per stamped row, as the UNIQUE user_channels_inbox_idx
+// requires. Shared by the channel-creation fanout and the late-join fan-in
+// (issue #301). Returns false if the membership row already existed (a benign
+// race for the late-join path: a concurrent device fanned the user in first;
+// the version bump is then a harmless gap).
+func fanUserIntoChannel(
+	m shared.MetaContext,
+	tx pgx.Tx,
+	uid proto.UID,
+	appDB string,
+	channelID proto.RTChannelIDShort,
+) (
+	bool,
+	error,
+) {
 	var inboxVers int64
-	err = c.rtdbtx.QueryRow(
+	err := tx.QueryRow(
 		m.Ctx(),
 		`INSERT INTO user_inbox (short_host_id, uid, app_id, inbox_version, mtime)
 		 VALUES ($1, $2, $3, 1, NOW())
@@ -655,13 +682,13 @@ func (c *channelMaker) fanoutToUser(m shared.MetaContext, uid proto.UID) error {
 		 RETURNING inbox_version`,
 		m.ShortHostID(),
 		uid.ExportToDB(),
-		app,
+		appDB,
 	).Scan(&inboxVers)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	_, err = c.rtdbtx.Exec(
+	tag, err := tx.Exec(
 		m.Ctx(),
 		`INSERT INTO user_channels
 			(short_host_id, channel_id, uid, app_id, inbox_version,
@@ -669,20 +696,18 @@ func (c *channelMaker) fanoutToUser(m shared.MetaContext, uid proto.UID) error {
 			 ctime, mtime)
 		VALUES ($1, $2, $3, $4, $5,
 		        NOW(), NULL, 0, false, false,
-		        NOW(), NOW())`,
+		        NOW(), NOW())
+		ON CONFLICT (short_host_id, channel_id, uid) DO NOTHING`,
 		m.ShortHostID(),
-		int64(c.md.Id.Short()),
+		channelID.Int64(),
 		uid.ExportToDB(),
-		app,
+		appDB,
 		inboxVers,
 	)
-	if shared.IsDuplicateKeyError(err, "user_channels_pkey") {
-		return core.InsertError("failed insert into user_channels, unexpected")
-	}
 	if err != nil {
-		return err
+		return false, err
 	}
-	return nil
+	return tag.RowsAffected() == 1, nil
 }
 
 func (c *channelMaker) run(m shared.MetaContext) error {

--- a/server/realtime/fanin.go
+++ b/server/realtime/fanin.go
@@ -1,0 +1,320 @@
+package realtime
+
+import (
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/server/shared"
+	"github.com/jackc/pgx/v5"
+)
+
+// reconcileUserChannels implements the late-join fan-in (issue #301): a user
+// added to a team -- or promoted past a channel's read role -- after a channel
+// was created never got a user_channels membership row from the creation
+// fanout, leaving them without delivery bumps, invisible threads in
+// rtGetChangedThreads, and a failing rtReadThrough. This pass diffs the
+// channels of the user's current teams against their membership rows and fans
+// them into anything missing, one inbox-version bump per stamped row (the
+// UNIQUE user_channels_inbox_idx forbids batch-stamping). The fresh bumps make
+// the discovered channels surface in the very sync (or poll) that triggered
+// the reconcile.
+//
+// It runs at the top of rtGetChangedThreads and rtPollInbox, but its work is
+// gated on an exact change signal: user_membership_vers (users DB) is bumped
+// in the same transaction as every team_members change for the user, so an
+// unchanged version proves an unchanged membership set. The steady-state cost
+// per call is therefore a single point read; the team-list/anti-join work runs
+// only after an actual membership change (or once per process per user, to
+// bootstrap and self-heal). Teams the user has left don't appear in the team
+// list, so their lingering rows are never re-created (and the sync's per-team
+// re-authorization keeps skipping them).
+func reconcileUserChannels(m shared.MetaContext, app proto.RTAppID) error {
+	uid := m.UID()
+	hub := m.G().RTInboxHub()
+	key := shared.RTInboxHubKey{
+		HostID: m.ShortHostID(),
+		Uid:    uid,
+		App:    app,
+	}
+	appDB, err := app.ExportToDB()
+	if err != nil {
+		return err
+	}
+
+	// Read the membership version BEFORE the team list below: if a change
+	// commits in between, we reconcile against the newer memberships but
+	// record the older version, so the next call harmlessly re-triggers.
+	// The converse -- recording a version whose changes we didn't see --
+	// can't happen.
+	markerVers, err := readUserMembershipVers(m, uid)
+	if err != nil {
+		return err
+	}
+	if seen, ok := hub.ReconciledThrough(key); ok && seen >= markerVers {
+		return nil
+	}
+
+	// The memory tier missed: process restart, or the marker moved. Consult
+	// the persistent tier (fanin_cursors): another process -- or a prior life
+	// of this one -- may already have reconciled through markerVers. If so,
+	// re-warm the memory tier and skip the heavy pass.
+	sqlVers, err := readFaninCursor(m, uid, appDB)
+	if err != nil {
+		return err
+	}
+	if sqlVers >= markerVers {
+		hub.SetReconciledThrough(key, sqlVers)
+		return nil
+	}
+
+	// The user's current teams, with their role in each -- one users-DB query.
+	// A user can hold memberships at multiple source roles; keep the highest
+	// destination role per team.
+	teams, err := shared.GetTeamListForUser(m)
+	if err != nil {
+		return err
+	}
+	roles := make(map[proto.TeamID]core.RoleKey)
+	for _, te := range teams {
+		rk, err := core.ImportRole(te.DstRole)
+		if err != nil {
+			return err
+		}
+		if prev, ok := roles[te.Id]; !ok || prev.LessThan(*rk) {
+			roles[te.Id] = *rk
+		}
+	}
+
+	var candidates []proto.RTChannelIDShort
+	if len(roles) > 0 {
+		candidates, err = findMissingChannels(m, app, uid, roles)
+		if err != nil {
+			return err
+		}
+	}
+
+	rtdb, err := m.Db(shared.DbTypeRealTime)
+	if err != nil {
+		return err
+	}
+	defer rtdb.Release()
+
+	// A successful reconcile with nothing to fan still advances both cursor
+	// tiers, so neither re-runs the pass until the next real change.
+	if len(candidates) == 0 {
+		err = upsertFaninCursor(m, rtdb, uid, appDB, markerVers)
+		if err != nil {
+			return err
+		}
+		hub.SetReconciledThrough(key, markerVers)
+		return nil
+	}
+
+	return shared.RetryTx2(m,
+		rtdb,
+		"realtime.reconcileUserChannels",
+		func(m shared.MetaContext, tx pgx.Tx) (func(shared.MetaContext), error) {
+			fanned := false
+			for _, chid := range candidates {
+				inserted, err := fanUserIntoChannel(m, tx, uid, appDB, chid)
+				if err != nil {
+					return nil, err
+				}
+				// !inserted = a concurrent device of this user fanned the
+				// row in first; the bump is a harmless version gap.
+				fanned = fanned || inserted
+			}
+			// The persistent cursor advances in the same transaction as the
+			// backfill it describes: recording success is inseparable from
+			// the writes themselves.
+			err := upsertFaninCursor(m, tx, uid, appDB, markerVers)
+			if err != nil {
+				return nil, err
+			}
+			// Once the writes commit, warm the memory tier, and wake the
+			// user's own parked pollers (their other devices) if this call
+			// did the fanning.
+			return func(m shared.MetaContext) {
+				hub.SetReconciledThrough(key, markerVers)
+				if fanned {
+					wakeInboxPollers(m, app, []proto.UID{uid})
+				}
+			}, nil
+		},
+	)
+}
+
+// readFaninCursor reads the persistent reconciled-through cursor; a user with
+// no row is at 0 (never reconciled, or the soft state was wiped).
+func readFaninCursor(
+	m shared.MetaContext,
+	uid proto.UID,
+	appDB string,
+) (
+	int64,
+	error,
+) {
+	db, err := m.Db(shared.DbTypeRealTime)
+	if err != nil {
+		return 0, err
+	}
+	defer db.Release()
+	var v int64
+	err = db.QueryRow(
+		m.Ctx(),
+		`SELECT vers FROM fanin_cursors
+		 WHERE short_host_id=$1 AND uid=$2 AND app_id=$3`,
+		m.ShortHostID().ExportToDB(),
+		uid.ExportToDB(),
+		appDB,
+	).Scan(&v)
+	if err == pgx.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+// upsertFaninCursor advances the persistent reconciled-through cursor,
+// monotonically (GREATEST guards against a stale writer racing a fresher
+// one). q is either the backfill's transaction -- making the advance atomic
+// with the writes it describes -- or a plain connection for the
+// nothing-to-fan paths.
+func upsertFaninCursor(
+	m shared.MetaContext,
+	q shared.DbExecer,
+	uid proto.UID,
+	appDB string,
+	vers int64,
+) error {
+	_, err := q.Exec(
+		m.Ctx(),
+		`INSERT INTO fanin_cursors (short_host_id, uid, app_id, vers, mtime)
+		 VALUES ($1, $2, $3, $4, NOW())
+		 ON CONFLICT (short_host_id, uid, app_id)
+		 DO UPDATE SET vers = GREATEST(fanin_cursors.vers, EXCLUDED.vers),
+		               mtime = NOW()`,
+		m.ShortHostID().ExportToDB(),
+		uid.ExportToDB(),
+		appDB,
+		vers,
+	)
+	return err
+}
+
+// readUserMembershipVers point-reads the user's membership-change version
+// from the users DB; a user with no row (no membership change since the table
+// was introduced) is at version 0.
+func readUserMembershipVers(
+	m shared.MetaContext,
+	uid proto.UID,
+) (
+	int64,
+	error,
+) {
+	db, err := m.Db(shared.DbTypeUsers)
+	if err != nil {
+		return 0, err
+	}
+	defer db.Release()
+	var v int64
+	err = db.QueryRow(
+		m.Ctx(),
+		`SELECT vers FROM user_membership_vers
+		 WHERE short_host_id=$1 AND uid=$2`,
+		m.ShortHostID().ExportToDB(),
+		uid.ExportToDB(),
+	).Scan(&v)
+	if err == pgx.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+// findMissingChannels returns the IDs of channels in the user's teams that
+// their role can read but that have no user_channels membership row, ordered
+// by channel ID for deterministic version allocation.
+func findMissingChannels(
+	m shared.MetaContext,
+	app proto.RTAppID,
+	uid proto.UID,
+	roles map[proto.TeamID]core.RoleKey,
+) (
+	[]proto.RTChannelIDShort,
+	error,
+) {
+	rtdb, err := m.Db(shared.DbTypeRealTime)
+	if err != nil {
+		return nil, err
+	}
+	defer rtdb.Release()
+
+	appDB, err := app.ExportToDB()
+	if err != nil {
+		return nil, err
+	}
+	teamIDs := make([][]byte, 0, len(roles))
+	for tid := range roles {
+		teamIDs = append(teamIDs, tid.ExportToDB())
+	}
+
+	rows, err := rtdb.Query(
+		m.Ctx(),
+		`SELECT c.channel_id, c.parent_team_id,
+		        c.read_role_type, c.read_role_viz_level
+		 FROM channels c
+		 WHERE c.short_host_id=$1
+		 AND c.app_id=$2
+		 AND c.parent_team_id = ANY($3)
+		 AND NOT EXISTS (
+		    SELECT 1 FROM user_channels uc
+		    WHERE uc.short_host_id = c.short_host_id
+		    AND uc.channel_id = c.channel_id
+		    AND uc.uid = $4
+		 )
+		 ORDER BY c.channel_id ASC`,
+		m.ShortHostID().ExportToDB(),
+		appDB,
+		teamIDs,
+		uid.ExportToDB(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ret []proto.RTChannelIDShort
+	for rows.Next() {
+		var chid int64
+		var teamRaw []byte
+		var rrt, rvl int
+		err = rows.Scan(&chid, &teamRaw, &rrt, &rvl)
+		if err != nil {
+			return nil, err
+		}
+		var team proto.TeamID
+		err = team.ImportFromDB(teamRaw)
+		if err != nil {
+			return nil, err
+		}
+		// Same membership rule as the creation fanout: the user's team role
+		// must be at or above the channel's read role.
+		readRole, err := core.ImportRoleKeyFromDB(rrt, rvl)
+		if err != nil {
+			return nil, err
+		}
+		role, ok := roles[team]
+		if !ok || role.LessThan(*readRole) {
+			continue
+		}
+		ret = append(ret, proto.RTChannelIDShort(chid))
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}

--- a/server/realtime/inbox.go
+++ b/server/realtime/inbox.go
@@ -139,6 +139,15 @@ func GetChangedThreads(
 		Channels: []rem.RTInboxChannel{},
 	}
 
+	// Late-join fan-in (issue #301): backfill membership rows for channels the
+	// user gained access to after creation; the fresh bumps make them surface
+	// in this very sync. Best-effort -- a transient failure just defers
+	// discovery to the next call.
+	err = reconcileUserChannels(m, arg.AppID)
+	if err != nil {
+		m.Warnw("GetChangedThreads", "stage", "reconcile", "err", err)
+	}
+
 	head, err := readInboxVersion(m, rtdb, m.UID(), arg.AppID)
 	if err != nil {
 		return nil, err
@@ -302,6 +311,14 @@ func PollInbox(
 		Uid:    m.UID(),
 		App:    arg.AppID,
 	}
+	// Late-join fan-in (issue #301), best-effort: if it backfills anything,
+	// the caller's version bumps, so the first read below returns Bumped
+	// immediately and the client runs the sync that discovers the channels.
+	err := reconcileUserChannels(m, arg.AppID)
+	if err != nil {
+		m.Warnw("PollInbox", "stage", "reconcile", "err", err)
+	}
+
 	deadline := time.Now().Add(cappedPollTimeout(arg.Timeout))
 
 	// oneRound runs a single subscribe/read/park round, with the subscription

--- a/server/shared/rt_inbox_hub.go
+++ b/server/shared/rt_inbox_hub.go
@@ -34,14 +34,44 @@ type RTInboxHubKey struct {
 // replaces the wake *source* with Redis pub/sub (and thus cross-process
 // wakes) without changing pollers or writers.
 type RTInboxHub struct {
-	sync.Mutex
+	sync.RWMutex
 	waiters map[RTInboxHubKey]map[chan struct{}]bool
+
+	// lastReconciled memoizes, per key, the user_membership_vers value that
+	// the late-join fan-in has successfully reconciled through (issue #301).
+	// In-process only, like the waiters: a restart just means one redundant
+	// reconcile per user on first contact.
+	lastReconciled map[RTInboxHubKey]int64
 }
 
 func NewRTInboxHub() *RTInboxHub {
 	return &RTInboxHub{
-		waiters: make(map[RTInboxHubKey]map[chan struct{}]bool),
+		waiters:        make(map[RTInboxHubKey]map[chan struct{}]bool),
+		lastReconciled: make(map[RTInboxHubKey]int64),
 	}
+}
+
+// ReconciledThrough returns the membership version the late-join fan-in has
+// successfully reconciled k through, and whether any reconcile has completed.
+func (h *RTInboxHub) ReconciledThrough(k RTInboxHubKey) (int64, bool) {
+	h.RLock()
+	defer h.RUnlock()
+	v, ok := h.lastReconciled[k]
+	return v, ok
+}
+
+// SetReconciledThrough advances (monotonically) the reconciled-through memo.
+// Callers must pass a version read BEFORE the reconcile's queries ran, and
+// call this only after its writes have committed -- a failed or in-flight
+// reconcile must not mask a membership change, and a change that lands
+// mid-reconcile keeps a higher version and re-triggers.
+func (h *RTInboxHub) SetReconciledThrough(k RTInboxHubKey, vers int64) {
+	h.Lock()
+	defer h.Unlock()
+	if cur, ok := h.lastReconciled[k]; ok && cur >= vers {
+		return
+	}
+	h.lastReconciled[k] = vers
 }
 
 // Subscribe registers a waiter and returns its one-shot wake channel, which
@@ -88,7 +118,7 @@ func (h *RTInboxHub) Wake(k RTInboxHubKey) {
 // metrics and tests (e.g., deterministically waiting for a poller to park
 // before triggering the bump that should wake it).
 func (h *RTInboxHub) NumWaiters(k RTInboxHubKey) int {
-	h.Lock()
-	defer h.Unlock()
+	h.RLock()
+	defer h.RUnlock()
 	return len(h.waiters[k])
 }

--- a/server/shared/team.go
+++ b/server/shared/team.go
@@ -4,7 +4,9 @@
 package shared
 
 import (
+	"bytes"
 	"errors"
+	"slices"
 	"sync"
 
 	"github.com/foks-proj/go-foks/lib/core"
@@ -47,6 +49,51 @@ func EditMembers(
 	}
 	for _, chng := range changes {
 		err := EditMember(m, tx, team, seqno, epno, chng, hepkm)
+		if err != nil {
+			return err
+		}
+	}
+	return bumpUserMembershipVers(m, tx, changes)
+}
+
+// bumpUserMembershipVers records, for every local user member in the change
+// set, that their team memberships changed -- in the same transaction as the
+// team_members writes, which is what makes the signal exact for readers (see
+// user_membership_vers in foks_users.sql). Sorted by UID so concurrent team
+// edits over overlapping member sets take row locks in a consistent order.
+func bumpUserMembershipVers(
+	m MetaContext,
+	tx pgx.Tx,
+	changes []proto.MemberRole,
+) error {
+	var uids []proto.UID
+	for _, chng := range changes {
+		id := chng.Member.Id
+		if !id.Entity.Type().IsUser() {
+			continue
+		}
+		if id.Host != nil && !id.Host.Eq(m.HostID().Id) {
+			continue
+		}
+		uid, err := id.Entity.ToUID()
+		if err != nil {
+			return err
+		}
+		uids = append(uids, uid)
+	}
+	slices.SortFunc(uids, func(a, b proto.UID) int {
+		return bytes.Compare(a[:], b[:])
+	})
+	for _, uid := range uids {
+		_, err := tx.Exec(
+			m.Ctx(),
+			`INSERT INTO user_membership_vers (short_host_id, uid, vers, mtime)
+			 VALUES ($1, $2, 1, NOW())
+			 ON CONFLICT (short_host_id, uid)
+			 DO UPDATE SET vers = user_membership_vers.vers + 1, mtime = NOW()`,
+			m.ShortHostID().ExportToDB(),
+			uid.ExportToDB(),
+		)
 		if err != nil {
 			return err
 		}

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -53,6 +53,9 @@ var usersPatch4 string
 //go:embed patches/foks_users/p5.sql
 var usersPatch5 string
 
+//go:embed patches/foks_users/p6.sql
+var usersPatch6 string
+
 //go:embed patches/foks_server_config/p1.sql
 var serverConfigPatch1 string
 
@@ -71,6 +74,9 @@ var realtimePatch2 string
 //go:embed patches/foks_realtime/p3.sql
 var realtimePatch3 string
 
+//go:embed patches/foks_realtime/p4.sql
+var realtimePatch4 string
+
 var Patches = map[string]map[int]string{
 	"foks_users": {
 		1: usersPatch1,
@@ -78,6 +84,7 @@ var Patches = map[string]map[int]string{
 		3: usersPatch3,
 		4: usersPatch4,
 		5: usersPatch5,
+		6: usersPatch6,
 	},
 	"foks_server_config": {
 		1: serverConfigPatch1,
@@ -88,5 +95,6 @@ var Patches = map[string]map[int]string{
 		1: realtimePatch1,
 		2: realtimePatch2,
 		3: realtimePatch3,
+		4: realtimePatch4,
 	},
 }

--- a/server/sql/foks_realtime.sql
+++ b/server/sql/foks_realtime.sql
@@ -208,6 +208,25 @@ CREATE TABLE user_inbox (
 );
 
 /*
+ * fanin_cursors: the persistent tier of the late-join fan-in's
+ * reconciled-through cursor (issue #301). vers is the user_membership_vers
+ * value (users DB) that the fan-in has successfully reconciled this (user,
+ * app) through; it is written in the same transaction as the backfill it
+ * describes. An in-memory tier (RTInboxHub) fronts it; this row is read only
+ * when the memory tier misses (process restart, or an actual membership
+ * change), and re-warms it. Soft state: deleting rows is always safe -- the
+ * fan-in just re-reconciles from ground truth.
+ */
+CREATE TABLE fanin_cursors (
+    short_host_id SMALLINT NOT NULL,
+    uid BYTEA NOT NULL,
+    app_id app_id NOT NULL,
+    vers BIGINT NOT NULL,
+    mtime TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY(short_host_id, uid, app_id)
+);
+
+/*
  * push_outbox: ephemeral queue of pending push notifications. Drained by the
  * push server; rows pruned after send. May later be replaced by Redis.
  */
@@ -251,3 +270,4 @@ CREATE TABLE schema_patches (
 INSERT INTO schema_patches (id, ctime) VALUES (1, NOW());
 INSERT INTO schema_patches (id, ctime) VALUES (2, NOW());
 INSERT INTO schema_patches (id, ctime) VALUES (3, NOW());
+INSERT INTO schema_patches (id, ctime) VALUES (4, NOW());

--- a/server/sql/foks_users.sql
+++ b/server/sql/foks_users.sql
@@ -229,6 +229,24 @@ CREATE TABLE team_members (
 
 CREATE INDEX team_members_member_idx ON team_members(short_host_id, member_host_id, member_id, active);
 
+/*
+ * user_membership_vers: one row per (host, user), whose vers is bumped -- in
+ * the same transaction as the team_members write it describes -- whenever the
+ * user is added to a team, has a team role changed, or is removed. Readers
+ * (the realtime service's late-join fan-in, issue #301) compare vers against
+ * the version they last reconciled through, turning "did this user's team
+ * memberships change?" into a single point read. The same-transaction rule is
+ * what makes the signal exact: an unchanged vers proves an unchanged
+ * membership set.
+ */
+CREATE TABLE user_membership_vers (
+    short_host_id SMALLINT NOT NULL,
+    uid BYTEA NOT NULL,
+    vers BIGINT NOT NULL,
+    mtime TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY(short_host_id, uid)
+);
+
 CREATE TABLE team_removal_keys (
     short_host_id SMALLINT NOT NULL,
     team_id BYTEA NOT NULL,
@@ -987,3 +1005,4 @@ INSERT INTO schema_patches (id, ctime) VALUES (2, NOW());
 INSERT INTO schema_patches (id, ctime) VALUES (3, NOW());
 INSERT INTO schema_patches (id, ctime) VALUES (4, NOW());
 INSERT INTO schema_patches (id, ctime) VALUES (5, NOW());
+INSERT INTO schema_patches (id, ctime) VALUES (6, NOW());

--- a/server/sql/patches/foks_realtime/p4.sql
+++ b/server/sql/patches/foks_realtime/p4.sql
@@ -1,0 +1,19 @@
+
+/*
+ * fanin_cursors: the persistent tier of the late-join fan-in's
+ * reconciled-through cursor (issue #301). vers is the user_membership_vers
+ * value (users DB) that the fan-in has successfully reconciled this (user,
+ * app) through; it is written in the same transaction as the backfill it
+ * describes. An in-memory tier (RTInboxHub) fronts it; this row is read only
+ * when the memory tier misses (process restart, or an actual membership
+ * change), and re-warms it. Soft state: deleting rows is always safe -- the
+ * fan-in just re-reconciles from ground truth.
+ */
+CREATE TABLE fanin_cursors (
+    short_host_id SMALLINT NOT NULL,
+    uid BYTEA NOT NULL,
+    app_id app_id NOT NULL,
+    vers BIGINT NOT NULL,
+    mtime TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY(short_host_id, uid, app_id)
+);

--- a/server/sql/patches/foks_users/p6.sql
+++ b/server/sql/patches/foks_users/p6.sql
@@ -1,0 +1,18 @@
+
+/*
+ * user_membership_vers: one row per (host, user), whose vers is bumped -- in
+ * the same transaction as the team_members write it describes -- whenever the
+ * user is added to a team, has a team role changed, or is removed. Readers
+ * (the realtime service's late-join fan-in, issue #301) compare vers against
+ * the version they last reconciled through, turning "did this user's team
+ * memberships change?" into a single point read. The same-transaction rule is
+ * what makes the signal exact: an unchanged vers proves an unchanged
+ * membership set.
+ */
+CREATE TABLE user_membership_vers (
+    short_host_id SMALLINT NOT NULL,
+    uid BYTEA NOT NULL,
+    vers BIGINT NOT NULL,
+    mtime TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY(short_host_id, uid)
+);


### PR DESCRIPTION
Closes #301.

## The gap

`user_channels` rows were written only by the channel-creation fanout, so a user added to a team — or promoted past a channel's read role — after a channel existed was invisible to the inbox machinery: no delivery bumps, no `rtGetChangedThreads` results, and a `RowNotFound` from `rtReadThrough`. (The inverse, removal, was already handled by sync-time re-authorization.)

## The fix: reconcile on sync/poll, gated by an exact change signal

The naive version of this reconcile — diff the user's teams' channels against their membership rows on every sync and poll — is O(channels-in-your-teams) of read work on the hottest path for an event that almost never fires. Instead of a time-based rate limit (approximate, still spuriously reconciles), the work is gated on an **exact signal**:

**`user_membership_vers`** (users DB, patch `p6`): one row per (host, user), bumped by `EditMembers` **in the same transaction** as every `team_members` change — add, role change, or removal — for each local user member in the change set. The same-transaction rule is the crux: an unchanged version *proves* an unchanged membership set, no TOCTOU. Bumps are UID-sorted for deterministic lock order across overlapping team edits.

The reconciled-through cursor is **two-tiered**. An in-memory tier on the `RTInboxHub` answers the steady state — **one users-DB point read per sync/poll**, everything else skipped. On a miss (process restart, or an actual marker change), a persistent tier — `fanin_cursors` (realtime DB, patch `p4`) — is consulted and re-warms memory: a restart costs one point read per user instead of a reconcile, and multiple realtime processes benefit from each other's work without waiting for Redis. Both tiers are **soft state**: wiping them just re-reconciles from ground truth, so eviction remains the universal repair. The persistent cursor advances *in the same transaction as the backfill it describes* — recording success is inseparable from the writes. The self-healing bootstrap property survives: a user with no cursor anywhere reconciles once on first contact, healing pre-existing gaps after deploy.

Two correctness rules on the cursor (both tiers):
- it advances **only on reconcile success** — the persistent tier inside the backfill transaction, the memory tier via the `RetryTx2` post-commit hook — so a failed reconcile can't mask a change;
- it advances to the version read **before** the reconcile's queries, so a change landing mid-reconcile keeps a higher version and re-triggers.

## The reconcile itself

One users-DB query (`GetTeamListForUser` already returns each team with the user's role), one indexed anti-join for channels lacking a membership row, a read-role filter mirroring the creation fanout's membership rule, then a `RetryTx2`-wrapped backfill allocating **one fresh inbox version per stamped row** — honoring the `UNIQUE user_channels_inbox_idx` constraint from #302, whose issue thread ruled out batch-stamping — with a post-commit wake of the user's *other* parked devices. Discovered channels surface in the very sync or poll that triggered the reconcile: a late-joined user's parked poll returns `Bumped` within one round-trip of joining.

The bump-and-insert pair is extracted from `channelMaker.fanoutToUser` into a shared `fanUserIntoChannel`; the membership insert is `ON CONFLICT DO NOTHING`, so two devices reconciling concurrently is a benign race (the loser's bump is a harmless version gap). Teams the user left never reappear (the team list only returns active memberships). Reconcile failures are best-effort warnings — discovery defers to the next call.

## Testing

`TestRTSendReadPermissions` extends with **dave**, who joins after all three channels exist:

- his first **poll** reconciles and returns `Bumped` with head 2 immediately;
- his **sync** shows both member-readable channels at distinct backfill versions (expected order computed from the random channel IDs, not assumed); admin-tier brass stays invisible;
- re-syncing doesn't re-fan-in (marker unchanged → point-read-only);
- his **read receipt** — the previously-failing operation — lands and bumps him like any member;
- **promoting him to admin** bumps his marker in the same tx as the role change, and his next sync discovers brass — proving the signal, not a cadence, drives re-reconciliation;
- his persistent cursor row tracks his marker at 2 (add + promote);
- nobody else's inbox moves.

Full `TestRT*` lib suite clean under `-race`, CLI `TestRT*`/`TestTeam*` green, build/vet/gofmt clean. The users-DB schema change follows the add-sql-patch checklist (patch file, `embed.go` registration, base `.sql` DDL + `schema_patches` row) and is exercised by the fresh-DB test env.

Co-authored-by: Claude Code
