### PR TITLE
chat(1d): persist inbox sync state to local soft SQLite

### DIFF
--- a/client/agent/rt.go
+++ b/client/agent/rt.go
@@ -116,4 +116,30 @@ func (c *AgentConn) ClientRTGetThread(
 	return *view, nil
 }
 
+func (c *AgentConn) ClientRTInboxView(
+	ctx context.Context,
+	arg lcl.ClientRTInboxViewArg,
+) (
+	lcl.RTInboxView,
+	error,
+) {
+	var zed lcl.RTInboxView
+	m := librt.NewMetaContext(c.MetaContext(ctx))
+	minder, err := librt.InitUserReq(m)
+	if err != nil {
+		return zed, err
+	}
+	if !arg.LocalOnly {
+		_, err = minder.SyncInbox(m, arg.AppID)
+		if err != nil {
+			return zed, err
+		}
+	}
+	view, err := minder.LocalInbox(m, arg.AppID)
+	if err != nil {
+		return zed, err
+	}
+	return *view, nil
+}
+
 var _ lcl.RealTimeInterface = (*AgentConn)(nil)

--- a/client/foks/cmd/rt.go
+++ b/client/foks/cmd/rt.go
@@ -384,6 +384,41 @@ func outputRTThread(m libclient.MetaContext, thread lcl.RTThreadView) error {
 	return nil
 }
 
+func rtInbox(m libclient.MetaContext, top *cobra.Command) {
+	var localOnly bool
+	quickRTCmd(
+		m, top,
+		"inbox", []string{"i"},
+		"show the inbox",
+		"sync the inbox from the server, then render it from local storage: "+
+			"one line per channel across all teams, with locally-computed unread "+
+			"counts. --local-only skips the sync and renders from disk alone.",
+		quickRTOpts{NoSupportTeam: true},
+		func(cmd *cobra.Command) {
+			cmd.Flags().BoolVar(&localOnly, "local-only", false,
+				"skip the network sync; render from local storage only")
+		},
+		func(args []string, cfg lcl.RTConfig, cli lcl.RealTimeClient) error {
+			if len(args) != 0 {
+				return ArgsError("inbox takes no arguments")
+			}
+			view, err := cli.ClientRTInboxView(m.Ctx(),
+				lcl.ClientRTInboxViewArg{
+					AppID:     cfg.AppID,
+					LocalOnly: localOnly,
+				},
+			)
+			if err != nil {
+				return err
+			}
+			if m.G().Cfg().JSONOutput() {
+				return JSONOutput(m, view)
+			}
+			return outputRTInboxTable(m, outputTableOpts{headers: true}, view)
+		},
+	)
+}
+
 func rtCmd(m libclient.MetaContext) *cobra.Command {
 	top := &cobra.Command{
 		Use:     "rt",
@@ -398,6 +433,7 @@ func rtCmd(m libclient.MetaContext) *cobra.Command {
 	rtListChannels(m, top)
 	rtSend(m, top)
 	rtRead(m, top)
+	rtInbox(m, top)
 	return top
 }
 

--- a/client/foks/cmd/tables.go
+++ b/client/foks/cmd/tables.go
@@ -8,9 +8,11 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/libterm"
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -746,6 +748,130 @@ func (r rtChannelRow) lessThan(other tableRow) bool {
 }
 
 var _ tableRow = rtChannelRow{}
+
+type rtInboxRow struct {
+	name   string
+	tier   proto.RTChannelTier
+	team   string
+	unread uint64
+	msg    string
+	last   string
+	vers   proto.RTInboxVersion
+}
+
+func (r rtInboxRow) toTableRow() table.Row {
+	unread := ""
+	if r.unread > 0 {
+		unread = fmt.Sprintf("%d", r.unread)
+	}
+	return table.Row{
+		r.name,
+		rtChannelTierGlyph(r.tier),
+		unread,
+		r.msg,
+		r.last,
+		r.team,
+	}
+}
+
+func (r rtInboxRow) headers() table.Row {
+	return table.Row{
+		"Channel",
+		"Tier",
+		"Unread",
+		"Last Message",
+		"Last Activity",
+		"Team",
+	}
+}
+
+// Newest inbox bump on top, mirroring LocalInbox's ordering.
+func (r rtInboxRow) lessThan(other tableRow) bool {
+	return r.vers > other.(rtInboxRow).vers
+}
+
+var _ tableRow = rtInboxRow{}
+
+// truncateToWidth caps s at width runes, marking the cut with an ellipsis.
+func truncateToWidth(s string, width int) string {
+	if width <= 0 || utf8.RuneCountInString(s) <= width {
+		return s
+	}
+	runes := []rune(s)
+	if width == 1 {
+		return "…"
+	}
+	return string(runes[:width-1]) + "…"
+}
+
+func outputRTInboxTable(
+	m libclient.MetaContext,
+	opts outputTableOpts,
+	view lcl.RTInboxView,
+) error {
+	rows := make([]rtInboxRow, 0, len(view.Rows))
+	fixed := 0
+	for _, r := range view.Rows {
+		team := ""
+		switch {
+		case !r.TeamName.IsZero():
+			team = r.TeamName.String()
+		default:
+			// The teamname cache had no answer; fall back to the raw ID.
+			s, err := r.Ch.ParentTeam.EntityID().StringErr()
+			if err != nil {
+				return err
+			}
+			team = s
+		}
+		var last, msg string
+		if r.LastSeq > 0 {
+			last = r.LastTime.Import().Local().Format("2006-01-02 15:04:05")
+		}
+		if r.Snippet != nil {
+			msg = *r.Snippet
+			if !r.LastSender.IsZero() {
+				msg = r.LastSender.String() + ": " + msg
+			}
+		}
+		row := rtInboxRow{
+			name:   displayRTChannelName(r.Ch.Name),
+			tier:   r.Ch.Tier,
+			team:   team,
+			unread: r.NumUnread,
+			msg:    msg,
+			last:   last,
+			vers:   r.InboxVersion,
+		}
+		rows = append(rows, row)
+		width := utf8.RuneCountInString(row.name) +
+			1 + // tier glyph
+			len("Unread") +
+			utf8.RuneCountInString(last) +
+			utf8.RuneCountInString(team)
+		fixed = max(fixed, width)
+	}
+
+	// When stdout is a live terminal, fit the snippet column to it: it absorbs
+	// whatever width the other columns leave over (~3 chars of border/padding
+	// per column edge). Piped or captured output is not truncated -- files and
+	// greps want the full content.
+	budget := 0
+	if dims, err := libterm.GetTermDims(); err == nil {
+		const numCols, minSnippet = 6, 16
+		budget = dims.Width - fixed - 3*(numCols+1)
+		budget = max(budget, minSnippet)
+	}
+
+	conv := func(i int, _ lcl.RTInboxRowView) (tableRow, error) {
+		row := rows[i]
+		if budget > 0 {
+			row.msg = truncateToWidth(row.msg, budget)
+		}
+		return row, nil
+	}
+	return convertAndOutputRows(m, opts, view.Rows, conv, nil)
+}
 
 func outputRTChannelListTable(
 	m libclient.MetaContext,

--- a/client/libclient/context.go
+++ b/client/libclient/context.go
@@ -194,5 +194,8 @@ func (g *GlobalContext) WarnwWithContext(
 
 func (m MetaContext) SetAsAgent() error {
 	return m.g.SetAsAgent(m.Ctx())
+}
 
+func (m MetaContext) Now() time.Time {
+	return m.g.Now()
 }

--- a/client/libclient/globals.go
+++ b/client/libclient/globals.go
@@ -130,7 +130,8 @@ type GlobalContext struct {
 
 	deviceNameCache DeviceNameCache
 
-	usernameLoader UsernameLoader
+	usernameLoader *UsernameLoader
+	teamnameLoader *TeamnameLoader
 
 	logRotate *LogRotate
 
@@ -165,7 +166,19 @@ func (d *GlobalContext) DeviceNameCache() *DeviceNameCache {
 func (d *GlobalContext) UsernameLoader() *UsernameLoader {
 	d.Lock()
 	defer d.Unlock()
-	return &d.usernameLoader
+	if d.usernameLoader == nil {
+		d.usernameLoader = NewUsernameLoader()
+	}
+	return d.usernameLoader
+}
+
+func (d *GlobalContext) TeamnameLoader() *TeamnameLoader {
+	d.Lock()
+	defer d.Unlock()
+	if d.teamnameLoader == nil {
+		d.teamnameLoader = NewTeamnameLoader()
+	}
+	return d.teamnameLoader
 }
 
 func (g *GlobalContext) PushShutdownHook(h func()) {

--- a/client/libclient/name_cache.go
+++ b/client/libclient/name_cache.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package libclient
+
+import (
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+type nameCacheEntry struct {
+	name      proto.NameUtf8
+	expiresAt time.Time
+}
+
+const (
+	// nameCacheTTLBase is the central lifetime of a cached key->name entry;
+	// nameCacheTTLJitter is the random spread added on top so a burst of
+	// entries cached together don't all expire at once and stampede the server.
+	nameCacheTTLBase   = 6 * time.Hour
+	nameCacheTTLJitter = 2 * time.Hour
+)
+
+// jitteredNameTTL returns a lifetime uniformly in
+// [base - jitter/2, base + jitter/2), centered on base (~6h).
+func jitteredNameTTL() time.Duration {
+	return nameCacheTTLBase - nameCacheTTLJitter/2 +
+		time.Duration(rand.Int63n(int64(nameCacheTTLJitter)))
+}
+
+// nameCache memoizes K -> display-name with two tiers: an in-memory map in
+// front of the soft local DB, so entries survive agent restarts. It's the
+// shared core of UsernameLoader and TeamnameLoader, which differ only in key
+// type, DataType, and how a key maps to a DB row address. Soft state
+// throughout: a failed read or write of the DB tier degrades to a cache miss,
+// never an error.
+type nameCache[K comparable] struct {
+	sync.RWMutex
+	m map[K]nameCacheEntry
+
+	typ lcl.DataType
+	// rowAddr maps a key to its (scope, key) address in the soft DB.
+	rowAddr func(K) (Scoper, any)
+}
+
+func newNameCache[K comparable](
+	typ lcl.DataType,
+	rowAddr func(K) (Scoper, any),
+) nameCache[K] {
+	return nameCache[K]{typ: typ, rowAddr: rowAddr}
+}
+
+// Get returns a cached, unexpired display name for k, if any, trying the
+// memory tier and then the soft DB. A fresh DB hit warms the memory tier, with
+// its expiry anchored at the row's write time, so the ~TTL staleness bound
+// holds across both tiers.
+func (c *nameCache[K]) Get(m MetaContext, k K) (proto.NameUtf8, bool) {
+	if nm, ok := c.getMem(m, k); ok {
+		return nm, true
+	}
+	return c.getDb(m, k)
+}
+
+// Set records k -> name in both tiers, with a fresh jittered TTL. A DB-tier
+// write failure is returned but the memory tier is set regardless.
+func (c *nameCache[K]) Set(m MetaContext, k K, nm proto.NameUtf8) error {
+	c.putMem(k, nm, m.Now().Add(jitteredNameTTL()))
+	if c.rowAddr == nil {
+		// Zero-value cache (not made via newNameCache): soft state, so degrade
+		// to memory-only rather than crash.
+		m.Warnw("nameCache.Set", "err", "no rowAddr; memory tier only")
+		return nil
+	}
+	scope, key := c.rowAddr(k)
+	return m.DbPut(DbTypeSoft, PutArg{
+		Scope: scope,
+		Typ:   c.typ,
+		Key:   key,
+		Val:   &nm,
+	})
+}
+
+// getMem returns an unexpired entry from the memory tier. An expired entry is
+// reported as a miss but left in place rather than deleted (no lock upgrade);
+// the Set or DB-warm that follows a miss overwrites it.
+func (c *nameCache[K]) getMem(m MetaContext, k K) (proto.NameUtf8, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	ent, ok := c.m[k]
+	if !ok || !m.Now().Before(ent.expiresAt) {
+		return "", false
+	}
+	return ent.name, true
+}
+
+func (c *nameCache[K]) putMem(k K, nm proto.NameUtf8, expiresAt time.Time) {
+	c.Lock()
+	defer c.Unlock()
+	if c.m == nil {
+		c.m = make(map[K]nameCacheEntry)
+	}
+	c.m[k] = nameCacheEntry{
+		name:      nm,
+		expiresAt: expiresAt,
+	}
+}
+
+func (c *nameCache[K]) getDb(m MetaContext, k K) (proto.NameUtf8, bool) {
+	if c.rowAddr == nil {
+		return "", false // zero-value cache; see Set
+	}
+	var nm proto.NameUtf8
+	scope, key := c.rowAddr(k)
+	tm, err := m.DbGet(&nm, DbTypeSoft, scope, c.typ, key)
+	if err != nil {
+		if !errors.Is(err, core.RowNotFoundError{}) {
+			m.Warnw("nameCache.getDb", "typ", c.typ, "key", k, "err", err)
+		}
+		return "", false
+	}
+	expiresAt := tm.Import().Add(jitteredNameTTL())
+	if !m.Now().Before(expiresAt) {
+		return "", false
+	}
+	c.putMem(k, nm, expiresAt)
+	return nm, true
+}

--- a/client/libclient/party_loader_cache.go
+++ b/client/libclient/party_loader_cache.go
@@ -78,6 +78,11 @@ func NewPartyLoaderCache(au *UserContext) *PartyLoaderCache {
 
 type PLCOpts struct {
 	Lock bool
+	// ForceRefresh bypasses the node-freshness shortcut for team loads, forcing
+	// a reload (and hence a fresh view bearer token). Used to recover when a
+	// cached token turns out to be stale server-side -- e.g. the caller's role
+	// in the team changed inside the freshness window.
+	ForceRefresh bool
 }
 
 func (p *PartyLoaderCache) getLockedNode(
@@ -184,7 +189,7 @@ func (p *PartyLoaderCache) loadTeam(
 		if err != nil {
 			return nil, err
 		}
-		if isFresh {
+		if isFresh && (opts == nil || !opts.ForceRefresh) {
 			return plcn, nil
 		}
 	}
@@ -293,7 +298,31 @@ func (a *BaseMinder[N, P]) GetParty(
 	*N,
 	error,
 ) {
-	plcn, err := a.plc.Load(m, t, &PLCOpts{})
+	return a.getParty(m, t, &PLCOpts{})
+}
+
+// GetPartyForceRefresh is GetParty, but reloads the party's backing team even
+// if the cached node is still fresh -- e.g. to mint a new view bearer token
+// after the server rejected the cached one as stale.
+func (a *BaseMinder[N, P]) GetPartyForceRefresh(
+	m MetaContext,
+	t lcl.ConfigTeam,
+) (
+	*N,
+	error,
+) {
+	return a.getParty(m, t, &PLCOpts{ForceRefresh: true})
+}
+
+func (a *BaseMinder[N, P]) getParty(
+	m MetaContext,
+	t lcl.ConfigTeam,
+	opts *PLCOpts,
+) (
+	*N,
+	error,
+) {
+	plcn, err := a.plc.Load(m, t, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/client/libclient/team_loader.go
+++ b/client/libclient/team_loader.go
@@ -216,17 +216,21 @@ func (t *TeamWrapper) IsAdHocTeam() bool {
 	return t.prot.Fqt.Team.IsAdHocTeam()
 }
 
-// returns {names X UIDs x ID x MashedIDs   } @ { name X ID }
-func (t *TeamWrapper) AllFQAdHocTeamStrings() ([]proto.FQAdHocTeamString, error) {
-
-	if !t.IsAdHocTeam() {
-		return nil, nil
+// adHocMemberIDsAndNames collects the local-host user members of an ad-hoc
+// team: their UIDs, and their usernames when every member's name is known
+// (from its loaded user chain, or captured from the username cache when the
+// chain load was skipped -- see LoadMemberNames). nameListOK is false when any
+// member's name is missing; the UID list is complete regardless.
+func (t *TeamWrapper) adHocMemberIDsAndNames() (
+	uids []proto.UID,
+	names []proto.NameUtf8,
+	err error,
+) {
+	err = t.index() // memberMap is built lazily
+	if err != nil {
+		return nil, nil, err
 	}
-
-	var uids []proto.UID
-	var names []proto.NameUtf8
 	host := t.prot.Fqt.Host
-
 	var badNameList bool
 
 	for m := range t.memberMap {
@@ -239,7 +243,7 @@ func (t *TeamWrapper) AllFQAdHocTeamStrings() ([]proto.FQAdHocTeamString, error)
 		}
 		uid, err := eid.ToUID()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		uids = append(uids, uid)
 		rp := t.rosterDetails[m.Fqe]
@@ -258,9 +262,45 @@ func (t *TeamWrapper) AllFQAdHocTeamStrings() ([]proto.FQAdHocTeamString, error)
 				badNameList = true
 			}
 		}
-		if badNameList {
-			break
-		}
+	}
+	if badNameList {
+		names = nil
+	}
+	return uids, names, nil
+}
+
+// AdHocDisplayName renders an ad-hoc team as its canonical member-name list
+// ("alice,bob,charlie"), the closest thing such a team has to a name. Returns
+// false for non-ad-hoc teams or when some member's username isn't known.
+func (t *TeamWrapper) AdHocDisplayName() (proto.NameUtf8, error) {
+	if !t.IsAdHocTeam() {
+		return "", core.InternalError("not an ad-hoc team")
+	}
+	_, names, err := t.adHocMemberIDsAndNames()
+	if err != nil {
+		return "", err
+	}
+	if len(names) == 0 {
+		return "", core.NameError("no names")
+	}
+	s, err := team.NamesToAdhHocCanonicalString(names, "")
+	if err != nil {
+		return "", err
+	}
+	return proto.NameUtf8(s), nil
+}
+
+// returns {names X UIDs x ID x MashedIDs   } @ { name X ID }
+func (t *TeamWrapper) AllFQAdHocTeamStrings() ([]proto.FQAdHocTeamString, error) {
+
+	if !t.IsAdHocTeam() {
+		return nil, nil
+	}
+
+	host := t.prot.Fqt.Host
+	uids, names, err := t.adHocMemberIDsAndNames()
+	if err != nil {
+		return nil, err
 	}
 	uidsJoined, err := team.UIDsToAdhHocCanonicalString(uids, proto.UID{})
 	if err != nil {
@@ -283,7 +323,7 @@ func (t *TeamWrapper) AllFQAdHocTeamStrings() ([]proto.FQAdHocTeamString, error)
 		proto.AdHocTeamString(mashedStr),
 		proto.AdHocTeamString(tid),
 	}
-	if !badNameList {
+	if len(names) > 0 {
 		namesJoined, err := team.NamesToAdhHocCanonicalString(names, "")
 		if err != nil {
 			return nil, err

--- a/client/libclient/team_minder.go
+++ b/client/libclient/team_minder.go
@@ -337,6 +337,37 @@ func (t *TeamMinder) getTeamWithRefresh(
 	return tr, nil
 }
 
+func (t *TeamMinder) fillTeamnameCache(m MetaContext, tw *TeamWrapper, fqt proto.FQTeam) error {
+	// Fill the teamname cache at the load site (every team load funnels
+	// through here), so ID-only display paths like the RT inbox can show
+	// names. An ad-hoc team has no name of its own; cache its canonical
+	// member-name list ("alice,bob,charlie") -- the full list, since the cache
+	// is shared across the agent's local users. Viewer-relative display
+	// (dropping the viewer's own name) happens at render time.
+	var nm proto.NameUtf8
+
+	// In the case of adhoc teams, generate an adhoc name and fill the cache.
+	if tw.IsAdHocTeam() {
+		var err error
+		nm, err = tw.AdHocDisplayName()
+		if err != nil {
+			return err
+		}
+	} else {
+		nm = tw.Name()
+	}
+	if nm.IsZero() {
+		return core.NameError("no name")
+	}
+
+	err := m.G().TeamnameLoader().Set(m, fqt, nm)
+	if err != nil {
+		m.Warnw("LoadTeamWithFQTeam", "stage", "teamnameCache", "fqt", fqt, "err", err)
+		return err
+	}
+	return nil
+}
+
 // LoadTeamWithFQTeam is a high-level function that accesses the result of prior explorations,
 // or a new one if the opts.Refresh flag is set to true.
 func (t *TeamMinder) LoadTeamWithFQTeam(
@@ -360,11 +391,22 @@ func (t *TeamMinder) LoadTeamWithFQTeam(
 
 	tr.ldr.Arg.LoadMembersFull = opts.LoadMembers
 
+	// An ad-hoc team is named by its member list, so have the loader capture
+	// member usernames (cheap: username-cache hits skip the user-chain loads),
+	// as the explore path already does. The teamname-cache fill below needs
+	// them.
+	if fqt.Team.IsAdHocTeam() {
+		tr.ldr.Arg.LoadMemberNames = true
+	}
+
 	tw, err := tr.ldr.Run(m)
 	if err != nil {
 		return nil, err
 	}
 	tr.tw = tw
+
+	_ = t.fillTeamnameCache(m, tw, fqt)
+
 	return tr, nil
 }
 

--- a/client/libclient/teamname_loader.go
+++ b/client/libclient/teamname_loader.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package libclient
+
+import (
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+// TeamnameLoader memoizes FQTeam -> display-name, the team-side sibling of
+// UsernameLoader (same two-tier nameCache underneath). It hangs off the
+// GlobalContext so all layers share it; team loads fill it at the load site
+// (TeamMinder.LoadTeamWithFQTeam), and the RT inbox renderer reads it to show
+// team names instead of IDs.
+//
+// Unlike UsernameLoader there's no integrated network load (yet): a miss is
+// just a miss and the caller falls back (e.g. displaying the team ID). Wiring
+// a single-flighted team load behind misses -- and plugging the cache into
+// more display paths -- is follow-up work.
+type TeamnameLoader struct {
+	nameCache[proto.FQTeam]
+}
+
+func NewTeamnameLoader() *TeamnameLoader {
+	return &TeamnameLoader{
+		nameCache: newNameCache(
+			lcl.DataType_TeamnameCacheEntry,
+			func(fqt proto.FQTeam) (Scoper, any) {
+				return &fqt.Host, fqt.Team
+			},
+		),
+	}
+}

--- a/client/libclient/username_loader.go
+++ b/client/libclient/username_loader.go
@@ -4,35 +4,11 @@
 package libclient
 
 import (
-	"errors"
-	"math/rand"
 	"sync"
-	"time"
 
-	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 )
-
-type usernameCacheEntry struct {
-	name      proto.NameUtf8
-	expiresAt time.Time
-}
-
-const (
-	// usernameCacheTTLBase is the central lifetime of a cached UID->name entry;
-	// usernameCacheTTLJitter is the random spread added on top so a burst of
-	// entries cached together don't all expire at once and stampede the server.
-	usernameCacheTTLBase   = 6 * time.Hour
-	usernameCacheTTLJitter = 2 * time.Hour
-)
-
-// jitteredUsernameTTL returns a lifetime uniformly in
-// [base - jitter/2, base + jitter/2), centered on base (~6h).
-func jitteredUsernameTTL() time.Duration {
-	return usernameCacheTTLBase - usernameCacheTTLJitter/2 +
-		time.Duration(rand.Int63n(int64(usernameCacheTTLJitter)))
-}
 
 // usernameFlight is a single-flight slot for one FQUser's user-chain load;
 // see UsernameLoader.Load. Only a successful result is recorded -- waiters
@@ -43,27 +19,32 @@ type usernameFlight struct {
 	ok   bool
 }
 
-// UsernameLoader resolves FQUser -> display-name, integrating a two-tier
-// cache with a single-flighted user-chain load on miss. It hangs off the
+// UsernameLoader resolves FQUser -> display-name, integrating the two-tier
+// nameCache with a single-flighted user-chain load on miss. It hangs off the
 // GlobalContext so that all layers share it: team loads fill it whenever a
 // member's user chain is loaded, and RT sender-name resolution fills it on
 // demand.
-//
-// The cache is two-tiered: an in-memory map in front of the soft local DB
-// (scope: HostID; key: UID; value: utf8 username), so entries survive agent
-// restarts. It's soft state -- a failed read or write of the DB tier degrades
-// to a cache miss, never an error.
 //
 // Keys are fully-qualified (UID + HostID), not bare UIDs: the GlobalContext
 // spans all of the agent's active users, who may live on different hosts, and
 // the same eldest key -- hence the same UID -- can be signed up under different
 // usernames on different hosts.
 type UsernameLoader struct {
-	sync.RWMutex
-	m map[proto.FQUser]usernameCacheEntry
+	nameCache[proto.FQUser]
 
 	flightMu sync.Mutex
 	flights  map[proto.FQUser]*usernameFlight
+}
+
+func NewUsernameLoader() *UsernameLoader {
+	return &UsernameLoader{
+		nameCache: newNameCache(
+			lcl.DataType_UsernameCacheEntry,
+			func(fqu proto.FQUser) (Scoper, any) {
+				return &fqu.HostID, fqu.Uid
+			},
+		),
+	}
 }
 
 // Load returns the display name for fqu, trying the cache tiers and then
@@ -154,70 +135,4 @@ func (u *UsernameLoader) loadAndFill(
 		m.Warnw("UsernameLoader.loadAndFill", "stage", "cacheSet", "fqu", fqu, "err", err)
 	}
 	return nm, uw, nil
-}
-
-// Get returns a cached, unexpired display name for fqu, if any, trying the
-// memory tier and then the soft DB. A fresh DB hit warms the memory tier, with
-// its expiry anchored at the row's write time, so the ~TTL staleness bound
-// holds across both tiers.
-func (u *UsernameLoader) Get(m MetaContext, fqu proto.FQUser) (proto.NameUtf8, bool) {
-	if nm, ok := u.getMem(m, fqu); ok {
-		return nm, true
-	}
-	return u.getDb(m, fqu)
-}
-
-// Set records fqu -> name in both tiers, with a fresh jittered TTL. A DB-tier
-// write failure is returned but the memory tier is set regardless.
-func (u *UsernameLoader) Set(m MetaContext, fqu proto.FQUser, nm proto.NameUtf8) error {
-	u.putMem(fqu, nm, m.G().Now().Add(jitteredUsernameTTL()))
-	return m.DbPut(DbTypeSoft, PutArg{
-		Scope: &fqu.HostID,
-		Typ:   lcl.DataType_UsernameCacheEntry,
-		Key:   fqu.Uid,
-		Val:   &nm,
-	})
-}
-
-// getMem returns an unexpired entry from the memory tier. An expired entry is
-// reported as a miss but left in place rather than deleted (no lock upgrade);
-// the Set or DB-warm that follows a miss overwrites it.
-func (u *UsernameLoader) getMem(m MetaContext, fqu proto.FQUser) (proto.NameUtf8, bool) {
-	u.RLock()
-	defer u.RUnlock()
-	ent, ok := u.m[fqu]
-	if !ok || !m.G().Now().Before(ent.expiresAt) {
-		return "", false
-	}
-	return ent.name, true
-}
-
-func (u *UsernameLoader) putMem(fqu proto.FQUser, nm proto.NameUtf8, expiresAt time.Time) {
-	u.Lock()
-	defer u.Unlock()
-	if u.m == nil {
-		u.m = make(map[proto.FQUser]usernameCacheEntry)
-	}
-	u.m[fqu] = usernameCacheEntry{
-		name:      nm,
-		expiresAt: expiresAt,
-	}
-}
-
-func (u *UsernameLoader) getDb(m MetaContext, fqu proto.FQUser) (proto.NameUtf8, bool) {
-	var nm proto.NameUtf8
-	tm, err := m.DbGet(&nm, DbTypeSoft, &fqu.HostID,
-		lcl.DataType_UsernameCacheEntry, fqu.Uid)
-	if err != nil {
-		if !errors.Is(err, core.RowNotFoundError{}) {
-			m.Warnw("UsernameLoader.getDb", "fqu", fqu, "err", err)
-		}
-		return "", false
-	}
-	expiresAt := tm.Import().Add(jitteredUsernameTTL())
-	if !m.G().Now().Before(expiresAt) {
-		return "", false
-	}
-	u.putMem(fqu, nm, expiresAt)
-	return nm, true
 }

--- a/client/librt/app.go
+++ b/client/librt/app.go
@@ -15,12 +15,19 @@ type App struct {
 	sync.Mutex
 	parent *libclient.UserContext
 	teams  map[proto.FQTeam]*Minder
+	user   *Minder // team-independent flows (e.g. the inbox); lazily made
+
+	// One lock per appID serializes inbox syncs for this user (the App is a
+	// per-UserContext singleton), so concurrent syncs can't interleave their
+	// page applies -- even across Minders.
+	inboxSyncLocks map[proto.RTAppID]*sync.Mutex
 }
 
 func NewApp(u *libclient.UserContext) *App {
 	return &App{
-		parent: u,
-		teams:  make(map[proto.FQTeam]*Minder),
+		parent:         u,
+		teams:          make(map[proto.FQTeam]*Minder),
+		inboxSyncLocks: make(map[proto.RTAppID]*sync.Mutex),
 	}
 }
 func (k *App) Cleanup(m libclient.MetaContext) error { return nil }
@@ -56,6 +63,29 @@ func (a *App) Minder(m MetaContext, actingAs lcl.ConfigTeam) (*Minder, error) {
 	return ret, nil
 }
 
+// UserMinder returns the user-scoped Minder, for flows that aren't tied to any
+// one team -- like the inbox, which spans all of the user's teams. Per-team
+// parties are still loaded lazily through its BaseMinder as needed.
+func (a *App) UserMinder() *Minder {
+	a.Lock()
+	defer a.Unlock()
+	if a.user == nil {
+		a.user = NewMinder(a.parent)
+	}
+	return a.user
+}
+
+func (a *App) inboxSyncLock(appID proto.RTAppID) *sync.Mutex {
+	a.Lock()
+	defer a.Unlock()
+	lk := a.inboxSyncLocks[appID]
+	if lk == nil {
+		lk = &sync.Mutex{}
+		a.inboxSyncLocks[appID] = lk
+	}
+	return lk
+}
+
 func appFromMeta(m MetaContext) (*App, error) {
 	au, err := m.ActiveConnectedUser(&libclient.ACUOpts{AssertUnlocked: true})
 	if err != nil {
@@ -87,4 +117,19 @@ func InitReq(
 		return nil, err
 	}
 	return ret, nil
+}
+
+// InitUserReq is InitReq for user-scoped requests that don't act as any one
+// team, like inbox sync and render.
+func InitUserReq(
+	m MetaContext,
+) (
+	*Minder,
+	error,
+) {
+	app, err := appFromMeta(m)
+	if err != nil {
+		return nil, err
+	}
+	return app.UserMinder(), nil
 }

--- a/client/librt/inbox.go
+++ b/client/librt/inbox.go
@@ -1,0 +1,397 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package librt
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/team"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+)
+
+// The inbox syncer persists the inbox-version delta (issue #303) to local soft
+// SQLite so app starts render instantly/offline and resync incrementally from
+// the stored cursor instead of a since=0 full sync.
+//
+// Storage layout, all soft state under scope lcl.RTInboxScope{fqu, appID} (the
+// inbox is viewer-scoped state spanning many parties):
+//   - DataType_RTInboxChannel, key = channelID: one wire-shape rem.RTInboxChannel
+//     per channel, denormalized like the server's user_channels. The channel
+//     name/desc inside remain in their secretboxes -- plaintext never hits the
+//     local DB; LocalInbox decrypts at render time.
+//   - DataType_RTInboxSyncState, key = EmptyKey: the sync cursor plus the index
+//     of persisted channelIDs (the KV layer can't enumerate keys in a scope).
+//
+// Each page applies atomically (rows + cursor in one DbPutTx), with the cursor
+// advanced to the highest version *applied*, never the server-reported head --
+// a crash mid-multi-page sync resumes at the last applied page. Merge is
+// whole-row overwrite; server-side monotonicity makes the server copy win.
+// All of it is self-healing soft state: wiping it just costs a full resync.
+
+func (d *Minder) inboxScope(appID proto.RTAppID) lcl.RTInboxScope {
+	return lcl.RTInboxScope{Fqu: d.au.FQU(), AppID: appID}
+}
+
+func (d *Minder) dbGetInboxSyncState(
+	m MetaContext,
+	appID proto.RTAppID,
+) (
+	lcl.RTInboxSyncState,
+	error,
+) {
+	var ret lcl.RTInboxSyncState
+	scope := d.inboxScope(appID)
+	_, err := m.DbGet(&ret, libclient.DbTypeSoft, &scope,
+		lcl.DataType_RTInboxSyncState, core.EmptyKey{})
+	if errors.Is(err, core.RowNotFoundError{}) {
+		return lcl.RTInboxSyncState{}, nil // never synced; cursor 0 = full sync
+	}
+	if err != nil {
+		return ret, err
+	}
+	return ret, nil
+}
+
+// SyncInbox pages rtGetChangedThreads from the locally-stored cursor and
+// applies each page transactionally (channel rows + advanced cursor). Syncs
+// for the same (user × app) are serialized so they can't interleave. Returns
+// what changed: the post-sync cursor and how many channel rows were applied.
+func (d *Minder) SyncInbox(
+	m MetaContext,
+	appID proto.RTAppID,
+) (
+	*lcl.RTInboxSyncSummary,
+	error,
+) {
+	return d.SyncInboxWithPageSize(m, appID, 0)
+}
+
+// SyncInboxWithPageSize is SyncInbox with an explicit page size for the
+// underlying rtGetChangedThreads calls; 0 = server default. Tests use small
+// pages to exercise the per-page atomic apply and crash-resume cursor.
+func (d *Minder) SyncInboxWithPageSize(
+	m MetaContext,
+	appID proto.RTAppID,
+	pageSize uint64,
+) (
+	*lcl.RTInboxSyncSummary,
+	error,
+) {
+	app, err := GetApp(d.au)
+	if err != nil {
+		return nil, err
+	}
+	lk := app.inboxSyncLock(appID)
+	lk.Lock()
+	defer lk.Unlock()
+
+	scope := d.inboxScope(appID)
+	state, err := d.dbGetInboxSyncState(m, appID)
+	if err != nil {
+		return nil, err
+	}
+	indexed := make(map[proto.RTChannelID]struct{}, len(state.Channels))
+	for _, chid := range state.Channels {
+		indexed[chid] = struct{}{}
+	}
+
+	var numChanged uint64
+	for {
+		delta, err := d.GetChangedThreads(m, appID, state.Vers, pageSize)
+		if err != nil {
+			return nil, err
+		}
+		if len(delta.Channels) == 0 {
+			break
+		}
+		pageVers := state.Vers
+		args := make([]libclient.PutArg, 0, len(delta.Channels)+1)
+		for i := range delta.Channels {
+			ch := &delta.Channels[i]
+			if ch.InboxVersion > pageVers {
+				pageVers = ch.InboxVersion
+			}
+			if _, ok := indexed[ch.Md.Id]; !ok {
+				indexed[ch.Md.Id] = struct{}{}
+				state.Channels = append(state.Channels, ch.Md.Id)
+			}
+			args = append(args, libclient.PutArg{
+				Scope: &scope,
+				Typ:   lcl.DataType_RTInboxChannel,
+				Key:   ch.Md.Id,
+				Val:   ch,
+			})
+		}
+		// A page that doesn't advance the cursor would loop forever; the server
+		// guarantees returned bumps are strictly past `since`.
+		if pageVers <= state.Vers {
+			return nil, core.BadServerDataError("inbox delta did not advance the cursor")
+		}
+		state.Vers = pageVers
+		args = append(args, libclient.PutArg{
+			Scope: &scope,
+			Typ:   lcl.DataType_RTInboxSyncState,
+			Key:   core.EmptyKey{},
+			Val:   &state,
+		})
+		err = m.DbPutTx(libclient.DbTypeSoft, args)
+		if err != nil {
+			return nil, err
+		}
+		numChanged += uint64(len(delta.Channels))
+
+		// Prefetch each changed channel's last message into the local message
+		// cache, so LocalInbox can render a snippet without the network.
+		// Best-effort and after the page apply: the rows are already durable,
+		// and a failure just means no snippet until the channel next bumps.
+		for i := range delta.Channels {
+			ch := &delta.Channels[i]
+			if ch.Md.LastMsg == nil {
+				continue
+			}
+			err := d.prefetchLastMsg(m, ch)
+			if err != nil {
+				m.Warnw("SyncInbox", "stage", "prefetchLastMsg",
+					"chid", ch.Md.Id, "err", err)
+			}
+		}
+
+		// The head rides along on every page purely as a termination hint; it
+		// is never stored (there may be unapplied bumps at versions between the
+		// cursor and the head).
+		if state.Vers >= delta.InboxVersion {
+			break
+		}
+	}
+	return &lcl.RTInboxSyncSummary{Vers: state.Vers, NumChanged: numChanged}, nil
+}
+
+// LocalInbox renders the inbox for (user × app) entirely from local storage --
+// no network. Channel names/descs are decrypted at render time with the parent
+// team's keys; a row that can't be read anymore (lost access, left team) is
+// skipped rather than failing the render, since this is all soft state. Rows
+// come back newest bump first.
+func (d *Minder) LocalInbox(
+	m MetaContext,
+	appID proto.RTAppID,
+) (
+	*lcl.RTInboxView,
+	error,
+) {
+	scope := d.inboxScope(appID)
+	state, err := d.dbGetInboxSyncState(m, appID)
+	if err != nil {
+		return nil, err
+	}
+	ret := lcl.RTInboxView{Vers: state.Vers}
+	for _, chid := range state.Channels {
+		var row rem.RTInboxChannel
+		_, err := m.DbGet(&row, libclient.DbTypeSoft, &scope,
+			lcl.DataType_RTInboxChannel, chid)
+		if err != nil {
+			m.Warnw("LocalInbox", "stage", "dbGet", "chid", chid, "err", err)
+			continue
+		}
+		rv, err := d.renderInboxRow(m, &row)
+		if err != nil {
+			m.Warnw("LocalInbox", "stage", "render", "chid", chid, "err", err)
+			continue
+		}
+		ret.Rows = append(ret.Rows, *rv)
+	}
+	slices.SortFunc(ret.Rows, func(a, b lcl.RTInboxRowView) int {
+		return cmp.Compare(b.InboxVersion, a.InboxVersion)
+	})
+	return &ret, nil
+}
+
+// configTeamByID addresses a parent team by its ID, using the ad-hoc arm for
+// ad-hoc team IDs so resolution takes the ad-hoc path.
+func configTeamByID(teamID proto.TeamID) lcl.ConfigTeam {
+	if teamID.IsAdHocTeam() {
+		return lcl.NewConfigTeamWithAdhoc(proto.FQAdHocTeamParsed{
+			Team: proto.NewAdHocTeamParsedWithId(teamID.EntityID()),
+		})
+	}
+	return team.WrapNamed(proto.FQTeamParsed{
+		Team: proto.NewParsedTeamWithFalse(teamID),
+	})
+}
+
+func (d *Minder) maybePopulateTeamName(m MetaContext, fqt proto.FQTeam) proto.NameUtf8 {
+	nm, ok := m.G().TeamnameLoader().Get(m.Base(), fqt)
+	if !ok {
+		return ""
+	}
+	if !fqt.Team.IsAdHocTeam() {
+		return nm
+	}
+	nm, err := team.StripSelfFromAdHocName(nm, d.au.Info.Username.NameUtf8)
+	if err != nil {
+		m.Warnw("renderInboxRow", "stage", "stripSelfFromAdHocName", "err", err)
+		return proto.NameUtf8(fmt.Sprintf("<error in strip: %s>", err.Error()))
+	}
+	return nm
+}
+
+// renderInboxRow decrypts one stored inbox row into its view form, loading the
+// parent team's party (and keys) by ID via the shared party-loader cache.
+func (d *Minder) renderInboxRow(
+	m MetaContext,
+	row *rem.RTInboxChannel,
+) (
+	*lcl.RTInboxRowView,
+	error,
+) {
+	cfgTeam := configTeamByID(row.Md.ParentTeam)
+	rtp, err := d.base.GetParty(m.Base(), cfgTeam)
+	if err != nil {
+		return nil, err
+	}
+	md, err := d.decryptChannelMetadata(m, rtp, row.Md)
+	if err != nil {
+		return nil, err
+	}
+	ret := lcl.RTInboxRowView{
+		Ch:           *md,
+		InboxVersion: row.InboxVersion,
+		ReadThrough:  row.ReadThrough,
+		Hidden:       row.Hidden,
+		Muted:        row.Muted,
+	}
+
+	// Team display name, via the teamname cache -- the GetParty above fills it
+	// whenever it (re)loads the team, so a miss is rare and just falls back to
+	// the ID at the display layer. An ad-hoc team's cached name is its full
+	// member list; drop the viewer's own name for DM-style display.
+	fqt := proto.FQTeam{Team: row.Md.ParentTeam, Host: d.au.HostID()}
+
+	ret.TeamName = d.maybePopulateTeamName(m, fqt)
+
+	if row.Md.LastMsg != nil {
+		ret.LastSeq = row.Md.LastMsg.Seq
+		ret.LastTime = row.Md.LastMsg.InsertTime
+		if ret.LastSeq > ret.ReadThrough {
+			ret.NumUnread = uint64(ret.LastSeq - ret.ReadThrough)
+		}
+		d.fillSnippet(m, rtp, cfgTeam, row, &ret)
+	}
+	return &ret, nil
+}
+
+// fillSnippet decorates a row view with a decrypted one-line preview of the
+// channel's last message, plus its sender's display name, when the message is
+// in the local cache (SyncInbox prefetches it there). Best-effort: any failure
+// leaves the fields nil rather than failing the render.
+func (d *Minder) fillSnippet(
+	m MetaContext,
+	rtp *RTParty,
+	cfgTeam lcl.ConfigTeam,
+	row *rem.RTInboxChannel,
+	out *lcl.RTInboxRowView,
+) {
+	seq := row.Md.LastMsg.Seq
+	enc, err := dbGetMsgs(m, d.au, row.Md.Id, seq, seq)
+	if err != nil {
+		m.Warnw("fillSnippet", "stage", "dbGet", "chid", row.Md.Id, "err", err)
+		return
+	}
+	if len(enc) != 1 {
+		return // not cached; no snippet
+	}
+	msgs, err := d.decodeMsgs(m, rtp, row.Md.AppID, row.Md.Id, enc)
+	if err != nil || len(msgs) != 1 {
+		if err != nil {
+			m.Warnw("fillSnippet", "stage", "decode", "chid", row.Md.Id, "err", err)
+		}
+		return
+	}
+	msg := msgs[0]
+	sn := snippet(msg.Body)
+	out.Snippet = &sn
+	out.LastSender = d.resolveSenderNameFromPartyIDShowError(m, cfgTeam, rtp, msg.Sender)
+}
+
+// snippetMaxLen bounds the snippet payload shipped over the agent RPC; it is
+// NOT display policy. Rendering to an actual width (console, window) is the
+// view layer's job -- see the CLI's inbox table, which fits the snippet to the
+// live terminal width. This just keeps a pathological multi-KB message body
+// from riding along with every inbox render.
+const snippetMaxLen = 512
+
+// snippet reduces a message body to its first line, bounded by snippetMaxLen.
+func snippet(body []byte) string {
+	s := string(body)
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		s = s[:i]
+	}
+	if len(s) > snippetMaxLen {
+		cut := snippetMaxLen
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		s = s[:cut] + "…"
+	}
+	return s
+}
+
+// prefetchLastMsg ensures a channel's last message sits in the local message
+// cache, fetching (and verifying) it from the server when absent, so the inbox
+// can render last-message snippets offline.
+func (d *Minder) prefetchLastMsg(
+	m MetaContext,
+	row *rem.RTInboxChannel,
+) error {
+	seq := row.Md.LastMsg.Seq
+	cached, err := dbGetMsgs(m, d.au, row.Md.Id, seq, seq)
+	if err != nil {
+		return err
+	}
+	if len(cached) > 0 {
+		return nil
+	}
+	rtp, err := d.base.GetParty(m.Base(), configTeamByID(row.Md.ParentTeam))
+	if err != nil {
+		return err
+	}
+	pr, cli, err := d.clientLocal(m.Base(), d.au)
+	if err != nil {
+		return err
+	}
+	d.serverThreadReads.Add(1)
+	page, err := cli.RtGetThread(m.Ctx(), rem.RTThreadQuery{
+		ChannelID: row.Md.Id,
+		Seqs:      []proto.RTMsgSeq{seq},
+	})
+	if err != nil {
+		return err
+	}
+	d.hookReadRes(&page)
+	sess := newMsgSession()
+	err = sess.loadFromServer(extractAllSeqIDPairsFromRTThreadPage(&page))
+	if err != nil {
+		return err
+	}
+	// The decode path only consults ch.Id from the request metadata, so a stub
+	// with just the ID suffices; the full decrypted channel metadata isn't
+	// needed to verify and cache a message.
+	irr := &initReqResult{
+		hostId: pr.Chain().HostID(),
+		rtp:    rtp,
+		appID:  row.Md.AppID,
+		cli:    cli,
+		ch:     &lcl.RTChannelMetadataPlaintext{Id: row.Md.Id},
+	}
+	_, err = d.decodeAndCacheServerMsgs(m, sess, irr, page.SeqMsgs)
+	return err
+}

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -1274,42 +1274,22 @@ func (d *Minder) initReq(
 	}, nil
 }
 
-// TeamViewToken returns the team's view bearer token, used for AsLocalTeam user
-// loads. The agent uses it to resolve message-sender UIDs to usernames: in
-// closed viewership mode, co-members can only load each other mediated through
-// the shared team, not directly. Returns nil if the team carries no view token
-// (e.g. it was loaded as self/owner); callers should treat name resolution as
-// best-effort and tolerate a nil token.
-func (d *Minder) TeamViewToken(
-	m MetaContext,
-	team lcl.ConfigTeam,
-) (
-	*rem.TeamVOBearerToken,
-	error,
-) {
-	err := assertTeam(team)
-	if err != nil {
-		return nil, err
-	}
-	rtp, err := d.base.GetParty(m.Base(), team)
-	if err != nil {
-		return nil, err
-	}
-	return rtp.PLCNode().ViewTok(), nil
-}
-
 // ResolveSenderNames maps each distinct user-sender UID in msgs to its display
 // name. Resolutions are memoized (see libclient.UsernameLoader) since each cache
 // miss is a full user-chain load; in closed viewership mode the load is mediated
-// through the shared team, so a team view bearer token (tok) is presented.
-// Best-effort: a sender that can't be loaded is omitted from the result rather
-// than failing.
+// through the shared team, presenting the team's view bearer token -- read
+// fresh from rtp's shared PLCNode per sender (see resolveSenderName), so a
+// mid-loop token refresh benefits every later sender. Best-effort: a sender
+// that can't be loaded is omitted from the result rather than failing.
 func (d *Minder) ResolveSenderNames(
 	m MetaContext,
 	team lcl.ConfigTeam,
-	tok *rem.TeamVOBearerToken,
+	rtp *RTParty,
 	msgs []ThreadMessage,
-) map[proto.UID]proto.NameUtf8 {
+) (
+	map[proto.UID]proto.NameUtf8,
+	error,
+) {
 	ret := make(map[proto.UID]proto.NameUtf8)
 	for i := range msgs {
 		sender := msgs[i].Sender
@@ -1318,16 +1298,50 @@ func (d *Minder) ResolveSenderNames(
 		}
 		uid, err := sender.UID()
 		if err != nil {
-			continue
+			return nil, err
 		}
 		if _, ok := ret[uid]; ok {
 			continue
 		}
-		if nm, ok := d.resolveSenderName(m, team, tok, uid); ok {
-			ret[uid] = nm
-		}
+		ret[uid] = d.resolveSenderNameFromUIDShowError(m, team, rtp, uid)
 	}
-	return ret
+	return ret, nil
+}
+
+func fmtNameUtf8Error(err error) proto.NameUtf8 {
+	return proto.NameUtf8(fmt.Sprintf("<error: %s>", err.Error()))
+}
+
+func (d *Minder) resolveSenderNameFromUIDShowError(
+	m MetaContext,
+	team lcl.ConfigTeam,
+	rtp *RTParty,
+	uid proto.UID,
+) proto.NameUtf8 {
+	nm, err := d.resolveSenderName(m, team, rtp, uid)
+	if err != nil {
+		return fmtNameUtf8Error(err)
+	}
+	return nm
+}
+
+func (d *Minder) resolveSenderNameFromPartyIDShowError(
+	m MetaContext,
+	team lcl.ConfigTeam,
+	rtp *RTParty,
+	partyID *proto.PartyID,
+) proto.NameUtf8 {
+	if partyID == nil {
+		return "<nil>"
+	}
+	if !partyID.IsUser() {
+		return "<non-user>"
+	}
+	uid, err := partyID.UID()
+	if err != nil {
+		return fmtNameUtf8Error(err)
+	}
+	return d.resolveSenderNameFromUIDShowError(m, team, rtp, uid)
 }
 
 // resolveSenderName returns the display name for a single sender UID, via the
@@ -1337,12 +1351,22 @@ func (d *Minder) ResolveSenderNames(
 // (open-vhost-or-as-local-user), which resolves symmetrically for any
 // co-member; named teams use the team-mediated (AsLocalTeam) load via the VO
 // bearer token.
+//
+// The token is read from rtp's PLCNode at call time, not taken as a parameter:
+// a cached token can go stale inside the team-cache freshness window (e.g. the
+// caller's own role in the team just changed), and the recovery below refreshes
+// the shared node in place -- so one refresh heals every subsequent resolve
+// against the same team, rather than each sender re-tripping on a stale
+// snapshot.
 func (d *Minder) resolveSenderName(
 	m MetaContext,
 	team lcl.ConfigTeam,
-	tok *rem.TeamVOBearerToken,
+	rtp *RTParty,
 	uid proto.UID,
-) (proto.NameUtf8, bool) {
+) (
+	proto.NameUtf8,
+	error,
+) {
 	// The loader is keyed by FQUser; senders are always on the active user's
 	// host (see decryptAndVerifyMsg's HostMismatchError check).
 	fqu := proto.FQUser{Uid: uid, HostID: d.au.HostID()}
@@ -1350,17 +1374,45 @@ func (d *Minder) resolveSenderName(
 	if typ, err := team.GetT(); err == nil && typ == lcl.ConfigTeamType_AdHoc {
 		loadMode = libclient.LoadModeForAdHoc
 	}
-	nm, _, err := m.G().UsernameLoader().Load(m.Base(), fqu,
-		libclient.LoadUserArg{
-			Uid:               uid,
-			LoadMode:          loadMode,
-			TeamVOBearerToken: tok,
-		})
-	if err != nil {
-		m.Warnw("resolveSenderName", "uid", uid, "err", err)
-		return "", false
+	load := func(tok *rem.TeamVOBearerToken) (proto.NameUtf8, error) {
+		nm, _, err := m.G().UsernameLoader().Load(m.Base(), fqu,
+			libclient.LoadUserArg{
+				Uid:               uid,
+				LoadMode:          loadMode,
+				TeamVOBearerToken: tok,
+			})
+		return nm, err
 	}
-	return nm, true
+	tok := rtp.PLCNode().ViewTok()
+	nm, err := load(tok)
+	if err == nil {
+		return nm, nil
+	}
+	var staleErr core.TeamBearerTokenStaleError
+	if !errors.As(err, &staleErr) {
+		m.Warnw("resolveSenderName", "stage", "nonStale", "uid", uid, "err", err)
+		return "", err
+	}
+	// Stale token. If a concurrent resolve already refreshed the team, the
+	// shared node holds a new token -- just use it. Otherwise force one
+	// refresh; it lands in the node, so later resolves fast-path. ViewTok
+	// returns a fresh copy per call, so compare by value (nil = no token).
+	if fresh := rtp.PLCNode().ViewTok(); !fresh.Eq(tok) {
+		tok = fresh
+	} else {
+		rtp, err := d.base.GetPartyForceRefresh(m.Base(), team)
+		if err != nil {
+			m.Warnw("resolveSenderName", "stage", "staleRefresh", "uid", uid, "err", err)
+			return "", err
+		}
+		tok = rtp.PLCNode().ViewTok()
+	}
+	nm, err = load(tok)
+	if err != nil {
+		m.Warnw("resolveSenderName", "stage", "staleRetry", "uid", uid, "err", err)
+		return "", err
+	}
+	return nm, nil
 }
 
 // if inc > 1, sort ascending
@@ -1627,15 +1679,34 @@ func (d *Minder) GetThreadView(
 	if err != nil {
 		return nil, err
 	}
-	tok, err := d.TeamViewToken(m, team)
+	rtp, err := d.base.GetParty(m.Base(), team)
 	if err != nil {
 		return nil, err
 	}
-	names := d.ResolveSenderNames(m, team, tok, msgs)
+	names, err := d.ResolveSenderNames(m, team, rtp, msgs)
+	if err != nil {
+		return nil, err
+	}
 
 	ret := lcl.RTThreadView{AtBeginning: atBeginning}
 	for i := range msgs {
 		ret.Msgs = append(ret.Msgs, threadMessageToView(&msgs[i], names))
+	}
+
+	// Viewing a page implies reading it: advance the read pointer to the
+	// newest message shown, so unread counts (and the viewer's other devices)
+	// catch up on the next inbox sync. The pointer is monotonic server-side --
+	// stale marks no-op -- so paging back through history never regresses it.
+	// Best-effort: the read itself already succeeded.
+	if len(msgs) > 0 {
+		maxSeq := msgs[0].Seq
+		for i := range msgs[1:] {
+			maxSeq = max(maxSeq, msgs[i+1].Seq)
+		}
+		err = d.ReadThrough(m, team, appID, channel, maxSeq)
+		if err != nil {
+			m.Warnw("GetThreadView", "stage", "readThrough", "err", err)
+		}
 	}
 	return &ret, nil
 }

--- a/integration-tests/cli/rt_test.go
+++ b/integration-tests/cli/rt_test.go
@@ -102,6 +102,23 @@ func TestRTAdHocTeamSendAndReceive(t *testing.T) {
 	msgFromBob := "thanks alice, glad to be here"
 	bob.runCmd(t, nil, "rt", "send", "--adhoc", string(aliceName), msgFromBob)
 
+	// Before alice reads the reply, her inbox counts it as unread: her own
+	// message was implicitly read by sending it, but bob's reply is news.
+	expectTeam := func(other proto.NameUtf8) proto.NameUtf8 {
+		s, err := team.NamesToAdhHocCanonicalString([]proto.NameUtf8{other}, "")
+		require.NoError(t, err)
+		return proto.NameUtf8(s)
+	}
+	var ainbox lcl.RTInboxView
+	alice.runCmdToJSON(t, &ainbox, "rt", "inbox")
+	require.Len(t, ainbox.Rows, 1)
+	arow := ainbox.Rows[0]
+	require.Equal(t, expectTeam(bobName), arow.TeamName)
+	require.Equal(t, uint64(1), arow.NumUnread)
+	require.NotNil(t, arow.Snippet)
+	require.Equal(t, msgFromBob, *arow.Snippet)
+	require.Equal(t, bobName, arow.LastSender)
+
 	alice.runCmdToJSON(t, &thread, "rt", "read", "--adhoc", string(bobName))
 	require.Len(t, thread.Msgs, 2)
 	require.Equal(t, msgFromBob, string(thread.Msgs[0].Body))
@@ -110,6 +127,24 @@ func TestRTAdHocTeamSendAndReceive(t *testing.T) {
 	require.Equal(t, msgFromAlice, string(thread.Msgs[1].Body))
 	require.NotNil(t, thread.Msgs[1].SenderName)
 	require.Equal(t, aliceName, *thread.Msgs[1].SenderName)
+
+	// Reading the thread marked it read (viewing a page advances the read
+	// pointer), so alice's unread count clears. The inbox renders the ad-hoc
+	// team DM-style throughout: each viewer sees the *other* member's name --
+	// not their own, and not the raw team ID.
+	alice.runCmdToJSON(t, &ainbox, "rt", "inbox")
+	require.Len(t, ainbox.Rows, 1)
+	require.Equal(t, uint64(0), ainbox.Rows[0].NumUnread)
+	require.Equal(t, proto.RTMsgSeq(2), ainbox.Rows[0].ReadThrough)
+
+	// bob sent the last message (sending implies reading), so nothing is
+	// unread for him either.
+	var binbox lcl.RTInboxView
+	bob.runCmdToJSON(t, &binbox, "rt", "inbox")
+	require.Len(t, binbox.Rows, 1)
+	brow := binbox.Rows[0]
+	require.Equal(t, expectTeam(aliceName), brow.TeamName)
+	require.Equal(t, uint64(0), brow.NumUnread)
 }
 
 // TestRTChannelMakeAndList exercises the CLI integration for making channels
@@ -210,6 +245,39 @@ func TestRTSendAndRead(t *testing.T) {
 	// Sending to a non-existent channel should fail.
 	err := b.runCmdErr(nil, "rt", "send", "-t", tm, "--channel", "nope", "lost message")
 	require.Error(t, err)
+
+	// `rt inbox` syncs the inbox to local storage and renders it from there:
+	// one row for #foo showing the team's name (not its ID) and a snippet of
+	// the last message. Nothing is unread -- every message is bob's own, and
+	// sending implies reading. --local-only skips the sync and must render
+	// identically from disk alone.
+	var inbox lcl.RTInboxView
+	b.runCmdToJSON(t, &inbox, "rt", "inbox")
+	require.Len(t, inbox.Rows, 1)
+	require.Equal(t, proto.RTChannelName("foo"), inbox.Rows[0].Ch.Name)
+	require.Equal(t, proto.RTMsgSeq(3), inbox.Rows[0].LastSeq)
+	require.Equal(t, proto.RTMsgSeq(3), inbox.Rows[0].ReadThrough)
+	require.Equal(t, uint64(0), inbox.Rows[0].NumUnread)
+	require.Equal(t, proto.NameUtf8(tm), inbox.Rows[0].TeamName)
+	require.NotNil(t, inbox.Rows[0].Snippet)
+	require.Equal(t, "a third one", *inbox.Rows[0].Snippet)
+	require.Equal(t, bob.username, inbox.Rows[0].LastSender)
+
+	var inbox2 lcl.RTInboxView
+	b.runCmdToJSON(t, &inbox2, "rt", "inbox", "--local-only")
+	require.Equal(t, inbox, inbox2)
+
+	// The text renderer shows the channel, the team name, and the snippet.
+	var terminalUI terminalUI
+	uis := libclient.UIs{
+		Terminal: &terminalUI,
+	}
+	err = b.runCmdErrWithUIs(uis, "rt", "inbox")
+	require.NoError(t, err)
+	out := terminalUI.String()
+	require.Contains(t, out, "#foo")
+	require.Contains(t, out, tm)
+	require.Contains(t, out, "a third one")
 }
 
 // TestRTSendAndReadCrossMember verifies sender-name resolution across two

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -1014,6 +1014,15 @@ func TestRTSendReadPermissions(t *testing.T) {
 		return v
 	}
 
+	// Sending implies reading: the send fanout stamped each sender's own read
+	// pointer at their message (no extra version bump -- see above), so a
+	// member's own messages never count against their unread badge. Recipients'
+	// pointers are untouched.
+	require.Equal(t, int64(1), ucRead(coco, chWatercooler))
+	require.Equal(t, int64(1), ucRead(bluey, chAnnounce))
+	require.Equal(t, int64(0), ucRead(bluey, chWatercooler))
+	require.Equal(t, int64(0), ucRead(coco, chAnnounce))
+
 	// coco marks announce read through its one message: her read pointer
 	// advances, her global inbox version bumps, and the announce row is
 	// stamped at the new version -- just like a delivery -- so her other
@@ -1093,12 +1102,13 @@ func TestRTSendReadPermissions(t *testing.T) {
 
 	// coco's full sync (since=0): both channels she's fanned into, oldest bump
 	// first; brass never appears (she was never fanned in, and it's admin-tier
-	// besides). Announce carries her read receipt.
+	// besides). Announce carries her explicit read receipt; watercooler carries
+	// the implicit one from her own send (sending implies reading).
 	delta, err := minderCoco.GetChangedThreads(mc, proto.RTAppID_Chat, 0, 0)
 	require.NoError(t, err)
 	require.Equal(t, proto.RTInboxVersion(5), delta.InboxVersion)
 	require.Equal(t, []row{
-		{id: *chWatercooler, vers: 3, read: 0, last: true},
+		{id: *chWatercooler, vers: 3, read: 1, last: true},
 		{id: *chAnnounce, vers: 5, read: 1, last: true},
 	}, summarize(delta))
 
@@ -1114,6 +1124,68 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.Equal(t, proto.RTInboxVersion(5), delta.InboxVersion)
 	require.Empty(t, delta.Channels)
 
+	// --- inbox persistence (#303) ---
+
+	// One assertable summary per locally-rendered inbox row. The name field
+	// proves the render decrypted the stored (still-boxed) channel metadata;
+	// team proves the teamname cache resolved the parent-team ID; snippet and
+	// sender prove the last message was prefetched into the local message
+	// cache, decrypted at render, and its sender's name resolved.
+	type irow struct {
+		id      proto.RTChannelID
+		name    proto.RTChannelName
+		vers    proto.RTInboxVersion
+		read    proto.RTMsgSeq
+		lastSeq proto.RTMsgSeq
+		unread  uint64
+		team    proto.NameUtf8
+		snippet string
+		sender  proto.NameUtf8
+	}
+	summarizeView := func(v *lcl.RTInboxView) []irow {
+		var out []irow
+		for _, r := range v.Rows {
+			ir := irow{
+				id:      r.Ch.Id,
+				name:    r.Ch.Name,
+				vers:    r.InboxVersion,
+				read:    r.ReadThrough,
+				lastSeq: r.LastSeq,
+				unread:  r.NumUnread,
+			}
+			if !r.TeamName.IsZero() {
+				ir.team = r.TeamName
+			}
+			if r.Snippet != nil {
+				ir.snippet = *r.Snippet
+			}
+			if !r.LastSender.IsZero() {
+				ir.sender = r.LastSender
+			}
+			out = append(out, ir)
+		}
+		return out
+	}
+
+	// coco persists her inbox to local soft storage: the full sync applies both
+	// channel rows and lands the cursor at her head. The local render -- a pure
+	// disk read -- computes unread = lastSeq - readThrough per channel and
+	// returns rows newest bump first. Nothing is unread: announce she marked
+	// read explicitly, and watercooler's only message is her own.
+	csum, err := minderCoco.SyncInbox(mc, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(5), csum.Vers)
+	require.Equal(t, uint64(2), csum.NumChanged)
+	cview, err := minderCoco.LocalInbox(mc, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(5), cview.Vers)
+	require.Equal(t, []irow{
+		{id: *chAnnounce, name: "announce", vers: 5, read: 1, lastSeq: 1, unread: 0,
+			team: tm.nm, snippet: "official notice", sender: bluey.name},
+		{id: *chWatercooler, name: "watercooler", vers: 3, read: 1, lastSeq: 1, unread: 0,
+			team: tm.nm, snippet: "hi all", sender: coco.name},
+	}, summarizeView(cview))
+
 	// bluey's full sync: all three channels, oldest bump first. brass has no
 	// messages, so no last-message preview.
 	delta, err = minderBluey.GetChangedThreads(mb, proto.RTAppID_Chat, 0, 0)
@@ -1121,7 +1193,7 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.Equal(t, proto.RTInboxVersion(6), delta.InboxVersion)
 	require.Equal(t, []row{
 		{id: *chBrass, vers: 3, read: 0, last: false},
-		{id: *chAnnounce, vers: 5, read: 0, last: true},
+		{id: *chAnnounce, vers: 5, read: 1, last: true},
 		{id: *chWatercooler, vers: 6, read: 1, last: true},
 	}, summarize(delta))
 
@@ -1133,7 +1205,7 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.Equal(t, proto.RTInboxVersion(6), delta.InboxVersion)
 	require.Equal(t, []row{
 		{id: *chBrass, vers: 3, read: 0, last: false},
-		{id: *chAnnounce, vers: 5, read: 0, last: true},
+		{id: *chAnnounce, vers: 5, read: 1, last: true},
 	}, summarize(delta))
 	delta, err = minderBluey.GetChangedThreads(mb, proto.RTAppID_Chat, 5, 2)
 	require.NoError(t, err)
@@ -1154,6 +1226,15 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, proto.RTInboxVersion(5), delta.InboxVersion)
 	require.Empty(t, delta.Channels)
+
+	// coco's persisted rows are now stranded locally (there are no tombstones,
+	// per the accepted-staleness notes in #303); re-syncing is an incremental
+	// no-op -- the server returns nothing for her and the stored cursor stays
+	// put rather than resetting to a full sync.
+	csum, err = minderCoco.SyncInbox(mc, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(5), csum.Vers)
+	require.Equal(t, uint64(0), csum.NumChanged)
 
 	// --- long poll ---
 
@@ -1291,6 +1372,91 @@ func TestRTSendReadPermissions(t *testing.T) {
 
 	// And nobody else's inbox moved.
 	require.Equal(t, int64(7), uiVers(bluey))
+
+	// --- inbox persistence, continued ---
+
+	// bluey's full sync persists all three channels in one page.
+	bsum, err := minderBluey.SyncInbox(mb, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(7), bsum.Vers)
+	require.Equal(t, uint64(3), bsum.NumChanged)
+
+	// Nothing is unread for bluey: the last message in each nonempty channel is
+	// her own, and sending stamps the sender's read pointer.
+	expectedBluey := []irow{
+		{id: *chWatercooler, name: "watercooler", vers: 7, read: 2, lastSeq: 2, unread: 0,
+			team: tm.nm, snippet: "wake up", sender: bluey.name},
+		{id: *chAnnounce, name: "announce", vers: 5, read: 1, lastSeq: 1, unread: 0,
+			team: tm.nm, snippet: "official notice", sender: bluey.name},
+		{id: *chBrass, name: "brass", vers: 3, read: 0, lastSeq: 0, unread: 0,
+			team: tm.nm},
+	}
+	bview, err := minderBluey.LocalInbox(mb, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(7), bview.Vers)
+	require.Equal(t, expectedBluey, summarizeView(bview))
+
+	// The render is served from disk: a fresh Minder with no warm state shows
+	// the same inbox, and re-syncing from the persisted cursor is a no-op
+	// rather than a since=0 full sync.
+	minderBluey2 := librt.NewMinder(mb.G().ActiveUser())
+	bview, err = minderBluey2.LocalInbox(mb, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, expectedBluey, summarizeView(bview))
+	bsum, err = minderBluey2.SyncInbox(mb, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(7), bsum.Vers)
+	require.Equal(t, uint64(0), bsum.NumChanged)
+
+	// New activity re-fetches exactly the bumped row on the next incremental
+	// sync; the merge is whole-row overwrite, so announce jumps to the new
+	// version/lastSeq while the other rows are untouched.
+	_, err = minderBluey.Send(mb, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString("announce"), []byte("second notice"))
+	require.NoError(t, err)
+	bsum, err = minderBluey.SyncInbox(mb, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(8), bsum.Vers)
+	require.Equal(t, uint64(1), bsum.NumChanged)
+	bview, err = minderBluey.LocalInbox(mb, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, []irow{
+		{id: *chAnnounce, name: "announce", vers: 8, read: 2, lastSeq: 2, unread: 0,
+			team: tm.nm, snippet: "second notice", sender: bluey.name},
+		{id: *chWatercooler, name: "watercooler", vers: 7, read: 2, lastSeq: 2, unread: 0,
+			team: tm.nm, snippet: "wake up", sender: bluey.name},
+		{id: *chBrass, name: "brass", vers: 3, read: 0, lastSeq: 0, unread: 0,
+			team: tm.nm},
+	}, summarizeView(bview))
+
+	// dave syncs with page size 1: each page applies its rows and advances the
+	// cursor in one transaction (a crash mid-sync resumes at the last applied
+	// page), and the paged result matches what a single-shot sync stores. His
+	// announce row took bluey's send above, so it sits at his head.
+	dsum, err := minderDave.SyncInboxWithPageSize(mdv, proto.RTAppID_Chat, 1)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(5), dsum.Vers)
+	require.Equal(t, uint64(3), dsum.NumChanged)
+	// The announce/watercooler backfill versions were allocated in channel-ID
+	// order (channel IDs are random), so compute watercooler's expected slot.
+	wcVers := proto.RTInboxVersion(2)
+	if chWatercooler == first {
+		wcVers = 1
+	}
+	dview, err := minderDave.LocalInbox(mdv, proto.RTAppID_Chat)
+	require.NoError(t, err)
+	require.Equal(t, proto.RTInboxVersion(5), dview.Vers)
+	// dave's unread counts are real: bluey wrote the last messages, and dave has
+	// only read announce through seq 1. His sync prefetched messages he never
+	// read into his local cache, so the snippets render from disk.
+	require.Equal(t, []irow{
+		{id: *chAnnounce, name: "announce", vers: 5, read: 1, lastSeq: 2, unread: 1,
+			team: tm.nm, snippet: "second notice", sender: bluey.name},
+		{id: *chBrass, name: "brass", vers: 4, read: 0, lastSeq: 0, unread: 0,
+			team: tm.nm},
+		{id: *chWatercooler, name: "watercooler", vers: wcVers, read: 0, lastSeq: 2, unread: 2,
+			team: tm.nm, snippet: "wake up", sender: bluey.name},
+	}, summarizeView(dview))
 }
 
 // TestRTSendEncryptionRole checks that the server rejects a message encrypted

--- a/integration-tests/lib/team_adhoc_test.go
+++ b/integration-tests/lib/team_adhoc_test.go
@@ -207,7 +207,7 @@ func TestSimpleCreateTeamAdHoc(t *testing.T) {
 	// The cache is two-tiered; the bottom tier is the soft local DB. A fresh
 	// cache with an empty memory tier must still resolve via the DB row that
 	// the Set above just wrote.
-	var uc2 libclient.UsernameLoader
+	uc2 := libclient.NewUsernameLoader()
 	nm2, ok := uc2.Get(f.ma, bobFqu)
 	require.True(t, ok)
 	require.Equal(t, bob.name, nm2)

--- a/lib/team/adhoc.go
+++ b/lib/team/adhoc.go
@@ -120,6 +120,35 @@ func NamesToAdhHocCanonicalString(
 	), nil
 }
 
+// StripSelfFromAdHocName drops the viewer's own username from a canonical
+// ad-hoc member-name list ("alice,bob,charlie" -> "bob,charlie" for alice),
+// for DM-style display of ad-hoc teams. A name that doesn't parse, or a list
+// that would strip to nothing (a solo team), is returned unchanged.
+func StripSelfFromAdHocName(
+	nm proto.NameUtf8,
+	self proto.NameUtf8,
+) (
+	proto.NameUtf8,
+	error,
+) {
+	selfNorm, err := core.NormalizeName(self)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(nm.String(), ",")
+	kept := make([]string, 0, len(parts))
+	for _, p := range parts {
+		// Canonical lists hold normalized names, so direct comparison works.
+		if !proto.Name(p).Eq(selfNorm) {
+			kept = append(kept, p)
+		}
+	}
+	if len(kept) == 0 || len(kept) == len(parts) {
+		return nm, nil
+	}
+	return proto.NameUtf8(strings.Join(kept, ",")), nil
+}
+
 func UIDsToAdhHocCanonicalString(
 	uids []proto.UID,
 	uid proto.UID,

--- a/proto-src/lcl/db.snowp
+++ b/proto-src/lcl/db.snowp
@@ -24,6 +24,7 @@ enum DataType {
     UsernameReservation @14;
     UsernameLookup @15;
     UsernameCacheEntry @16; // soft-state UID -> username memo; see libclient.UsernameLoader
+    TeamnameCacheEntry @17; // soft-state TeamID -> teamname memo; see libclient.TeamnameLoader
 
     KVRealm @65;
     KVNSRoot @66;
@@ -38,6 +39,8 @@ enum DataType {
     RTThreadMsgData @97;
     RTOutboxMsg @98;
     RTChannelSet @99;
+    RTInboxSyncState @100; // cursor + channelID index; see librt inbox syncer
+    RTInboxChannel @101;   // one rem.RTInboxChannel row per channel
 }
 
 typedef ScopeLabel = Blob;

--- a/proto-src/lcl/realtime.snowp
+++ b/proto-src/lcl/realtime.snowp
@@ -58,6 +58,50 @@ struct RTChannelSetForTeam {
     team @3 : lib.TeamID;
 }
 
+// DB scope for locally-persisted inbox sync state: the inbox is viewer-scoped
+// state spanning many parties, so it's keyed by the viewing user plus the app.
+struct RTInboxScope {
+    fqu @0 : lib.FQUser;
+    appID @1 : lib.RTAppID;
+}
+
+// Singleton row (per RTInboxScope) holding the inbox sync cursor and the index
+// of channels with persisted RTInboxChannel rows. The KV layer can't enumerate
+// keys within a scope, hence the explicit index; it's small (channel counts are
+// modest in Stage 1a) and is updated atomically with the rows it indexes.
+struct RTInboxSyncState {
+    vers @0 : lib.RTInboxVersion;         // highest inbox version *applied* locally
+    channels @1 : List(lib.RTChannelID);  // channels with a persisted row
+}
+
+// One decrypted inbox channel as presented to the CLI / app layer.
+struct RTInboxRowView {
+    ch @0 : RTChannelMetadataPlaintext;
+    inboxVersion @1 : lib.RTInboxVersion; // version at which this channel last bumped
+    readThrough @2 : lib.RTMsgSeq;        // viewer's read pointer; 0 = nothing read
+    lastSeq @3 : lib.RTMsgSeq;            // last message in channel; 0 = no messages
+    lastTime @4 : lib.Time;               // server insert time of last message; 0 if none
+    numUnread @5 : Uint;                  // max(lastSeq - readThrough, 0)
+    hidden @6 : Bool;
+    muted @7 : Bool;
+    teamName @8 : lib.NameUtf8;           // via the teamname cache; empty if unresolved
+    snippet @9 : Option(Text);            // first line of the last message, decrypted at render;
+                                          // nil if the message isn't in the local cache
+    lastSender @10 : lib.NameUtf8;        // last message's sender; empty if unresolved
+}
+
+// The viewer's inbox, rendered entirely from local storage.
+struct RTInboxView {
+    rows @0 : List(RTInboxRowView);       // newest bump first
+    vers @1 : lib.RTInboxVersion;         // local sync cursor
+}
+
+// What a SyncInbox pass did.
+struct RTInboxSyncSummary {
+    vers @0 : lib.RTInboxVersion;         // cursor after the sync
+    numChanged @1 : Uint;                 // channel rows applied
+}
+
 // A decrypted message as presented to the CLI / app layer.
 struct RTMsgView {
     seq @0 : lib.RTMsgSeq;
@@ -101,6 +145,11 @@ protocol RealTime
         num @1 : Uint,          /* max messages in the page; 0 = default */
         before @2 : lib.RTMsgSeq /* page messages older than this seq (exclusive); 0 = most recent */
     ) -> RTThreadView;
+
+    clientRTInboxView @4 (
+        appID @0 : lib.RTAppID,
+        localOnly @1 : Bool     /* skip the network sync; render from disk only */
+    ) -> RTInboxView;
 
 }
 

--- a/proto/lcl/db.go
+++ b/proto/lcl/db.go
@@ -65,6 +65,7 @@ const (
 	DataType_UsernameReservation  DataType = 14
 	DataType_UsernameLookup       DataType = 15
 	DataType_UsernameCacheEntry   DataType = 16
+	DataType_TeamnameCacheEntry   DataType = 17
 	DataType_KVRealm              DataType = 65
 	DataType_KVNSRoot             DataType = 66
 	DataType_KVDir                DataType = 67
@@ -77,6 +78,8 @@ const (
 	DataType_RTThreadMsgData      DataType = 97
 	DataType_RTOutboxMsg          DataType = 98
 	DataType_RTChannelSet         DataType = 99
+	DataType_RTInboxSyncState     DataType = 100
+	DataType_RTInboxChannel       DataType = 101
 )
 
 var DataTypeMap = map[string]DataType{
@@ -96,6 +99,7 @@ var DataTypeMap = map[string]DataType{
 	"UsernameReservation":  14,
 	"UsernameLookup":       15,
 	"UsernameCacheEntry":   16,
+	"TeamnameCacheEntry":   17,
 	"KVRealm":              65,
 	"KVNSRoot":             66,
 	"KVDir":                67,
@@ -108,36 +112,41 @@ var DataTypeMap = map[string]DataType{
 	"RTThreadMsgData":      97,
 	"RTOutboxMsg":          98,
 	"RTChannelSet":         99,
+	"RTInboxSyncState":     100,
+	"RTInboxChannel":       101,
 }
 var DataTypeRevMap = map[DataType]string{
-	0:  "None",
-	1:  "YubiKey",
-	3:  "TreeLocation",
-	4:  "MerkleRootByHash",
-	5:  "MerkleRootHashByEpno",
-	6:  "MerkleLatestEpno",
-	7:  "Hostchain",
-	8:  "SharedKeyCacheEntry",
-	9:  "UserSigchainState",
-	10: "SubkeyBox",
-	11: "User",
-	12: "GenericChainState",
-	13: "TeamChainState",
-	14: "UsernameReservation",
-	15: "UsernameLookup",
-	16: "UsernameCacheEntry",
-	65: "KVRealm",
-	66: "KVNSRoot",
-	67: "KVDir",
-	68: "KVDirent",
-	69: "KVFileHeader",
-	70: "KVFileChunk",
-	71: "KVNSName",
-	72: "KVSymlink",
-	73: "KVGitRefSet",
-	97: "RTThreadMsgData",
-	98: "RTOutboxMsg",
-	99: "RTChannelSet",
+	0:   "None",
+	1:   "YubiKey",
+	3:   "TreeLocation",
+	4:   "MerkleRootByHash",
+	5:   "MerkleRootHashByEpno",
+	6:   "MerkleLatestEpno",
+	7:   "Hostchain",
+	8:   "SharedKeyCacheEntry",
+	9:   "UserSigchainState",
+	10:  "SubkeyBox",
+	11:  "User",
+	12:  "GenericChainState",
+	13:  "TeamChainState",
+	14:  "UsernameReservation",
+	15:  "UsernameLookup",
+	16:  "UsernameCacheEntry",
+	17:  "TeamnameCacheEntry",
+	65:  "KVRealm",
+	66:  "KVNSRoot",
+	67:  "KVDir",
+	68:  "KVDirent",
+	69:  "KVFileHeader",
+	70:  "KVFileChunk",
+	71:  "KVNSName",
+	72:  "KVSymlink",
+	73:  "KVGitRefSet",
+	97:  "RTThreadMsgData",
+	98:  "RTOutboxMsg",
+	99:  "RTChannelSet",
+	100: "RTInboxSyncState",
+	101: "RTInboxChannel",
 }
 
 type DataTypeInternal__ DataType

--- a/proto/lcl/realtime.go
+++ b/proto/lcl/realtime.go
@@ -657,6 +657,375 @@ func (r *RTChannelSetForTeam) Decode(dec rpc.Decoder) error {
 
 func (r *RTChannelSetForTeam) Bytes() []byte { return nil }
 
+type RTInboxScope struct {
+	Fqu   lib.FQUser
+	AppID lib.RTAppID
+}
+type RTInboxScopeInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Fqu     *lib.FQUserInternal__
+	AppID   *lib.RTAppIDInternal__
+}
+
+func (r RTInboxScopeInternal__) Import() RTInboxScope {
+	return RTInboxScope{
+		Fqu: (func(x *lib.FQUserInternal__) (ret lib.FQUser) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Fqu),
+		AppID: (func(x *lib.RTAppIDInternal__) (ret lib.RTAppID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.AppID),
+	}
+}
+func (r RTInboxScope) Export() *RTInboxScopeInternal__ {
+	return &RTInboxScopeInternal__{
+		Fqu:   r.Fqu.Export(),
+		AppID: r.AppID.Export(),
+	}
+}
+func (r *RTInboxScope) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTInboxScope) Decode(dec rpc.Decoder) error {
+	var tmp RTInboxScopeInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTInboxScope) Bytes() []byte { return nil }
+
+type RTInboxSyncState struct {
+	Vers     lib.RTInboxVersion
+	Channels []lib.RTChannelID
+}
+type RTInboxSyncStateInternal__ struct {
+	_struct  struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Vers     *lib.RTInboxVersionInternal__
+	Channels *[](*lib.RTChannelIDInternal__)
+}
+
+func (r RTInboxSyncStateInternal__) Import() RTInboxSyncState {
+	return RTInboxSyncState{
+		Vers: (func(x *lib.RTInboxVersionInternal__) (ret lib.RTInboxVersion) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Vers),
+		Channels: (func(x *[](*lib.RTChannelIDInternal__)) (ret []lib.RTChannelID) {
+			if x == nil || len(*x) == 0 {
+				return nil
+			}
+			ret = make([]lib.RTChannelID, len(*x))
+			for k, v := range *x {
+				if v == nil {
+					continue
+				}
+				ret[k] = (func(x *lib.RTChannelIDInternal__) (ret lib.RTChannelID) {
+					if x == nil {
+						return ret
+					}
+					return x.Import()
+				})(v)
+			}
+			return ret
+		})(r.Channels),
+	}
+}
+func (r RTInboxSyncState) Export() *RTInboxSyncStateInternal__ {
+	return &RTInboxSyncStateInternal__{
+		Vers: r.Vers.Export(),
+		Channels: (func(x []lib.RTChannelID) *[](*lib.RTChannelIDInternal__) {
+			if len(x) == 0 {
+				return nil
+			}
+			ret := make([](*lib.RTChannelIDInternal__), len(x))
+			for k, v := range x {
+				ret[k] = v.Export()
+			}
+			return &ret
+		})(r.Channels),
+	}
+}
+func (r *RTInboxSyncState) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTInboxSyncState) Decode(dec rpc.Decoder) error {
+	var tmp RTInboxSyncStateInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTInboxSyncState) Bytes() []byte { return nil }
+
+type RTInboxRowView struct {
+	Ch           RTChannelMetadataPlaintext
+	InboxVersion lib.RTInboxVersion
+	ReadThrough  lib.RTMsgSeq
+	LastSeq      lib.RTMsgSeq
+	LastTime     lib.Time
+	NumUnread    uint64
+	Hidden       bool
+	Muted        bool
+	TeamName     lib.NameUtf8
+	Snippet      *string
+	LastSender   lib.NameUtf8
+}
+type RTInboxRowViewInternal__ struct {
+	_struct      struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Ch           *RTChannelMetadataPlaintextInternal__
+	InboxVersion *lib.RTInboxVersionInternal__
+	ReadThrough  *lib.RTMsgSeqInternal__
+	LastSeq      *lib.RTMsgSeqInternal__
+	LastTime     *lib.TimeInternal__
+	NumUnread    *uint64
+	Hidden       *bool
+	Muted        *bool
+	TeamName     *lib.NameUtf8Internal__
+	Snippet      *string
+	LastSender   *lib.NameUtf8Internal__
+}
+
+func (r RTInboxRowViewInternal__) Import() RTInboxRowView {
+	return RTInboxRowView{
+		Ch: (func(x *RTChannelMetadataPlaintextInternal__) (ret RTChannelMetadataPlaintext) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Ch),
+		InboxVersion: (func(x *lib.RTInboxVersionInternal__) (ret lib.RTInboxVersion) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.InboxVersion),
+		ReadThrough: (func(x *lib.RTMsgSeqInternal__) (ret lib.RTMsgSeq) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.ReadThrough),
+		LastSeq: (func(x *lib.RTMsgSeqInternal__) (ret lib.RTMsgSeq) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.LastSeq),
+		LastTime: (func(x *lib.TimeInternal__) (ret lib.Time) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.LastTime),
+		NumUnread: (func(x *uint64) (ret uint64) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.NumUnread),
+		Hidden: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.Hidden),
+		Muted: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.Muted),
+		TeamName: (func(x *lib.NameUtf8Internal__) (ret lib.NameUtf8) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.TeamName),
+		Snippet: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *string) (ret string) {
+				if x == nil {
+					return ret
+				}
+				return *x
+			})(x)
+			return &tmp
+		})(r.Snippet),
+		LastSender: (func(x *lib.NameUtf8Internal__) (ret lib.NameUtf8) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.LastSender),
+	}
+}
+func (r RTInboxRowView) Export() *RTInboxRowViewInternal__ {
+	return &RTInboxRowViewInternal__{
+		Ch:           r.Ch.Export(),
+		InboxVersion: r.InboxVersion.Export(),
+		ReadThrough:  r.ReadThrough.Export(),
+		LastSeq:      r.LastSeq.Export(),
+		LastTime:     r.LastTime.Export(),
+		NumUnread:    &r.NumUnread,
+		Hidden:       &r.Hidden,
+		Muted:        &r.Muted,
+		TeamName:     r.TeamName.Export(),
+		Snippet:      r.Snippet,
+		LastSender:   r.LastSender.Export(),
+	}
+}
+func (r *RTInboxRowView) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTInboxRowView) Decode(dec rpc.Decoder) error {
+	var tmp RTInboxRowViewInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTInboxRowView) Bytes() []byte { return nil }
+
+type RTInboxView struct {
+	Rows []RTInboxRowView
+	Vers lib.RTInboxVersion
+}
+type RTInboxViewInternal__ struct {
+	_struct struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Rows    *[](*RTInboxRowViewInternal__)
+	Vers    *lib.RTInboxVersionInternal__
+}
+
+func (r RTInboxViewInternal__) Import() RTInboxView {
+	return RTInboxView{
+		Rows: (func(x *[](*RTInboxRowViewInternal__)) (ret []RTInboxRowView) {
+			if x == nil || len(*x) == 0 {
+				return nil
+			}
+			ret = make([]RTInboxRowView, len(*x))
+			for k, v := range *x {
+				if v == nil {
+					continue
+				}
+				ret[k] = (func(x *RTInboxRowViewInternal__) (ret RTInboxRowView) {
+					if x == nil {
+						return ret
+					}
+					return x.Import()
+				})(v)
+			}
+			return ret
+		})(r.Rows),
+		Vers: (func(x *lib.RTInboxVersionInternal__) (ret lib.RTInboxVersion) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Vers),
+	}
+}
+func (r RTInboxView) Export() *RTInboxViewInternal__ {
+	return &RTInboxViewInternal__{
+		Rows: (func(x []RTInboxRowView) *[](*RTInboxRowViewInternal__) {
+			if len(x) == 0 {
+				return nil
+			}
+			ret := make([](*RTInboxRowViewInternal__), len(x))
+			for k, v := range x {
+				ret[k] = v.Export()
+			}
+			return &ret
+		})(r.Rows),
+		Vers: r.Vers.Export(),
+	}
+}
+func (r *RTInboxView) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTInboxView) Decode(dec rpc.Decoder) error {
+	var tmp RTInboxViewInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTInboxView) Bytes() []byte { return nil }
+
+type RTInboxSyncSummary struct {
+	Vers       lib.RTInboxVersion
+	NumChanged uint64
+}
+type RTInboxSyncSummaryInternal__ struct {
+	_struct    struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	Vers       *lib.RTInboxVersionInternal__
+	NumChanged *uint64
+}
+
+func (r RTInboxSyncSummaryInternal__) Import() RTInboxSyncSummary {
+	return RTInboxSyncSummary{
+		Vers: (func(x *lib.RTInboxVersionInternal__) (ret lib.RTInboxVersion) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(r.Vers),
+		NumChanged: (func(x *uint64) (ret uint64) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.NumChanged),
+	}
+}
+func (r RTInboxSyncSummary) Export() *RTInboxSyncSummaryInternal__ {
+	return &RTInboxSyncSummaryInternal__{
+		Vers:       r.Vers.Export(),
+		NumChanged: &r.NumChanged,
+	}
+}
+func (r *RTInboxSyncSummary) Encode(enc rpc.Encoder) error {
+	return enc.Encode(r.Export())
+}
+
+func (r *RTInboxSyncSummary) Decode(dec rpc.Decoder) error {
+	var tmp RTInboxSyncSummaryInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*r = tmp.Import()
+	return nil
+}
+
+func (r *RTInboxSyncSummary) Bytes() []byte { return nil }
+
 type RTMsgView struct {
 	Seq        lib.RTMsgSeq
 	MsgID      lib.RTMsgID
@@ -1062,11 +1431,60 @@ func (c *ClientRTGetThreadArg) Decode(dec rpc.Decoder) error {
 
 func (c *ClientRTGetThreadArg) Bytes() []byte { return nil }
 
+type ClientRTInboxViewArg struct {
+	AppID     lib.RTAppID
+	LocalOnly bool
+}
+type ClientRTInboxViewArgInternal__ struct {
+	_struct   struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	AppID     *lib.RTAppIDInternal__
+	LocalOnly *bool
+}
+
+func (c ClientRTInboxViewArgInternal__) Import() ClientRTInboxViewArg {
+	return ClientRTInboxViewArg{
+		AppID: (func(x *lib.RTAppIDInternal__) (ret lib.RTAppID) {
+			if x == nil {
+				return ret
+			}
+			return x.Import()
+		})(c.AppID),
+		LocalOnly: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(c.LocalOnly),
+	}
+}
+func (c ClientRTInboxViewArg) Export() *ClientRTInboxViewArgInternal__ {
+	return &ClientRTInboxViewArgInternal__{
+		AppID:     c.AppID.Export(),
+		LocalOnly: &c.LocalOnly,
+	}
+}
+func (c *ClientRTInboxViewArg) Encode(enc rpc.Encoder) error {
+	return enc.Encode(c.Export())
+}
+
+func (c *ClientRTInboxViewArg) Decode(dec rpc.Decoder) error {
+	var tmp ClientRTInboxViewArgInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*c = tmp.Import()
+	return nil
+}
+
+func (c *ClientRTInboxViewArg) Bytes() []byte { return nil }
+
 type RealTimeInterface interface {
 	ClientRTMakeChannel(context.Context, ClientRTMakeChannelArg) (lib.RTChannelID, error)
 	ClientRTListChannelsForTeam(context.Context, RTConfig) (RTChannelSetForTeam, error)
 	ClientRTSend(context.Context, ClientRTSendArg) (lib.RTMsgSeq, error)
 	ClientRTGetThread(context.Context, ClientRTGetThreadArg) (RTThreadView, error)
+	ClientRTInboxView(context.Context, ClientRTInboxViewArg) (RTInboxView, error)
 	ErrorWrapper() func(error) lib.Status
 	CheckArgHeader(ctx context.Context, h Header) error
 	MakeResHeader() Header
@@ -1199,6 +1617,27 @@ func (c RealTimeClient) ClientRTGetThread(ctx context.Context, arg ClientRTGetTh
 	res = tmp.Data.Import()
 	return
 }
+func (c RealTimeClient) ClientRTInboxView(ctx context.Context, arg ClientRTInboxViewArg) (res RTInboxView, err error) {
+	warg := &rpc.DataWrap[Header, *ClientRTInboxViewArgInternal__]{
+		Data: arg.Export(),
+	}
+	if c.MakeArgHeader != nil {
+		warg.Header = c.MakeArgHeader()
+	}
+	var tmp rpc.DataWrap[Header, RTInboxViewInternal__]
+	err = c.Cli.Call2(ctx, rpc.NewMethodV2(RealTimeProtocolID, 4, "RealTime.clientRTInboxView"), warg, &tmp, 0*time.Millisecond, realTimeErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
+	if err != nil {
+		return
+	}
+	if c.CheckResHeader != nil {
+		err = c.CheckResHeader(ctx, tmp.Header)
+		if err != nil {
+			return
+		}
+	}
+	res = tmp.Data.Import()
+	return
+}
 func RealTimeProtocol(i RealTimeInterface) rpc.ProtocolV2 {
 	return rpc.ProtocolV2{
 		Name: "RealTime",
@@ -1319,6 +1758,35 @@ func RealTimeProtocol(i RealTimeInterface) rpc.ProtocolV2 {
 					},
 				},
 				Name: "clientRTGetThread",
+			},
+			4: {
+				ServeHandlerDescription: rpc.ServeHandlerDescription{
+					MakeArg: func() interface{} {
+						var ret rpc.DataWrap[Header, *ClientRTInboxViewArgInternal__]
+						return &ret
+					},
+					Handler: func(ctx context.Context, args interface{}) (interface{}, error) {
+						typedWrappedArg, ok := args.(*rpc.DataWrap[Header, *ClientRTInboxViewArgInternal__])
+						if !ok {
+							err := rpc.NewTypeError((*rpc.DataWrap[Header, *ClientRTInboxViewArgInternal__])(nil), args)
+							return nil, err
+						}
+						if err := i.CheckArgHeader(ctx, typedWrappedArg.Header); err != nil {
+							return nil, err
+						}
+						typedArg := typedWrappedArg.Data
+						tmp, err := i.ClientRTInboxView(ctx, (typedArg.Import()))
+						if err != nil {
+							return nil, err
+						}
+						ret := rpc.DataWrap[Header, *RTInboxViewInternal__]{
+							Data:   tmp.Export(),
+							Header: i.MakeResHeader(),
+						}
+						return &ret, nil
+					},
+				},
+				Name: "clientRTInboxView",
 			},
 		},
 		WrapError: RealTimeMakeGenericErrorWrapper(i.ErrorWrapper()),

--- a/proto/rem/extras.go
+++ b/proto/rem/extras.go
@@ -78,6 +78,17 @@ func (k TeamRemovalKey) Eq(k2 TeamRemovalKey) bool {
 	return hmac.Equal(k[:], k2[:])
 }
 
+// Eq compares bearer tokens in constant time (they're secrets, so a
+// short-circuiting comparison could leak via timing if ever used against
+// attacker-supplied input). Pointer form since tokens are optional in many
+// spots; nil equals only nil.
+func (t *TeamVOBearerToken) Eq(t2 *TeamVOBearerToken) bool {
+	if t == nil || t2 == nil {
+		return t == t2
+	}
+	return hmac.Equal(t[:], t2[:])
+}
+
 func (r TeamRawInboxRowVar) Token() (lib.TeamRSVP, error) {
 	var zed lib.TeamRSVP
 	typ, err := r.GetT()

--- a/server/realtime/messages.go
+++ b/server/realtime/messages.go
@@ -31,7 +31,7 @@ type messageSender struct {
 	parentTeam proto.TeamID
 	writeRole  proto.Role
 	readRole   proto.Role
-	prevSeq    int64
+	prevSeq    proto.RTMsgSeq
 	appID      proto.RTAppID
 
 	// members whose inbox versions the fanout bumped; the caller wakes their
@@ -47,7 +47,7 @@ func (s *messageSender) channelID() int64 { return int64(s.arg.Chid) }
 func (s *messageSender) lockChannel(m shared.MetaContext) error {
 	var teamRaw []byte
 	var wrt, wvl, rrt, rvl int
-	var prevSeq *int64
+	var prevSeqRaw *int64
 	var appRaw string
 	err := s.tx.QueryRow(
 		m.Ctx(),
@@ -58,7 +58,7 @@ func (s *messageSender) lockChannel(m shared.MetaContext) error {
 		 FOR UPDATE`,
 		m.ShortHostID(),
 		s.channelID(),
-	).Scan(&teamRaw, &wrt, &wvl, &rrt, &rvl, &prevSeq, &appRaw)
+	).Scan(&teamRaw, &wrt, &wvl, &rrt, &rvl, &prevSeqRaw, &appRaw)
 	if err == pgx.ErrNoRows {
 		return core.RowNotFoundError{}
 	}
@@ -81,8 +81,8 @@ func (s *messageSender) lockChannel(m shared.MetaContext) error {
 	if err != nil {
 		return err
 	}
-	if prevSeq != nil {
-		s.prevSeq = *prevSeq
+	if prevSeqRaw != nil {
+		s.prevSeq = proto.RTMsgSeq(*prevSeqRaw)
 	}
 	return nil
 }
@@ -154,7 +154,7 @@ func (s *messageSender) internSender(m shared.MetaContext) (int, error) {
 func (s *messageSender) insertMessage(
 	m shared.MetaContext,
 	senderNo int,
-	seq int64,
+	seq proto.RTMsgSeq,
 ) (
 	proto.Time,
 	error,
@@ -204,7 +204,7 @@ func (s *messageSender) insertMessage(
 		 RETURNING insert_time`,
 		m.ShortHostID(),
 		s.channelID(),
-		seq,
+		seq.Int64(),
 		s.arg.Md.MsgID.Bytes(),
 		typ,
 		naclctxt,
@@ -256,6 +256,7 @@ func (s *messageSender) insertMessage(
 func (s *messageSender) fanoutInboxVersions(
 	m shared.MetaContext,
 	insertTime time.Time,
+	seq proto.RTMsgSeq,
 ) error {
 	// Bump each member's (uid, app) global inbox version. The insert arm is
 	// paranoia -- the channel-creation fanout writes user_inbox before
@@ -301,11 +302,19 @@ func (s *messageSender) fanoutInboxVersions(
 
 	// Stamp each membership row at its owner's just-bumped global version, and
 	// refresh the denormalized last-message time for inbox ordering. Reads the
-	// user_inbox rows written above in the same transaction.
+	// user_inbox rows written above in the same transaction. Sending implies
+	// reading: the sender's own read pointer advances to the new message in the
+	// same stamp (GREATEST keeps it monotonic), so a member's own messages never
+	// count against their unread badge. No extra version is consumed -- the row
+	// was bumping for the delivery anyway, so other devices pick the read state
+	// up along with the message.
 	_, err = s.tx.Exec(
 		m.Ctx(),
 		`UPDATE user_channels uc
-		 SET inbox_version = ui.inbox_version, last_msg_time = $3, mtime = NOW()
+		 SET inbox_version = ui.inbox_version, last_msg_time = $3, mtime = NOW(),
+		     read_through = CASE WHEN uc.uid = $4
+		                         THEN GREATEST(uc.read_through, $5)
+		                         ELSE uc.read_through END
 		 FROM user_inbox ui
 		 WHERE ui.short_host_id = uc.short_host_id
 		   AND ui.uid = uc.uid AND ui.app_id = uc.app_id
@@ -313,6 +322,8 @@ func (s *messageSender) fanoutInboxVersions(
 		m.ShortHostID(),
 		s.channelID(),
 		insertTime,
+		s.sender.ExportToDB(),
+		seq.Int64(),
 	)
 	return err
 }
@@ -329,7 +340,7 @@ func (s *messageSender) run(m shared.MetaContext) (*rem.RTSendRes, error) {
 	seq := s.prevSeq + 1
 	// Optional optimistic-concurrency check from the client.
 	if s.arg.ExpectedPrevSeq.IsValid() &&
-		s.arg.ExpectedPrevSeq.Int64() != s.prevSeq {
+		s.arg.ExpectedPrevSeq != s.prevSeq {
 		return nil, core.RTRaceError{Which: "messages"}
 	}
 	senderNo, err := s.internSender(m)
@@ -340,7 +351,7 @@ func (s *messageSender) run(m shared.MetaContext) (*rem.RTSendRes, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = s.fanoutInboxVersions(m, insertTime.Import())
+	err = s.fanoutInboxVersions(m, insertTime.Import(), seq)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Implements #303 (closes #303).

## What

Without local persistence, the inbox-version protocol (#302) degenerates: every app start is a `since=0` full sync, and the inbox can't render offline or instantly before the network answers. This PR adds an inbox syncer to librt that persists the delta to local soft SQLite, making the badge computation (`max(lastSeq − readThrough, 0)` per channel) a pure local read.

## Design (per the issue + follow-up comment)

- **Hand-rolled `DbGet`/`DbPutTx`**, not the generic `Cache[...]` — the per-page atomic apply (rows + cursor in one local tx) is the whole ballgame.
- **Scope = FQU + AppID** (`lcl.RTInboxScope`), per the issue's follow-up comment: the inbox is viewer-scoped state spanning many parties.
- **Two new soft DataTypes**: `RTInboxChannel` stores one wire-shape `rem.RTInboxChannel` per channel, keyed by channelID — denormalized like server-side `user_channels`, with name/desc still in their secretboxes (plaintext never hits the local DB; decryption happens only at render). `RTInboxSyncState` is a per-scope singleton holding the sync cursor **plus** the channelID index — the issue sketched these as separate rows, but with the FQU+AppID scope both are per-scope singletons written in the same tx, so they're merged.
- **Cursor = highest version applied, never the server-reported head** (the head is only a loop-termination hint). Each page applies atomically, so a crash mid-multi-page sync resumes at the last applied page. A page that fails to advance the cursor is rejected as bad server data.
- **Merge = whole-row overwrite, server wins**; syncs are serialized per (user × app) via a lock on the librt `App` singleton, so page applies can't interleave even across Minders.
- **Accepted staleness**: rows for channels we can no longer read (lost access, left team — no tombstones yet) are skipped at render, not errors.
- **Self-healing**: all soft state; wiping it just costs a full resync.

## API surface

- `Minder.SyncInbox(m, appID)` (+ `SyncInboxWithPageSize` for tests) — page `rtGetChangedThreads` from the stored cursor, apply transactionally, return a summary.
- `Minder.LocalInbox(m, appID)` — render from disk, no network, newest bump first.
- `App.UserMinder()` / `librt.InitUserReq` — user-scoped Minder for flows that act as no one team.
- Agent RPC `clientRTInboxView` and CLI `foks rt inbox [--local-only]`, doubling as the integration-test probe.

## Tests

`TestRTSendReadPermissions` extends: coco's full sync persists both her channels and renders from disk with computed unread counts; after her removal, re-sync is an incremental no-op that strands her rows locally (documented accepted staleness). bluey round-trips through a fresh Minder (pure disk read), re-syncs as a no-op from the stored cursor, and picks up exactly the one bumped row after new activity. dave syncs at page size 1, exercising the per-page atomic apply against random channel-ID backfill order. `TestRTSendAndRead` (cli) probes `rt inbox` in JSON, `--local-only`, and text forms. All RT suites clean under `-race`.

Co-authored-by: Claude Code