### PR TITLE
chat(1d): inbox polish — team names, own-send unread fix, snippets

### DIFF
--- a/client/foks/cmd/tables.go
+++ b/client/foks/cmd/tables.go
@@ -838,7 +838,7 @@ func outputRTInboxTable(
 			name:   displayRTChannelName(r.Ch.Name),
 			tier:   r.Ch.Tier,
 			team:   team,
-			unread: r.Unread,
+			unread: r.NumUnread,
 			msg:    msg,
 			last:   last,
 			vers:   r.InboxVersion,

--- a/client/foks/cmd/tables.go
+++ b/client/foks/cmd/tables.go
@@ -8,9 +8,11 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/libterm"
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -752,6 +754,7 @@ type rtInboxRow struct {
 	tier   proto.RTChannelTier
 	team   string
 	unread uint64
+	msg    string
 	last   string
 	vers   proto.RTInboxVersion
 }
@@ -765,6 +768,7 @@ func (r rtInboxRow) toTableRow() table.Row {
 		r.name,
 		rtChannelTierGlyph(r.tier),
 		unread,
+		r.msg,
 		r.last,
 		r.team,
 	}
@@ -775,6 +779,7 @@ func (r rtInboxRow) headers() table.Row {
 		"Channel",
 		"Tier",
 		"Unread",
+		"Last Message",
 		"Last Activity",
 		"Team",
 	}
@@ -787,29 +792,83 @@ func (r rtInboxRow) lessThan(other tableRow) bool {
 
 var _ tableRow = rtInboxRow{}
 
+// truncateToWidth caps s at width runes, marking the cut with an ellipsis.
+func truncateToWidth(s string, width int) string {
+	if width <= 0 || utf8.RuneCountInString(s) <= width {
+		return s
+	}
+	runes := []rune(s)
+	if width == 1 {
+		return "…"
+	}
+	return string(runes[:width-1]) + "…"
+}
+
 func outputRTInboxTable(
 	m libclient.MetaContext,
 	opts outputTableOpts,
 	view lcl.RTInboxView,
 ) error {
-	conv := func(_ int, r lcl.RTInboxRowView) (tableRow, error) {
-		team, err := r.Ch.ParentTeam.EntityID().StringErr()
-		if err != nil {
-			return nil, err
+	rows := make([]rtInboxRow, 0, len(view.Rows))
+	fixed := 0
+	for _, r := range view.Rows {
+		team := ""
+		switch {
+		case r.TeamName != nil:
+			team = string(*r.TeamName)
+		default:
+			// The teamname cache had no answer; fall back to the raw ID.
+			s, err := r.Ch.ParentTeam.EntityID().StringErr()
+			if err != nil {
+				return err
+			}
+			team = s
 		}
-		var last string
+		var last, msg string
 		if r.LastSeq > 0 {
 			last = r.LastTime.Import().Local().Format("2006-01-02 15:04:05")
 		}
-		ret := rtInboxRow{
+		if r.Snippet != nil {
+			msg = *r.Snippet
+			if r.LastSender != nil {
+				msg = string(*r.LastSender) + ": " + msg
+			}
+		}
+		row := rtInboxRow{
 			name:   displayRTChannelName(r.Ch.Name),
 			tier:   r.Ch.Tier,
 			team:   team,
 			unread: r.Unread,
+			msg:    msg,
 			last:   last,
 			vers:   r.InboxVersion,
 		}
-		return ret, nil
+		rows = append(rows, row)
+		width := utf8.RuneCountInString(row.name) +
+			1 + // tier glyph
+			len("Unread") +
+			utf8.RuneCountInString(last) +
+			utf8.RuneCountInString(team)
+		fixed = max(fixed, width)
+	}
+
+	// When stdout is a live terminal, fit the snippet column to it: it absorbs
+	// whatever width the other columns leave over (~3 chars of border/padding
+	// per column edge). Piped or captured output is not truncated -- files and
+	// greps want the full content.
+	budget := 0
+	if dims, err := libterm.GetTermDims(); err == nil {
+		const numCols, minSnippet = 6, 16
+		budget = dims.Width - fixed - 3*(numCols+1)
+		budget = max(budget, minSnippet)
+	}
+
+	conv := func(i int, _ lcl.RTInboxRowView) (tableRow, error) {
+		row := rows[i]
+		if budget > 0 {
+			row.msg = truncateToWidth(row.msg, budget)
+		}
+		return row, nil
 	}
 	return convertAndOutputRows(m, opts, view.Rows, conv, nil)
 }

--- a/client/libclient/globals.go
+++ b/client/libclient/globals.go
@@ -130,7 +130,8 @@ type GlobalContext struct {
 
 	deviceNameCache DeviceNameCache
 
-	usernameLoader UsernameLoader
+	usernameLoader *UsernameLoader
+	teamnameLoader *TeamnameLoader
 
 	logRotate *LogRotate
 
@@ -165,7 +166,19 @@ func (d *GlobalContext) DeviceNameCache() *DeviceNameCache {
 func (d *GlobalContext) UsernameLoader() *UsernameLoader {
 	d.Lock()
 	defer d.Unlock()
-	return &d.usernameLoader
+	if d.usernameLoader == nil {
+		d.usernameLoader = NewUsernameLoader()
+	}
+	return d.usernameLoader
+}
+
+func (d *GlobalContext) TeamnameLoader() *TeamnameLoader {
+	d.Lock()
+	defer d.Unlock()
+	if d.teamnameLoader == nil {
+		d.teamnameLoader = NewTeamnameLoader()
+	}
+	return d.teamnameLoader
 }
 
 func (g *GlobalContext) PushShutdownHook(h func()) {

--- a/client/libclient/name_cache.go
+++ b/client/libclient/name_cache.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package libclient
+
+import (
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+type nameCacheEntry struct {
+	name      proto.NameUtf8
+	expiresAt time.Time
+}
+
+const (
+	// nameCacheTTLBase is the central lifetime of a cached key->name entry;
+	// nameCacheTTLJitter is the random spread added on top so a burst of
+	// entries cached together don't all expire at once and stampede the server.
+	nameCacheTTLBase   = 6 * time.Hour
+	nameCacheTTLJitter = 2 * time.Hour
+)
+
+// jitteredNameTTL returns a lifetime uniformly in
+// [base - jitter/2, base + jitter/2), centered on base (~6h).
+func jitteredNameTTL() time.Duration {
+	return nameCacheTTLBase - nameCacheTTLJitter/2 +
+		time.Duration(rand.Int63n(int64(nameCacheTTLJitter)))
+}
+
+// nameCache memoizes K -> display-name with two tiers: an in-memory map in
+// front of the soft local DB, so entries survive agent restarts. It's the
+// shared core of UsernameLoader and TeamnameLoader, which differ only in key
+// type, DataType, and how a key maps to a DB row address. Soft state
+// throughout: a failed read or write of the DB tier degrades to a cache miss,
+// never an error.
+type nameCache[K comparable] struct {
+	sync.RWMutex
+	m map[K]nameCacheEntry
+
+	typ lcl.DataType
+	// rowAddr maps a key to its (scope, key) address in the soft DB.
+	rowAddr func(K) (Scoper, any)
+}
+
+func newNameCache[K comparable](
+	typ lcl.DataType,
+	rowAddr func(K) (Scoper, any),
+) nameCache[K] {
+	return nameCache[K]{typ: typ, rowAddr: rowAddr}
+}
+
+// Get returns a cached, unexpired display name for k, if any, trying the
+// memory tier and then the soft DB. A fresh DB hit warms the memory tier, with
+// its expiry anchored at the row's write time, so the ~TTL staleness bound
+// holds across both tiers.
+func (c *nameCache[K]) Get(m MetaContext, k K) (proto.NameUtf8, bool) {
+	if nm, ok := c.getMem(m, k); ok {
+		return nm, true
+	}
+	return c.getDb(m, k)
+}
+
+// Set records k -> name in both tiers, with a fresh jittered TTL. A DB-tier
+// write failure is returned but the memory tier is set regardless.
+func (c *nameCache[K]) Set(m MetaContext, k K, nm proto.NameUtf8) error {
+	c.putMem(k, nm, m.G().Now().Add(jitteredNameTTL()))
+	if c.rowAddr == nil {
+		// Zero-value cache (not made via newNameCache): soft state, so degrade
+		// to memory-only rather than crash.
+		m.Warnw("nameCache.Set", "err", "no rowAddr; memory tier only")
+		return nil
+	}
+	scope, key := c.rowAddr(k)
+	return m.DbPut(DbTypeSoft, PutArg{
+		Scope: scope,
+		Typ:   c.typ,
+		Key:   key,
+		Val:   &nm,
+	})
+}
+
+// getMem returns an unexpired entry from the memory tier. An expired entry is
+// reported as a miss but left in place rather than deleted (no lock upgrade);
+// the Set or DB-warm that follows a miss overwrites it.
+func (c *nameCache[K]) getMem(m MetaContext, k K) (proto.NameUtf8, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	ent, ok := c.m[k]
+	if !ok || !m.G().Now().Before(ent.expiresAt) {
+		return "", false
+	}
+	return ent.name, true
+}
+
+func (c *nameCache[K]) putMem(k K, nm proto.NameUtf8, expiresAt time.Time) {
+	c.Lock()
+	defer c.Unlock()
+	if c.m == nil {
+		c.m = make(map[K]nameCacheEntry)
+	}
+	c.m[k] = nameCacheEntry{
+		name:      nm,
+		expiresAt: expiresAt,
+	}
+}
+
+func (c *nameCache[K]) getDb(m MetaContext, k K) (proto.NameUtf8, bool) {
+	if c.rowAddr == nil {
+		return "", false // zero-value cache; see Set
+	}
+	var nm proto.NameUtf8
+	scope, key := c.rowAddr(k)
+	tm, err := m.DbGet(&nm, DbTypeSoft, scope, c.typ, key)
+	if err != nil {
+		if !errors.Is(err, core.RowNotFoundError{}) {
+			m.Warnw("nameCache.getDb", "typ", c.typ, "key", k, "err", err)
+		}
+		return "", false
+	}
+	expiresAt := tm.Import().Add(jitteredNameTTL())
+	if !m.G().Now().Before(expiresAt) {
+		return "", false
+	}
+	c.putMem(k, nm, expiresAt)
+	return nm, true
+}

--- a/client/libclient/party_loader_cache.go
+++ b/client/libclient/party_loader_cache.go
@@ -78,6 +78,11 @@ func NewPartyLoaderCache(au *UserContext) *PartyLoaderCache {
 
 type PLCOpts struct {
 	Lock bool
+	// ForceRefresh bypasses the node-freshness shortcut for team loads, forcing
+	// a reload (and hence a fresh view bearer token). Used to recover when a
+	// cached token turns out to be stale server-side -- e.g. the caller's role
+	// in the team changed inside the freshness window.
+	ForceRefresh bool
 }
 
 func (p *PartyLoaderCache) getLockedNode(
@@ -184,7 +189,7 @@ func (p *PartyLoaderCache) loadTeam(
 		if err != nil {
 			return nil, err
 		}
-		if isFresh {
+		if isFresh && (opts == nil || !opts.ForceRefresh) {
 			return plcn, nil
 		}
 	}
@@ -293,7 +298,31 @@ func (a *BaseMinder[N, P]) GetParty(
 	*N,
 	error,
 ) {
-	plcn, err := a.plc.Load(m, t, &PLCOpts{})
+	return a.getParty(m, t, &PLCOpts{})
+}
+
+// GetPartyForceRefresh is GetParty, but reloads the party's backing team even
+// if the cached node is still fresh -- e.g. to mint a new view bearer token
+// after the server rejected the cached one as stale.
+func (a *BaseMinder[N, P]) GetPartyForceRefresh(
+	m MetaContext,
+	t lcl.ConfigTeam,
+) (
+	*N,
+	error,
+) {
+	return a.getParty(m, t, &PLCOpts{ForceRefresh: true})
+}
+
+func (a *BaseMinder[N, P]) getParty(
+	m MetaContext,
+	t lcl.ConfigTeam,
+	opts *PLCOpts,
+) (
+	*N,
+	error,
+) {
+	plcn, err := a.plc.Load(m, t, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/client/libclient/team_loader.go
+++ b/client/libclient/team_loader.go
@@ -216,17 +216,22 @@ func (t *TeamWrapper) IsAdHocTeam() bool {
 	return t.prot.Fqt.Team.IsAdHocTeam()
 }
 
-// returns {names X UIDs x ID x MashedIDs   } @ { name X ID }
-func (t *TeamWrapper) AllFQAdHocTeamStrings() ([]proto.FQAdHocTeamString, error) {
-
-	if !t.IsAdHocTeam() {
-		return nil, nil
+// adHocMemberIDsAndNames collects the local-host user members of an ad-hoc
+// team: their UIDs, and their usernames when every member's name is known
+// (from its loaded user chain, or captured from the username cache when the
+// chain load was skipped -- see LoadMemberNames). nameListOK is false when any
+// member's name is missing; the UID list is complete regardless.
+func (t *TeamWrapper) adHocMemberIDsAndNames() (
+	uids []proto.UID,
+	names []proto.NameUtf8,
+	nameListOK bool,
+	err error,
+) {
+	err = t.index() // memberMap is built lazily
+	if err != nil {
+		return nil, nil, false, err
 	}
-
-	var uids []proto.UID
-	var names []proto.NameUtf8
 	host := t.prot.Fqt.Host
-
 	var badNameList bool
 
 	for m := range t.memberMap {
@@ -239,7 +244,7 @@ func (t *TeamWrapper) AllFQAdHocTeamStrings() ([]proto.FQAdHocTeamString, error)
 		}
 		uid, err := eid.ToUID()
 		if err != nil {
-			return nil, err
+			return nil, nil, false, err
 		}
 		uids = append(uids, uid)
 		rp := t.rosterDetails[m.Fqe]
@@ -258,10 +263,41 @@ func (t *TeamWrapper) AllFQAdHocTeamStrings() ([]proto.FQAdHocTeamString, error)
 				badNameList = true
 			}
 		}
-		if badNameList {
-			break
-		}
 	}
+	return uids, names, !badNameList, nil
+}
+
+// AdHocDisplayName renders an ad-hoc team as its canonical member-name list
+// ("alice,bob,charlie"), the closest thing such a team has to a name. Returns
+// false for non-ad-hoc teams or when some member's username isn't known.
+func (t *TeamWrapper) AdHocDisplayName() (proto.NameUtf8, bool) {
+	if !t.IsAdHocTeam() {
+		return "", false
+	}
+	_, names, ok, err := t.adHocMemberIDsAndNames()
+	if err != nil || !ok || len(names) == 0 {
+		return "", false
+	}
+	s, err := team.NamesToAdhHocCanonicalString(names, "")
+	if err != nil {
+		return "", false
+	}
+	return proto.NameUtf8(s), true
+}
+
+// returns {names X UIDs x ID x MashedIDs   } @ { name X ID }
+func (t *TeamWrapper) AllFQAdHocTeamStrings() ([]proto.FQAdHocTeamString, error) {
+
+	if !t.IsAdHocTeam() {
+		return nil, nil
+	}
+
+	host := t.prot.Fqt.Host
+	uids, names, nameListOK, err := t.adHocMemberIDsAndNames()
+	if err != nil {
+		return nil, err
+	}
+	badNameList := !nameListOK
 	uidsJoined, err := team.UIDsToAdhHocCanonicalString(uids, proto.UID{})
 	if err != nil {
 		return nil, err

--- a/client/libclient/team_minder.go
+++ b/client/libclient/team_minder.go
@@ -360,11 +360,36 @@ func (t *TeamMinder) LoadTeamWithFQTeam(
 
 	tr.ldr.Arg.LoadMembersFull = opts.LoadMembers
 
+	// An ad-hoc team is named by its member list, so have the loader capture
+	// member usernames (cheap: username-cache hits skip the user-chain loads),
+	// as the explore path already does. The teamname-cache fill below needs
+	// them.
+	if fqt.Team.IsAdHocTeam() {
+		tr.ldr.Arg.LoadMemberNames = true
+	}
+
 	tw, err := tr.ldr.Run(m)
 	if err != nil {
 		return nil, err
 	}
 	tr.tw = tw
+
+	// Fill the teamname cache at the load site (every team load funnels
+	// through here), so ID-only display paths like the RT inbox can show
+	// names. An ad-hoc team has no name of its own; cache its canonical
+	// member-name list ("alice,bob,charlie") -- the full list, since the cache
+	// is shared across the agent's local users. Viewer-relative display
+	// (dropping the viewer's own name) happens at render time.
+	nm := tw.Name()
+	if nm == "" {
+		nm, _ = tw.AdHocDisplayName()
+	}
+	if nm != "" {
+		err = m.G().TeamnameLoader().Set(m, fqt, nm)
+		if err != nil {
+			m.Warnw("LoadTeamWithFQTeam", "stage", "teamnameCache", "fqt", fqt, "err", err)
+		}
+	}
 	return tr, nil
 }
 

--- a/client/libclient/teamname_loader.go
+++ b/client/libclient/teamname_loader.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package libclient
+
+import (
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+)
+
+// TeamnameLoader memoizes FQTeam -> display-name, the team-side sibling of
+// UsernameLoader (same two-tier nameCache underneath). It hangs off the
+// GlobalContext so all layers share it; team loads fill it at the load site
+// (TeamMinder.LoadTeamWithFQTeam), and the RT inbox renderer reads it to show
+// team names instead of IDs.
+//
+// Unlike UsernameLoader there's no integrated network load (yet): a miss is
+// just a miss and the caller falls back (e.g. displaying the team ID). Wiring
+// a single-flighted team load behind misses -- and plugging the cache into
+// more display paths -- is follow-up work.
+type TeamnameLoader struct {
+	nameCache[proto.FQTeam]
+}
+
+func NewTeamnameLoader() *TeamnameLoader {
+	return &TeamnameLoader{
+		nameCache: newNameCache(
+			lcl.DataType_TeamnameCacheEntry,
+			func(fqt proto.FQTeam) (Scoper, any) {
+				return &fqt.Host, fqt.Team
+			},
+		),
+	}
+}

--- a/client/libclient/username_loader.go
+++ b/client/libclient/username_loader.go
@@ -4,35 +4,11 @@
 package libclient
 
 import (
-	"errors"
-	"math/rand"
 	"sync"
-	"time"
 
-	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 )
-
-type usernameCacheEntry struct {
-	name      proto.NameUtf8
-	expiresAt time.Time
-}
-
-const (
-	// usernameCacheTTLBase is the central lifetime of a cached UID->name entry;
-	// usernameCacheTTLJitter is the random spread added on top so a burst of
-	// entries cached together don't all expire at once and stampede the server.
-	usernameCacheTTLBase   = 6 * time.Hour
-	usernameCacheTTLJitter = 2 * time.Hour
-)
-
-// jitteredUsernameTTL returns a lifetime uniformly in
-// [base - jitter/2, base + jitter/2), centered on base (~6h).
-func jitteredUsernameTTL() time.Duration {
-	return usernameCacheTTLBase - usernameCacheTTLJitter/2 +
-		time.Duration(rand.Int63n(int64(usernameCacheTTLJitter)))
-}
 
 // usernameFlight is a single-flight slot for one FQUser's user-chain load;
 // see UsernameLoader.Load. Only a successful result is recorded -- waiters
@@ -43,27 +19,32 @@ type usernameFlight struct {
 	ok   bool
 }
 
-// UsernameLoader resolves FQUser -> display-name, integrating a two-tier
-// cache with a single-flighted user-chain load on miss. It hangs off the
+// UsernameLoader resolves FQUser -> display-name, integrating the two-tier
+// nameCache with a single-flighted user-chain load on miss. It hangs off the
 // GlobalContext so that all layers share it: team loads fill it whenever a
 // member's user chain is loaded, and RT sender-name resolution fills it on
 // demand.
-//
-// The cache is two-tiered: an in-memory map in front of the soft local DB
-// (scope: HostID; key: UID; value: utf8 username), so entries survive agent
-// restarts. It's soft state -- a failed read or write of the DB tier degrades
-// to a cache miss, never an error.
 //
 // Keys are fully-qualified (UID + HostID), not bare UIDs: the GlobalContext
 // spans all of the agent's active users, who may live on different hosts, and
 // the same eldest key -- hence the same UID -- can be signed up under different
 // usernames on different hosts.
 type UsernameLoader struct {
-	sync.RWMutex
-	m map[proto.FQUser]usernameCacheEntry
+	nameCache[proto.FQUser]
 
 	flightMu sync.Mutex
 	flights  map[proto.FQUser]*usernameFlight
+}
+
+func NewUsernameLoader() *UsernameLoader {
+	return &UsernameLoader{
+		nameCache: newNameCache(
+			lcl.DataType_UsernameCacheEntry,
+			func(fqu proto.FQUser) (Scoper, any) {
+				return &fqu.HostID, fqu.Uid
+			},
+		),
+	}
 }
 
 // Load returns the display name for fqu, trying the cache tiers and then
@@ -154,70 +135,4 @@ func (u *UsernameLoader) loadAndFill(
 		m.Warnw("UsernameLoader.loadAndFill", "stage", "cacheSet", "fqu", fqu, "err", err)
 	}
 	return nm, uw, nil
-}
-
-// Get returns a cached, unexpired display name for fqu, if any, trying the
-// memory tier and then the soft DB. A fresh DB hit warms the memory tier, with
-// its expiry anchored at the row's write time, so the ~TTL staleness bound
-// holds across both tiers.
-func (u *UsernameLoader) Get(m MetaContext, fqu proto.FQUser) (proto.NameUtf8, bool) {
-	if nm, ok := u.getMem(m, fqu); ok {
-		return nm, true
-	}
-	return u.getDb(m, fqu)
-}
-
-// Set records fqu -> name in both tiers, with a fresh jittered TTL. A DB-tier
-// write failure is returned but the memory tier is set regardless.
-func (u *UsernameLoader) Set(m MetaContext, fqu proto.FQUser, nm proto.NameUtf8) error {
-	u.putMem(fqu, nm, m.G().Now().Add(jitteredUsernameTTL()))
-	return m.DbPut(DbTypeSoft, PutArg{
-		Scope: &fqu.HostID,
-		Typ:   lcl.DataType_UsernameCacheEntry,
-		Key:   fqu.Uid,
-		Val:   &nm,
-	})
-}
-
-// getMem returns an unexpired entry from the memory tier. An expired entry is
-// reported as a miss but left in place rather than deleted (no lock upgrade);
-// the Set or DB-warm that follows a miss overwrites it.
-func (u *UsernameLoader) getMem(m MetaContext, fqu proto.FQUser) (proto.NameUtf8, bool) {
-	u.RLock()
-	defer u.RUnlock()
-	ent, ok := u.m[fqu]
-	if !ok || !m.G().Now().Before(ent.expiresAt) {
-		return "", false
-	}
-	return ent.name, true
-}
-
-func (u *UsernameLoader) putMem(fqu proto.FQUser, nm proto.NameUtf8, expiresAt time.Time) {
-	u.Lock()
-	defer u.Unlock()
-	if u.m == nil {
-		u.m = make(map[proto.FQUser]usernameCacheEntry)
-	}
-	u.m[fqu] = usernameCacheEntry{
-		name:      nm,
-		expiresAt: expiresAt,
-	}
-}
-
-func (u *UsernameLoader) getDb(m MetaContext, fqu proto.FQUser) (proto.NameUtf8, bool) {
-	var nm proto.NameUtf8
-	tm, err := m.DbGet(&nm, DbTypeSoft, &fqu.HostID,
-		lcl.DataType_UsernameCacheEntry, fqu.Uid)
-	if err != nil {
-		if !errors.Is(err, core.RowNotFoundError{}) {
-			m.Warnw("UsernameLoader.getDb", "fqu", fqu, "err", err)
-		}
-		return "", false
-	}
-	expiresAt := tm.Import().Add(jitteredUsernameTTL())
-	if !m.G().Now().Before(expiresAt) {
-		return "", false
-	}
-	u.putMem(fqu, nm, expiresAt)
-	return nm, true
 }

--- a/client/librt/inbox.go
+++ b/client/librt/inbox.go
@@ -260,7 +260,11 @@ func (d *Minder) renderInboxRow(
 	fqt := proto.FQTeam{Team: row.Md.ParentTeam, Host: d.au.HostID()}
 	if nm, ok := m.G().TeamnameLoader().Get(m.Base(), fqt); ok {
 		if row.Md.ParentTeam.IsAdHocTeam() {
-			nm = team.StripSelfFromAdHocName(nm, d.au.Info.Username.NameUtf8)
+			nm, err = team.StripSelfFromAdHocName(nm, d.au.Info.Username.NameUtf8)
+			if err != nil {
+				nm = "<error>"
+				m.Warnw("renderInboxRow", "stage", "stripSelfFromAdHocName", "err", err)
+			}
 		}
 		ret.TeamName = &nm
 	}
@@ -308,7 +312,7 @@ func (d *Minder) fillSnippet(
 	out.Snippet = &sn
 	if msg.Sender != nil && msg.Sender.IsUser() {
 		if uid, err := msg.Sender.UID(); err == nil {
-			if nm, ok := d.resolveSenderName(m, cfgTeam, rtp, uid); ok {
+			if nm, err := d.resolveSenderName(m, cfgTeam, rtp, uid); err == nil {
 				out.LastSender = &nm
 			}
 		}

--- a/client/librt/inbox.go
+++ b/client/librt/inbox.go
@@ -273,7 +273,7 @@ func (d *Minder) renderInboxRow(
 		ret.LastSeq = row.Md.LastMsg.Seq
 		ret.LastTime = row.Md.LastMsg.InsertTime
 		if ret.LastSeq > ret.ReadThrough {
-			ret.Unread = uint64(ret.LastSeq - ret.ReadThrough)
+			ret.NumUnread = uint64(ret.LastSeq - ret.ReadThrough)
 		}
 		d.fillSnippet(m, rtp, cfgTeam, row, &ret)
 	}

--- a/client/librt/inbox.go
+++ b/client/librt/inbox.go
@@ -308,7 +308,7 @@ func (d *Minder) fillSnippet(
 	out.Snippet = &sn
 	if msg.Sender != nil && msg.Sender.IsUser() {
 		if uid, err := msg.Sender.UID(); err == nil {
-			if nm, ok := d.resolveSenderName(m, cfgTeam, rtp.PLCNode().ViewTok(), uid); ok {
+			if nm, ok := d.resolveSenderName(m, cfgTeam, rtp, uid); ok {
 				out.LastSender = &nm
 			}
 		}

--- a/client/librt/inbox.go
+++ b/client/librt/inbox.go
@@ -7,6 +7,8 @@ import (
 	"cmp"
 	"errors"
 	"slices"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/lib/core"
@@ -147,6 +149,22 @@ func (d *Minder) SyncInboxWithPageSize(
 		}
 		numChanged += uint64(len(delta.Channels))
 
+		// Prefetch each changed channel's last message into the local message
+		// cache, so LocalInbox can render a snippet without the network.
+		// Best-effort and after the page apply: the rows are already durable,
+		// and a failure just means no snippet until the channel next bumps.
+		for i := range delta.Channels {
+			ch := &delta.Channels[i]
+			if ch.Md.LastMsg == nil {
+				continue
+			}
+			err := d.prefetchLastMsg(m, ch)
+			if err != nil {
+				m.Warnw("SyncInbox", "stage", "prefetchLastMsg",
+					"chid", ch.Md.Id, "err", err)
+			}
+		}
+
 		// The head rides along on every page purely as a termination hint; it
 		// is never stored (there may be unapplied bumps at versions between the
 		// cursor and the head).
@@ -196,6 +214,19 @@ func (d *Minder) LocalInbox(
 	return &ret, nil
 }
 
+// configTeamByID addresses a parent team by its ID, using the ad-hoc arm for
+// ad-hoc team IDs so resolution takes the ad-hoc path.
+func configTeamByID(teamID proto.TeamID) lcl.ConfigTeam {
+	if teamID.IsAdHocTeam() {
+		return lcl.NewConfigTeamWithAdhoc(proto.FQAdHocTeamParsed{
+			Team: proto.NewAdHocTeamParsedWithId(teamID.EntityID()),
+		})
+	}
+	return team.WrapNamed(proto.FQTeamParsed{
+		Team: proto.NewParsedTeamWithFalse(teamID),
+	})
+}
+
 // renderInboxRow decrypts one stored inbox row into its view form, loading the
 // parent team's party (and keys) by ID via the shared party-loader cache.
 func (d *Minder) renderInboxRow(
@@ -205,9 +236,7 @@ func (d *Minder) renderInboxRow(
 	*lcl.RTInboxRowView,
 	error,
 ) {
-	cfgTeam := team.WrapNamed(proto.FQTeamParsed{
-		Team: proto.NewParsedTeamWithFalse(row.Md.ParentTeam),
-	})
+	cfgTeam := configTeamByID(row.Md.ParentTeam)
 	rtp, err := d.base.GetParty(m.Base(), cfgTeam)
 	if err != nil {
 		return nil, err
@@ -223,12 +252,139 @@ func (d *Minder) renderInboxRow(
 		Hidden:       row.Hidden,
 		Muted:        row.Muted,
 	}
+
+	// Team display name, via the teamname cache -- the GetParty above fills it
+	// whenever it (re)loads the team, so a miss is rare and just falls back to
+	// the ID at the display layer. An ad-hoc team's cached name is its full
+	// member list; drop the viewer's own name for DM-style display.
+	fqt := proto.FQTeam{Team: row.Md.ParentTeam, Host: d.au.HostID()}
+	if nm, ok := m.G().TeamnameLoader().Get(m.Base(), fqt); ok {
+		if row.Md.ParentTeam.IsAdHocTeam() {
+			nm = team.StripSelfFromAdHocName(nm, d.au.Info.Username.NameUtf8)
+		}
+		ret.TeamName = &nm
+	}
+
 	if row.Md.LastMsg != nil {
 		ret.LastSeq = row.Md.LastMsg.Seq
 		ret.LastTime = row.Md.LastMsg.InsertTime
 		if ret.LastSeq > ret.ReadThrough {
 			ret.Unread = uint64(ret.LastSeq - ret.ReadThrough)
 		}
+		d.fillSnippet(m, rtp, cfgTeam, row, &ret)
 	}
 	return &ret, nil
+}
+
+// fillSnippet decorates a row view with a decrypted one-line preview of the
+// channel's last message, plus its sender's display name, when the message is
+// in the local cache (SyncInbox prefetches it there). Best-effort: any failure
+// leaves the fields nil rather than failing the render.
+func (d *Minder) fillSnippet(
+	m MetaContext,
+	rtp *RTParty,
+	cfgTeam lcl.ConfigTeam,
+	row *rem.RTInboxChannel,
+	out *lcl.RTInboxRowView,
+) {
+	seq := row.Md.LastMsg.Seq
+	enc, err := dbGetMsgs(m, d.au, row.Md.Id, seq, seq)
+	if err != nil {
+		m.Warnw("fillSnippet", "stage", "dbGet", "chid", row.Md.Id, "err", err)
+		return
+	}
+	if len(enc) != 1 {
+		return // not cached; no snippet
+	}
+	msgs, err := d.decodeMsgs(m, rtp, row.Md.AppID, row.Md.Id, enc)
+	if err != nil || len(msgs) != 1 {
+		if err != nil {
+			m.Warnw("fillSnippet", "stage", "decode", "chid", row.Md.Id, "err", err)
+		}
+		return
+	}
+	msg := msgs[0]
+	sn := snippet(msg.Body)
+	out.Snippet = &sn
+	if msg.Sender != nil && msg.Sender.IsUser() {
+		if uid, err := msg.Sender.UID(); err == nil {
+			if nm, ok := d.resolveSenderName(m, cfgTeam, rtp.PLCNode().ViewTok(), uid); ok {
+				out.LastSender = &nm
+			}
+		}
+	}
+}
+
+// snippetMaxLen bounds the snippet payload shipped over the agent RPC; it is
+// NOT display policy. Rendering to an actual width (console, window) is the
+// view layer's job -- see the CLI's inbox table, which fits the snippet to the
+// live terminal width. This just keeps a pathological multi-KB message body
+// from riding along with every inbox render.
+const snippetMaxLen = 512
+
+// snippet reduces a message body to its first line, bounded by snippetMaxLen.
+func snippet(body []byte) string {
+	s := string(body)
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		s = s[:i]
+	}
+	if len(s) > snippetMaxLen {
+		cut := snippetMaxLen
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		s = s[:cut] + "…"
+	}
+	return s
+}
+
+// prefetchLastMsg ensures a channel's last message sits in the local message
+// cache, fetching (and verifying) it from the server when absent, so the inbox
+// can render last-message snippets offline.
+func (d *Minder) prefetchLastMsg(
+	m MetaContext,
+	row *rem.RTInboxChannel,
+) error {
+	seq := row.Md.LastMsg.Seq
+	cached, err := dbGetMsgs(m, d.au, row.Md.Id, seq, seq)
+	if err != nil {
+		return err
+	}
+	if len(cached) > 0 {
+		return nil
+	}
+	rtp, err := d.base.GetParty(m.Base(), configTeamByID(row.Md.ParentTeam))
+	if err != nil {
+		return err
+	}
+	pr, cli, err := d.clientLocal(m.Base(), d.au)
+	if err != nil {
+		return err
+	}
+	d.serverThreadReads.Add(1)
+	page, err := cli.RtGetThread(m.Ctx(), rem.RTThreadQuery{
+		ChannelID: row.Md.Id,
+		Seqs:      []proto.RTMsgSeq{seq},
+	})
+	if err != nil {
+		return err
+	}
+	d.hookReadRes(&page)
+	sess := newMsgSession()
+	err = sess.loadFromServer(extractAllSeqIDPairsFromRTThreadPage(&page))
+	if err != nil {
+		return err
+	}
+	// The decode path only consults ch.Id from the request metadata, so a stub
+	// with just the ID suffices; the full decrypted channel metadata isn't
+	// needed to verify and cache a message.
+	irr := &initReqResult{
+		hostId: pr.Chain().HostID(),
+		rtp:    rtp,
+		appID:  row.Md.AppID,
+		cli:    cli,
+		ch:     &lcl.RTChannelMetadataPlaintext{Id: row.Md.Id},
+	}
+	_, err = d.decodeAndCacheServerMsgs(m, sess, irr, page.SeqMsgs)
+	return err
 }

--- a/client/librt/inbox.go
+++ b/client/librt/inbox.go
@@ -310,13 +310,9 @@ func (d *Minder) fillSnippet(
 	msg := msgs[0]
 	sn := snippet(msg.Body)
 	out.Snippet = &sn
-	if msg.Sender != nil && msg.Sender.IsUser() {
-		if uid, err := msg.Sender.UID(); err == nil {
-			if nm, err := d.resolveSenderName(m, cfgTeam, rtp, uid); err == nil {
-				out.LastSender = &nm
-			}
-		}
-	}
+	out.LastSender = core.Ptr(
+		d.resolveSenderNameFromPartyIDShowError(m, cfgTeam, rtp, msg.Sender),
+	)
 }
 
 // snippetMaxLen bounds the snippet payload shipped over the agent RPC; it is

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -1337,6 +1337,10 @@ func (d *Minder) ResolveSenderNames(
 // (open-vhost-or-as-local-user), which resolves symmetrically for any
 // co-member; named teams use the team-mediated (AsLocalTeam) load via the VO
 // bearer token.
+//
+// A cached bearer token can go stale inside the team-cache freshness window --
+// e.g. when the caller's own role in the team just changed -- so a stale-token
+// rejection force-refreshes the team (minting a fresh token) and retries once.
 func (d *Minder) resolveSenderName(
 	m MetaContext,
 	team lcl.ConfigTeam,
@@ -1350,12 +1354,25 @@ func (d *Minder) resolveSenderName(
 	if typ, err := team.GetT(); err == nil && typ == lcl.ConfigTeamType_AdHoc {
 		loadMode = libclient.LoadModeForAdHoc
 	}
-	nm, _, err := m.G().UsernameLoader().Load(m.Base(), fqu,
-		libclient.LoadUserArg{
-			Uid:               uid,
-			LoadMode:          loadMode,
-			TeamVOBearerToken: tok,
-		})
+	load := func(tok *rem.TeamVOBearerToken) (proto.NameUtf8, error) {
+		nm, _, err := m.G().UsernameLoader().Load(m.Base(), fqu,
+			libclient.LoadUserArg{
+				Uid:               uid,
+				LoadMode:          loadMode,
+				TeamVOBearerToken: tok,
+			})
+		return nm, err
+	}
+	nm, err := load(tok)
+	var staleErr core.TeamBearerTokenStaleError
+	if errors.As(err, &staleErr) {
+		rtp, err2 := d.base.GetPartyForceRefresh(m.Base(), team)
+		if err2 != nil {
+			m.Warnw("resolveSenderName", "stage", "staleRefresh", "uid", uid, "err", err2)
+			return "", false
+		}
+		nm, err = load(rtp.PLCNode().ViewTok())
+	}
 	if err != nil {
 		m.Warnw("resolveSenderName", "uid", uid, "err", err)
 		return "", false

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -1303,16 +1303,45 @@ func (d *Minder) ResolveSenderNames(
 		if _, ok := ret[uid]; ok {
 			continue
 		}
-		nm, err := d.resolveSenderName(m, team, rtp, uid)
-		var resolved proto.NameUtf8
-		if err == nil {
-			resolved = nm
-		} else {
-			resolved = proto.NameUtf8(fmt.Sprintf("<error: %s>", err.Error()))
-		}
-		ret[uid] = resolved
+		ret[uid] = d.resolveSenderNameFromUIDShowError(m, team, rtp, uid)
 	}
 	return ret, nil
+}
+
+func fmtNameUtf8Error(err error) proto.NameUtf8 {
+	return proto.NameUtf8(fmt.Sprintf("<error: %s>", err.Error()))
+}
+
+func (d *Minder) resolveSenderNameFromUIDShowError(
+	m MetaContext,
+	team lcl.ConfigTeam,
+	rtp *RTParty,
+	uid proto.UID,
+) proto.NameUtf8 {
+	nm, err := d.resolveSenderName(m, team, rtp, uid)
+	if err != nil {
+		return fmtNameUtf8Error(err)
+	}
+	return nm
+}
+
+func (d *Minder) resolveSenderNameFromPartyIDShowError(
+	m MetaContext,
+	team lcl.ConfigTeam,
+	rtp *RTParty,
+	partyID *proto.PartyID,
+) proto.NameUtf8 {
+	if partyID == nil {
+		return "<nil>"
+	}
+	if !partyID.IsUser() {
+		return "<non-user>"
+	}
+	uid, err := partyID.UID()
+	if err != nil {
+		return fmtNameUtf8Error(err)
+	}
+	return d.resolveSenderNameFromUIDShowError(m, team, rtp, uid)
 }
 
 // resolveSenderName returns the display name for a single sender UID, via the

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -1654,6 +1654,22 @@ func (d *Minder) GetThreadView(
 	for i := range msgs {
 		ret.Msgs = append(ret.Msgs, threadMessageToView(&msgs[i], names))
 	}
+
+	// Viewing a page implies reading it: advance the read pointer to the
+	// newest message shown, so unread counts (and the viewer's other devices)
+	// catch up on the next inbox sync. The pointer is monotonic server-side --
+	// stale marks no-op -- so paging back through history never regresses it.
+	// Best-effort: the read itself already succeeded.
+	if len(msgs) > 0 {
+		maxSeq := msgs[0].Seq
+		for i := range msgs[1:] {
+			maxSeq = max(maxSeq, msgs[i+1].Seq)
+		}
+		err = d.ReadThrough(m, team, appID, channel, maxSeq)
+		if err != nil {
+			m.Warnw("GetThreadView", "stage", "readThrough", "err", err)
+		}
+	}
 	return &ret, nil
 }
 

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -1286,7 +1286,10 @@ func (d *Minder) ResolveSenderNames(
 	team lcl.ConfigTeam,
 	rtp *RTParty,
 	msgs []ThreadMessage,
-) map[proto.UID]proto.NameUtf8 {
+) (
+	map[proto.UID]proto.NameUtf8,
+	error,
+) {
 	ret := make(map[proto.UID]proto.NameUtf8)
 	for i := range msgs {
 		sender := msgs[i].Sender
@@ -1295,16 +1298,21 @@ func (d *Minder) ResolveSenderNames(
 		}
 		uid, err := sender.UID()
 		if err != nil {
-			continue
+			return nil, err
 		}
 		if _, ok := ret[uid]; ok {
 			continue
 		}
-		if nm, ok := d.resolveSenderName(m, team, rtp, uid); ok {
-			ret[uid] = nm
+		nm, err := d.resolveSenderName(m, team, rtp, uid)
+		var resolved proto.NameUtf8
+		if err == nil {
+			resolved = nm
+		} else {
+			resolved = proto.NameUtf8(fmt.Sprintf("<error: %s>", err.Error()))
 		}
+		ret[uid] = resolved
 	}
-	return ret
+	return ret, nil
 }
 
 // resolveSenderName returns the display name for a single sender UID, via the
@@ -1326,7 +1334,10 @@ func (d *Minder) resolveSenderName(
 	team lcl.ConfigTeam,
 	rtp *RTParty,
 	uid proto.UID,
-) (proto.NameUtf8, bool) {
+) (
+	proto.NameUtf8,
+	error,
+) {
 	// The loader is keyed by FQUser; senders are always on the active user's
 	// host (see decryptAndVerifyMsg's HostMismatchError check).
 	fqu := proto.FQUser{Uid: uid, HostID: d.au.HostID()}
@@ -1346,12 +1357,12 @@ func (d *Minder) resolveSenderName(
 	tok := rtp.PLCNode().ViewTok()
 	nm, err := load(tok)
 	if err == nil {
-		return nm, true
+		return nm, nil
 	}
 	var staleErr core.TeamBearerTokenStaleError
 	if !errors.As(err, &staleErr) {
 		m.Warnw("resolveSenderName", "stage", "nonStale", "uid", uid, "err", err)
-		return "", false
+		return "", err
 	}
 	// Stale token. If a concurrent resolve already refreshed the team, the
 	// shared node holds a new token -- just use it. Otherwise force one
@@ -1363,16 +1374,16 @@ func (d *Minder) resolveSenderName(
 		rtp, err := d.base.GetPartyForceRefresh(m.Base(), team)
 		if err != nil {
 			m.Warnw("resolveSenderName", "stage", "staleRefresh", "uid", uid, "err", err)
-			return "", false
+			return "", err
 		}
 		tok = rtp.PLCNode().ViewTok()
 	}
 	nm, err = load(tok)
 	if err != nil {
 		m.Warnw("resolveSenderName", "stage", "staleRetry", "uid", uid, "err", err)
-		return "", false
+		return "", err
 	}
-	return nm, true
+	return nm, nil
 }
 
 // if inc > 1, sort ascending
@@ -1643,7 +1654,10 @@ func (d *Minder) GetThreadView(
 	if err != nil {
 		return nil, err
 	}
-	names := d.ResolveSenderNames(m, team, rtp, msgs)
+	names, err := d.ResolveSenderNames(m, team, rtp, msgs)
+	if err != nil {
+		return nil, err
+	}
 
 	ret := lcl.RTThreadView{AtBeginning: atBeginning}
 	for i := range msgs {

--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -1274,40 +1274,17 @@ func (d *Minder) initReq(
 	}, nil
 }
 
-// TeamViewToken returns the team's view bearer token, used for AsLocalTeam user
-// loads. The agent uses it to resolve message-sender UIDs to usernames: in
-// closed viewership mode, co-members can only load each other mediated through
-// the shared team, not directly. Returns nil if the team carries no view token
-// (e.g. it was loaded as self/owner); callers should treat name resolution as
-// best-effort and tolerate a nil token.
-func (d *Minder) TeamViewToken(
-	m MetaContext,
-	team lcl.ConfigTeam,
-) (
-	*rem.TeamVOBearerToken,
-	error,
-) {
-	err := assertTeam(team)
-	if err != nil {
-		return nil, err
-	}
-	rtp, err := d.base.GetParty(m.Base(), team)
-	if err != nil {
-		return nil, err
-	}
-	return rtp.PLCNode().ViewTok(), nil
-}
-
 // ResolveSenderNames maps each distinct user-sender UID in msgs to its display
 // name. Resolutions are memoized (see libclient.UsernameLoader) since each cache
 // miss is a full user-chain load; in closed viewership mode the load is mediated
-// through the shared team, so a team view bearer token (tok) is presented.
-// Best-effort: a sender that can't be loaded is omitted from the result rather
-// than failing.
+// through the shared team, presenting the team's view bearer token -- read
+// fresh from rtp's shared PLCNode per sender (see resolveSenderName), so a
+// mid-loop token refresh benefits every later sender. Best-effort: a sender
+// that can't be loaded is omitted from the result rather than failing.
 func (d *Minder) ResolveSenderNames(
 	m MetaContext,
 	team lcl.ConfigTeam,
-	tok *rem.TeamVOBearerToken,
+	rtp *RTParty,
 	msgs []ThreadMessage,
 ) map[proto.UID]proto.NameUtf8 {
 	ret := make(map[proto.UID]proto.NameUtf8)
@@ -1323,7 +1300,7 @@ func (d *Minder) ResolveSenderNames(
 		if _, ok := ret[uid]; ok {
 			continue
 		}
-		if nm, ok := d.resolveSenderName(m, team, tok, uid); ok {
+		if nm, ok := d.resolveSenderName(m, team, rtp, uid); ok {
 			ret[uid] = nm
 		}
 	}
@@ -1338,13 +1315,16 @@ func (d *Minder) ResolveSenderNames(
 // co-member; named teams use the team-mediated (AsLocalTeam) load via the VO
 // bearer token.
 //
-// A cached bearer token can go stale inside the team-cache freshness window --
-// e.g. when the caller's own role in the team just changed -- so a stale-token
-// rejection force-refreshes the team (minting a fresh token) and retries once.
+// The token is read from rtp's PLCNode at call time, not taken as a parameter:
+// a cached token can go stale inside the team-cache freshness window (e.g. the
+// caller's own role in the team just changed), and the recovery below refreshes
+// the shared node in place -- so one refresh heals every subsequent resolve
+// against the same team, rather than each sender re-tripping on a stale
+// snapshot.
 func (d *Minder) resolveSenderName(
 	m MetaContext,
 	team lcl.ConfigTeam,
-	tok *rem.TeamVOBearerToken,
+	rtp *RTParty,
 	uid proto.UID,
 ) (proto.NameUtf8, bool) {
 	// The loader is keyed by FQUser; senders are always on the active user's
@@ -1363,18 +1343,33 @@ func (d *Minder) resolveSenderName(
 			})
 		return nm, err
 	}
+	tok := rtp.PLCNode().ViewTok()
 	nm, err := load(tok)
+	if err == nil {
+		return nm, true
+	}
 	var staleErr core.TeamBearerTokenStaleError
-	if errors.As(err, &staleErr) {
-		rtp, err2 := d.base.GetPartyForceRefresh(m.Base(), team)
-		if err2 != nil {
-			m.Warnw("resolveSenderName", "stage", "staleRefresh", "uid", uid, "err", err2)
+	if !errors.As(err, &staleErr) {
+		m.Warnw("resolveSenderName", "stage", "nonStale", "uid", uid, "err", err)
+		return "", false
+	}
+	// Stale token. If a concurrent resolve already refreshed the team, the
+	// shared node holds a new token -- just use it. Otherwise force one
+	// refresh; it lands in the node, so later resolves fast-path. ViewTok
+	// returns a fresh copy per call, so compare by value (nil = no token).
+	if fresh := rtp.PLCNode().ViewTok(); !fresh.Eq(tok) {
+		tok = fresh
+	} else {
+		rtp, err := d.base.GetPartyForceRefresh(m.Base(), team)
+		if err != nil {
+			m.Warnw("resolveSenderName", "stage", "staleRefresh", "uid", uid, "err", err)
 			return "", false
 		}
-		nm, err = load(rtp.PLCNode().ViewTok())
+		tok = rtp.PLCNode().ViewTok()
 	}
+	nm, err = load(tok)
 	if err != nil {
-		m.Warnw("resolveSenderName", "uid", uid, "err", err)
+		m.Warnw("resolveSenderName", "stage", "staleRetry", "uid", uid, "err", err)
 		return "", false
 	}
 	return nm, true
@@ -1644,11 +1639,11 @@ func (d *Minder) GetThreadView(
 	if err != nil {
 		return nil, err
 	}
-	tok, err := d.TeamViewToken(m, team)
+	rtp, err := d.base.GetParty(m.Base(), team)
 	if err != nil {
 		return nil, err
 	}
-	names := d.ResolveSenderNames(m, team, tok, msgs)
+	names := d.ResolveSenderNames(m, team, rtp, msgs)
 
 	ret := lcl.RTThreadView{AtBeginning: atBeginning}
 	for i := range msgs {

--- a/integration-tests/cli/rt_test.go
+++ b/integration-tests/cli/rt_test.go
@@ -102,26 +102,13 @@ func TestRTAdHocTeamSendAndReceive(t *testing.T) {
 	msgFromBob := "thanks alice, glad to be here"
 	bob.runCmd(t, nil, "rt", "send", "--adhoc", string(aliceName), msgFromBob)
 
-	alice.runCmdToJSON(t, &thread, "rt", "read", "--adhoc", string(bobName))
-	require.Len(t, thread.Msgs, 2)
-	require.Equal(t, msgFromBob, string(thread.Msgs[0].Body))
-	require.NotNil(t, thread.Msgs[0].SenderName)
-	require.Equal(t, bobName, *thread.Msgs[0].SenderName)
-	require.Equal(t, msgFromAlice, string(thread.Msgs[1].Body))
-	require.NotNil(t, thread.Msgs[1].SenderName)
-	require.Equal(t, aliceName, *thread.Msgs[1].SenderName)
-
-	// The inbox renders the ad-hoc team DM-style: each viewer sees the *other*
-	// member's name -- not their own, and not the raw team ID. The expected
-	// name goes through the same normalization the canonical member list uses.
+	// Before alice reads the reply, her inbox counts it as unread: her own
+	// message was implicitly read by sending it, but bob's reply is news.
 	expectTeam := func(other proto.NameUtf8) proto.NameUtf8 {
 		s, err := team.NamesToAdhHocCanonicalString([]proto.NameUtf8{other}, "")
 		require.NoError(t, err)
 		return proto.NameUtf8(s)
 	}
-
-	// alice has bob's reply unread: her own message was implicitly read by
-	// sending it, and nothing has marked bob's reply read.
 	var ainbox lcl.RTInboxView
 	alice.runCmdToJSON(t, &ainbox, "rt", "inbox")
 	require.Len(t, ainbox.Rows, 1)
@@ -134,7 +121,26 @@ func TestRTAdHocTeamSendAndReceive(t *testing.T) {
 	require.NotNil(t, arow.LastSender)
 	require.Equal(t, bobName, *arow.LastSender)
 
-	// bob sent the last message, so nothing is unread for him.
+	alice.runCmdToJSON(t, &thread, "rt", "read", "--adhoc", string(bobName))
+	require.Len(t, thread.Msgs, 2)
+	require.Equal(t, msgFromBob, string(thread.Msgs[0].Body))
+	require.NotNil(t, thread.Msgs[0].SenderName)
+	require.Equal(t, bobName, *thread.Msgs[0].SenderName)
+	require.Equal(t, msgFromAlice, string(thread.Msgs[1].Body))
+	require.NotNil(t, thread.Msgs[1].SenderName)
+	require.Equal(t, aliceName, *thread.Msgs[1].SenderName)
+
+	// Reading the thread marked it read (viewing a page advances the read
+	// pointer), so alice's unread count clears. The inbox renders the ad-hoc
+	// team DM-style throughout: each viewer sees the *other* member's name --
+	// not their own, and not the raw team ID.
+	alice.runCmdToJSON(t, &ainbox, "rt", "inbox")
+	require.Len(t, ainbox.Rows, 1)
+	require.Equal(t, uint64(0), ainbox.Rows[0].Unread)
+	require.Equal(t, proto.RTMsgSeq(2), ainbox.Rows[0].ReadThrough)
+
+	// bob sent the last message (sending implies reading), so nothing is
+	// unread for him either.
 	var binbox lcl.RTInboxView
 	bob.runCmdToJSON(t, &binbox, "rt", "inbox")
 	require.Len(t, binbox.Rows, 1)

--- a/integration-tests/cli/rt_test.go
+++ b/integration-tests/cli/rt_test.go
@@ -115,7 +115,7 @@ func TestRTAdHocTeamSendAndReceive(t *testing.T) {
 	arow := ainbox.Rows[0]
 	require.NotNil(t, arow.TeamName)
 	require.Equal(t, expectTeam(bobName), *arow.TeamName)
-	require.Equal(t, uint64(1), arow.Unread)
+	require.Equal(t, uint64(1), arow.NumUnread)
 	require.NotNil(t, arow.Snippet)
 	require.Equal(t, msgFromBob, *arow.Snippet)
 	require.NotNil(t, arow.LastSender)
@@ -136,7 +136,7 @@ func TestRTAdHocTeamSendAndReceive(t *testing.T) {
 	// not their own, and not the raw team ID.
 	alice.runCmdToJSON(t, &ainbox, "rt", "inbox")
 	require.Len(t, ainbox.Rows, 1)
-	require.Equal(t, uint64(0), ainbox.Rows[0].Unread)
+	require.Equal(t, uint64(0), ainbox.Rows[0].NumUnread)
 	require.Equal(t, proto.RTMsgSeq(2), ainbox.Rows[0].ReadThrough)
 
 	// bob sent the last message (sending implies reading), so nothing is
@@ -147,7 +147,7 @@ func TestRTAdHocTeamSendAndReceive(t *testing.T) {
 	brow := binbox.Rows[0]
 	require.NotNil(t, brow.TeamName)
 	require.Equal(t, expectTeam(aliceName), *brow.TeamName)
-	require.Equal(t, uint64(0), brow.Unread)
+	require.Equal(t, uint64(0), brow.NumUnread)
 }
 
 // TestRTChannelMakeAndList exercises the CLI integration for making channels
@@ -260,7 +260,7 @@ func TestRTSendAndRead(t *testing.T) {
 	require.Equal(t, proto.RTChannelName("foo"), inbox.Rows[0].Ch.Name)
 	require.Equal(t, proto.RTMsgSeq(3), inbox.Rows[0].LastSeq)
 	require.Equal(t, proto.RTMsgSeq(3), inbox.Rows[0].ReadThrough)
-	require.Equal(t, uint64(0), inbox.Rows[0].Unread)
+	require.Equal(t, uint64(0), inbox.Rows[0].NumUnread)
 	require.NotNil(t, inbox.Rows[0].TeamName)
 	require.Equal(t, proto.NameUtf8(tm), *inbox.Rows[0].TeamName)
 	require.NotNil(t, inbox.Rows[0].Snippet)

--- a/integration-tests/cli/rt_test.go
+++ b/integration-tests/cli/rt_test.go
@@ -110,6 +110,38 @@ func TestRTAdHocTeamSendAndReceive(t *testing.T) {
 	require.Equal(t, msgFromAlice, string(thread.Msgs[1].Body))
 	require.NotNil(t, thread.Msgs[1].SenderName)
 	require.Equal(t, aliceName, *thread.Msgs[1].SenderName)
+
+	// The inbox renders the ad-hoc team DM-style: each viewer sees the *other*
+	// member's name -- not their own, and not the raw team ID. The expected
+	// name goes through the same normalization the canonical member list uses.
+	expectTeam := func(other proto.NameUtf8) proto.NameUtf8 {
+		s, err := team.NamesToAdhHocCanonicalString([]proto.NameUtf8{other}, "")
+		require.NoError(t, err)
+		return proto.NameUtf8(s)
+	}
+
+	// alice has bob's reply unread: her own message was implicitly read by
+	// sending it, and nothing has marked bob's reply read.
+	var ainbox lcl.RTInboxView
+	alice.runCmdToJSON(t, &ainbox, "rt", "inbox")
+	require.Len(t, ainbox.Rows, 1)
+	arow := ainbox.Rows[0]
+	require.NotNil(t, arow.TeamName)
+	require.Equal(t, expectTeam(bobName), *arow.TeamName)
+	require.Equal(t, uint64(1), arow.Unread)
+	require.NotNil(t, arow.Snippet)
+	require.Equal(t, msgFromBob, *arow.Snippet)
+	require.NotNil(t, arow.LastSender)
+	require.Equal(t, bobName, *arow.LastSender)
+
+	// bob sent the last message, so nothing is unread for him.
+	var binbox lcl.RTInboxView
+	bob.runCmdToJSON(t, &binbox, "rt", "inbox")
+	require.Len(t, binbox.Rows, 1)
+	brow := binbox.Rows[0]
+	require.NotNil(t, brow.TeamName)
+	require.Equal(t, expectTeam(aliceName), *brow.TeamName)
+	require.Equal(t, uint64(0), brow.Unread)
 }
 
 // TestRTChannelMakeAndList exercises the CLI integration for making channels
@@ -212,20 +244,29 @@ func TestRTSendAndRead(t *testing.T) {
 	require.Error(t, err)
 
 	// `rt inbox` syncs the inbox to local storage and renders it from there:
-	// one row for #foo with all three messages unread. --local-only skips the
-	// sync and must render identically from disk alone.
+	// one row for #foo showing the team's name (not its ID) and a snippet of
+	// the last message. Nothing is unread -- every message is bob's own, and
+	// sending implies reading. --local-only skips the sync and must render
+	// identically from disk alone.
 	var inbox lcl.RTInboxView
 	b.runCmdToJSON(t, &inbox, "rt", "inbox")
 	require.Len(t, inbox.Rows, 1)
 	require.Equal(t, proto.RTChannelName("foo"), inbox.Rows[0].Ch.Name)
 	require.Equal(t, proto.RTMsgSeq(3), inbox.Rows[0].LastSeq)
-	require.Equal(t, uint64(3), inbox.Rows[0].Unread)
+	require.Equal(t, proto.RTMsgSeq(3), inbox.Rows[0].ReadThrough)
+	require.Equal(t, uint64(0), inbox.Rows[0].Unread)
+	require.NotNil(t, inbox.Rows[0].TeamName)
+	require.Equal(t, proto.NameUtf8(tm), *inbox.Rows[0].TeamName)
+	require.NotNil(t, inbox.Rows[0].Snippet)
+	require.Equal(t, "a third one", *inbox.Rows[0].Snippet)
+	require.NotNil(t, inbox.Rows[0].LastSender)
+	require.Equal(t, bob.username, *inbox.Rows[0].LastSender)
 
 	var inbox2 lcl.RTInboxView
 	b.runCmdToJSON(t, &inbox2, "rt", "inbox", "--local-only")
 	require.Equal(t, inbox, inbox2)
 
-	// The text renderer shows the channel name and its unread count.
+	// The text renderer shows the channel, the team name, and the snippet.
 	var terminalUI terminalUI
 	uis := libclient.UIs{
 		Terminal: &terminalUI,
@@ -234,7 +275,8 @@ func TestRTSendAndRead(t *testing.T) {
 	require.NoError(t, err)
 	out := terminalUI.String()
 	require.Contains(t, out, "#foo")
-	require.Contains(t, out, "3")
+	require.Contains(t, out, tm)
+	require.Contains(t, out, "a third one")
 }
 
 // TestRTSendAndReadCrossMember verifies sender-name resolution across two

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -1151,7 +1151,7 @@ func TestRTSendReadPermissions(t *testing.T) {
 				vers:    r.InboxVersion,
 				read:    r.ReadThrough,
 				lastSeq: r.LastSeq,
-				unread:  r.Unread,
+				unread:  r.NumUnread,
 			}
 			if r.TeamName != nil {
 				ir.team = *r.TeamName

--- a/integration-tests/lib/rt_test.go
+++ b/integration-tests/lib/rt_test.go
@@ -1014,6 +1014,15 @@ func TestRTSendReadPermissions(t *testing.T) {
 		return v
 	}
 
+	// Sending implies reading: the send fanout stamped each sender's own read
+	// pointer at their message (no extra version bump -- see above), so a
+	// member's own messages never count against their unread badge. Recipients'
+	// pointers are untouched.
+	require.Equal(t, int64(1), ucRead(coco, chWatercooler))
+	require.Equal(t, int64(1), ucRead(bluey, chAnnounce))
+	require.Equal(t, int64(0), ucRead(bluey, chWatercooler))
+	require.Equal(t, int64(0), ucRead(coco, chAnnounce))
+
 	// coco marks announce read through its one message: her read pointer
 	// advances, her global inbox version bumps, and the announce row is
 	// stamped at the new version -- just like a delivery -- so her other
@@ -1093,12 +1102,13 @@ func TestRTSendReadPermissions(t *testing.T) {
 
 	// coco's full sync (since=0): both channels she's fanned into, oldest bump
 	// first; brass never appears (she was never fanned in, and it's admin-tier
-	// besides). Announce carries her read receipt.
+	// besides). Announce carries her explicit read receipt; watercooler carries
+	// the implicit one from her own send (sending implies reading).
 	delta, err := minderCoco.GetChangedThreads(mc, proto.RTAppID_Chat, 0, 0)
 	require.NoError(t, err)
 	require.Equal(t, proto.RTInboxVersion(5), delta.InboxVersion)
 	require.Equal(t, []row{
-		{id: *chWatercooler, vers: 3, read: 0, last: true},
+		{id: *chWatercooler, vers: 3, read: 1, last: true},
 		{id: *chAnnounce, vers: 5, read: 1, last: true},
 	}, summarize(delta))
 
@@ -1116,8 +1126,11 @@ func TestRTSendReadPermissions(t *testing.T) {
 
 	// --- inbox persistence (#303) ---
 
-	// One assertable summary per locally-rendered inbox row; the name field
-	// proves the render decrypted the stored (still-boxed) channel metadata.
+	// One assertable summary per locally-rendered inbox row. The name field
+	// proves the render decrypted the stored (still-boxed) channel metadata;
+	// team proves the teamname cache resolved the parent-team ID; snippet and
+	// sender prove the last message was prefetched into the local message
+	// cache, decrypted at render, and its sender's name resolved.
 	type irow struct {
 		id      proto.RTChannelID
 		name    proto.RTChannelName
@@ -1125,18 +1138,31 @@ func TestRTSendReadPermissions(t *testing.T) {
 		read    proto.RTMsgSeq
 		lastSeq proto.RTMsgSeq
 		unread  uint64
+		team    proto.NameUtf8
+		snippet string
+		sender  proto.NameUtf8
 	}
 	summarizeView := func(v *lcl.RTInboxView) []irow {
 		var out []irow
 		for _, r := range v.Rows {
-			out = append(out, irow{
+			ir := irow{
 				id:      r.Ch.Id,
 				name:    r.Ch.Name,
 				vers:    r.InboxVersion,
 				read:    r.ReadThrough,
 				lastSeq: r.LastSeq,
 				unread:  r.Unread,
-			})
+			}
+			if r.TeamName != nil {
+				ir.team = *r.TeamName
+			}
+			if r.Snippet != nil {
+				ir.snippet = *r.Snippet
+			}
+			if r.LastSender != nil {
+				ir.sender = *r.LastSender
+			}
+			out = append(out, ir)
 		}
 		return out
 	}
@@ -1144,7 +1170,8 @@ func TestRTSendReadPermissions(t *testing.T) {
 	// coco persists her inbox to local soft storage: the full sync applies both
 	// channel rows and lands the cursor at her head. The local render -- a pure
 	// disk read -- computes unread = lastSeq - readThrough per channel and
-	// returns rows newest bump first.
+	// returns rows newest bump first. Nothing is unread: announce she marked
+	// read explicitly, and watercooler's only message is her own.
 	csum, err := minderCoco.SyncInbox(mc, proto.RTAppID_Chat)
 	require.NoError(t, err)
 	require.Equal(t, proto.RTInboxVersion(5), csum.Vers)
@@ -1153,8 +1180,10 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, proto.RTInboxVersion(5), cview.Vers)
 	require.Equal(t, []irow{
-		{id: *chAnnounce, name: "announce", vers: 5, read: 1, lastSeq: 1, unread: 0},
-		{id: *chWatercooler, name: "watercooler", vers: 3, read: 0, lastSeq: 1, unread: 1},
+		{id: *chAnnounce, name: "announce", vers: 5, read: 1, lastSeq: 1, unread: 0,
+			team: tm.nm, snippet: "official notice", sender: bluey.name},
+		{id: *chWatercooler, name: "watercooler", vers: 3, read: 1, lastSeq: 1, unread: 0,
+			team: tm.nm, snippet: "hi all", sender: coco.name},
 	}, summarizeView(cview))
 
 	// bluey's full sync: all three channels, oldest bump first. brass has no
@@ -1164,7 +1193,7 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.Equal(t, proto.RTInboxVersion(6), delta.InboxVersion)
 	require.Equal(t, []row{
 		{id: *chBrass, vers: 3, read: 0, last: false},
-		{id: *chAnnounce, vers: 5, read: 0, last: true},
+		{id: *chAnnounce, vers: 5, read: 1, last: true},
 		{id: *chWatercooler, vers: 6, read: 1, last: true},
 	}, summarize(delta))
 
@@ -1176,7 +1205,7 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.Equal(t, proto.RTInboxVersion(6), delta.InboxVersion)
 	require.Equal(t, []row{
 		{id: *chBrass, vers: 3, read: 0, last: false},
-		{id: *chAnnounce, vers: 5, read: 0, last: true},
+		{id: *chAnnounce, vers: 5, read: 1, last: true},
 	}, summarize(delta))
 	delta, err = minderBluey.GetChangedThreads(mb, proto.RTAppID_Chat, 5, 2)
 	require.NoError(t, err)
@@ -1352,10 +1381,15 @@ func TestRTSendReadPermissions(t *testing.T) {
 	require.Equal(t, proto.RTInboxVersion(7), bsum.Vers)
 	require.Equal(t, uint64(3), bsum.NumChanged)
 
+	// Nothing is unread for bluey: the last message in each nonempty channel is
+	// her own, and sending stamps the sender's read pointer.
 	expectedBluey := []irow{
-		{id: *chWatercooler, name: "watercooler", vers: 7, read: 1, lastSeq: 2, unread: 1},
-		{id: *chAnnounce, name: "announce", vers: 5, read: 0, lastSeq: 1, unread: 1},
-		{id: *chBrass, name: "brass", vers: 3, read: 0, lastSeq: 0, unread: 0},
+		{id: *chWatercooler, name: "watercooler", vers: 7, read: 2, lastSeq: 2, unread: 0,
+			team: tm.nm, snippet: "wake up", sender: bluey.name},
+		{id: *chAnnounce, name: "announce", vers: 5, read: 1, lastSeq: 1, unread: 0,
+			team: tm.nm, snippet: "official notice", sender: bluey.name},
+		{id: *chBrass, name: "brass", vers: 3, read: 0, lastSeq: 0, unread: 0,
+			team: tm.nm},
 	}
 	bview, err := minderBluey.LocalInbox(mb, proto.RTAppID_Chat)
 	require.NoError(t, err)
@@ -1387,9 +1421,12 @@ func TestRTSendReadPermissions(t *testing.T) {
 	bview, err = minderBluey.LocalInbox(mb, proto.RTAppID_Chat)
 	require.NoError(t, err)
 	require.Equal(t, []irow{
-		{id: *chAnnounce, name: "announce", vers: 8, read: 0, lastSeq: 2, unread: 2},
-		{id: *chWatercooler, name: "watercooler", vers: 7, read: 1, lastSeq: 2, unread: 1},
-		{id: *chBrass, name: "brass", vers: 3, read: 0, lastSeq: 0, unread: 0},
+		{id: *chAnnounce, name: "announce", vers: 8, read: 2, lastSeq: 2, unread: 0,
+			team: tm.nm, snippet: "second notice", sender: bluey.name},
+		{id: *chWatercooler, name: "watercooler", vers: 7, read: 2, lastSeq: 2, unread: 0,
+			team: tm.nm, snippet: "wake up", sender: bluey.name},
+		{id: *chBrass, name: "brass", vers: 3, read: 0, lastSeq: 0, unread: 0,
+			team: tm.nm},
 	}, summarizeView(bview))
 
 	// dave syncs with page size 1: each page applies its rows and advances the
@@ -1409,10 +1446,16 @@ func TestRTSendReadPermissions(t *testing.T) {
 	dview, err := minderDave.LocalInbox(mdv, proto.RTAppID_Chat)
 	require.NoError(t, err)
 	require.Equal(t, proto.RTInboxVersion(5), dview.Vers)
+	// dave's unread counts are real: bluey wrote the last messages, and dave has
+	// only read announce through seq 1. His sync prefetched messages he never
+	// read into his local cache, so the snippets render from disk.
 	require.Equal(t, []irow{
-		{id: *chAnnounce, name: "announce", vers: 5, read: 1, lastSeq: 2, unread: 1},
-		{id: *chBrass, name: "brass", vers: 4, read: 0, lastSeq: 0, unread: 0},
-		{id: *chWatercooler, name: "watercooler", vers: wcVers, read: 0, lastSeq: 2, unread: 2},
+		{id: *chAnnounce, name: "announce", vers: 5, read: 1, lastSeq: 2, unread: 1,
+			team: tm.nm, snippet: "second notice", sender: bluey.name},
+		{id: *chBrass, name: "brass", vers: 4, read: 0, lastSeq: 0, unread: 0,
+			team: tm.nm},
+		{id: *chWatercooler, name: "watercooler", vers: wcVers, read: 0, lastSeq: 2, unread: 2,
+			team: tm.nm, snippet: "wake up", sender: bluey.name},
 	}, summarizeView(dview))
 }
 

--- a/integration-tests/lib/team_adhoc_test.go
+++ b/integration-tests/lib/team_adhoc_test.go
@@ -207,7 +207,7 @@ func TestSimpleCreateTeamAdHoc(t *testing.T) {
 	// The cache is two-tiered; the bottom tier is the soft local DB. A fresh
 	// cache with an empty memory tier must still resolve via the DB row that
 	// the Set above just wrote.
-	var uc2 libclient.UsernameLoader
+	uc2 := libclient.NewUsernameLoader()
 	nm2, ok := uc2.Get(f.ma, bobFqu)
 	require.True(t, ok)
 	require.Equal(t, bob.name, nm2)

--- a/lib/team/adhoc.go
+++ b/lib/team/adhoc.go
@@ -127,23 +127,26 @@ func NamesToAdhHocCanonicalString(
 func StripSelfFromAdHocName(
 	nm proto.NameUtf8,
 	self proto.NameUtf8,
-) proto.NameUtf8 {
+) (
+	proto.NameUtf8,
+	error,
+) {
 	selfNorm, err := core.NormalizeName(self)
 	if err != nil {
-		return nm
+		return "", err
 	}
-	parts := strings.Split(string(nm), ",")
+	parts := strings.Split(nm.String(), ",")
 	kept := make([]string, 0, len(parts))
 	for _, p := range parts {
 		// Canonical lists hold normalized names, so direct comparison works.
-		if p != string(selfNorm) {
+		if !proto.Name(p).Eq(selfNorm) {
 			kept = append(kept, p)
 		}
 	}
 	if len(kept) == 0 || len(kept) == len(parts) {
-		return nm
+		return nm, nil
 	}
-	return proto.NameUtf8(strings.Join(kept, ","))
+	return proto.NameUtf8(strings.Join(kept, ",")), nil
 }
 
 func UIDsToAdhHocCanonicalString(

--- a/lib/team/adhoc.go
+++ b/lib/team/adhoc.go
@@ -120,6 +120,32 @@ func NamesToAdhHocCanonicalString(
 	), nil
 }
 
+// StripSelfFromAdHocName drops the viewer's own username from a canonical
+// ad-hoc member-name list ("alice,bob,charlie" -> "bob,charlie" for alice),
+// for DM-style display of ad-hoc teams. A name that doesn't parse, or a list
+// that would strip to nothing (a solo team), is returned unchanged.
+func StripSelfFromAdHocName(
+	nm proto.NameUtf8,
+	self proto.NameUtf8,
+) proto.NameUtf8 {
+	selfNorm, err := core.NormalizeName(self)
+	if err != nil {
+		return nm
+	}
+	parts := strings.Split(string(nm), ",")
+	kept := make([]string, 0, len(parts))
+	for _, p := range parts {
+		// Canonical lists hold normalized names, so direct comparison works.
+		if p != string(selfNorm) {
+			kept = append(kept, p)
+		}
+	}
+	if len(kept) == 0 || len(kept) == len(parts) {
+		return nm
+	}
+	return proto.NameUtf8(strings.Join(kept, ","))
+}
+
 func UIDsToAdhHocCanonicalString(
 	uids []proto.UID,
 	uid proto.UID,

--- a/proto-src/lcl/db.snowp
+++ b/proto-src/lcl/db.snowp
@@ -24,6 +24,7 @@ enum DataType {
     UsernameReservation @14;
     UsernameLookup @15;
     UsernameCacheEntry @16; // soft-state UID -> username memo; see libclient.UsernameLoader
+    TeamnameCacheEntry @17; // soft-state TeamID -> teamname memo; see libclient.TeamnameLoader
 
     KVRealm @65;
     KVNSRoot @66;

--- a/proto-src/lcl/realtime.snowp
+++ b/proto-src/lcl/realtime.snowp
@@ -84,6 +84,10 @@ struct RTInboxRowView {
     unread @5 : Uint;                     // max(lastSeq - readThrough, 0)
     hidden @6 : Bool;
     muted @7 : Bool;
+    teamName @8 : Option(lib.NameUtf8);   // via the teamname cache; nil if unresolved
+    snippet @9 : Option(Text);            // first line of the last message, decrypted at render;
+                                          // nil if the message isn't in the local cache
+    lastSender @10 : Option(lib.NameUtf8); // last message's sender; nil if unresolved
 }
 
 // The viewer's inbox, rendered entirely from local storage.

--- a/proto-src/lcl/realtime.snowp
+++ b/proto-src/lcl/realtime.snowp
@@ -81,7 +81,7 @@ struct RTInboxRowView {
     readThrough @2 : lib.RTMsgSeq;        // viewer's read pointer; 0 = nothing read
     lastSeq @3 : lib.RTMsgSeq;            // last message in channel; 0 = no messages
     lastTime @4 : lib.Time;               // server insert time of last message; 0 if none
-    unread @5 : Uint;                     // max(lastSeq - readThrough, 0)
+    numUnread @5 : Uint;                  // max(lastSeq - readThrough, 0)
     hidden @6 : Bool;
     muted @7 : Bool;
     teamName @8 : Option(lib.NameUtf8);   // via the teamname cache; nil if unresolved

--- a/proto/lcl/db.go
+++ b/proto/lcl/db.go
@@ -65,6 +65,7 @@ const (
 	DataType_UsernameReservation  DataType = 14
 	DataType_UsernameLookup       DataType = 15
 	DataType_UsernameCacheEntry   DataType = 16
+	DataType_TeamnameCacheEntry   DataType = 17
 	DataType_KVRealm              DataType = 65
 	DataType_KVNSRoot             DataType = 66
 	DataType_KVDir                DataType = 67
@@ -98,6 +99,7 @@ var DataTypeMap = map[string]DataType{
 	"UsernameReservation":  14,
 	"UsernameLookup":       15,
 	"UsernameCacheEntry":   16,
+	"TeamnameCacheEntry":   17,
 	"KVRealm":              65,
 	"KVNSRoot":             66,
 	"KVDir":                67,
@@ -130,6 +132,7 @@ var DataTypeRevMap = map[DataType]string{
 	14:  "UsernameReservation",
 	15:  "UsernameLookup",
 	16:  "UsernameCacheEntry",
+	17:  "TeamnameCacheEntry",
 	65:  "KVRealm",
 	66:  "KVNSRoot",
 	67:  "KVDir",

--- a/proto/lcl/realtime.go
+++ b/proto/lcl/realtime.go
@@ -783,6 +783,9 @@ type RTInboxRowView struct {
 	Unread       uint64
 	Hidden       bool
 	Muted        bool
+	TeamName     *lib.NameUtf8
+	Snippet      *string
+	LastSender   *lib.NameUtf8
 }
 type RTInboxRowViewInternal__ struct {
 	_struct      struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -794,6 +797,9 @@ type RTInboxRowViewInternal__ struct {
 	Unread       *uint64
 	Hidden       *bool
 	Muted        *bool
+	TeamName     *lib.NameUtf8Internal__
+	Snippet      *string
+	LastSender   *lib.NameUtf8Internal__
 }
 
 func (r RTInboxRowViewInternal__) Import() RTInboxRowView {
@@ -846,6 +852,42 @@ func (r RTInboxRowViewInternal__) Import() RTInboxRowView {
 			}
 			return *x
 		})(r.Muted),
+		TeamName: (func(x *lib.NameUtf8Internal__) *lib.NameUtf8 {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *lib.NameUtf8Internal__) (ret lib.NameUtf8) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(r.TeamName),
+		Snippet: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *string) (ret string) {
+				if x == nil {
+					return ret
+				}
+				return *x
+			})(x)
+			return &tmp
+		})(r.Snippet),
+		LastSender: (func(x *lib.NameUtf8Internal__) *lib.NameUtf8 {
+			if x == nil {
+				return nil
+			}
+			tmp := (func(x *lib.NameUtf8Internal__) (ret lib.NameUtf8) {
+				if x == nil {
+					return ret
+				}
+				return x.Import()
+			})(x)
+			return &tmp
+		})(r.LastSender),
 	}
 }
 func (r RTInboxRowView) Export() *RTInboxRowViewInternal__ {
@@ -858,6 +900,19 @@ func (r RTInboxRowView) Export() *RTInboxRowViewInternal__ {
 		Unread:       &r.Unread,
 		Hidden:       &r.Hidden,
 		Muted:        &r.Muted,
+		TeamName: (func(x *lib.NameUtf8) *lib.NameUtf8Internal__ {
+			if x == nil {
+				return nil
+			}
+			return (*x).Export()
+		})(r.TeamName),
+		Snippet: r.Snippet,
+		LastSender: (func(x *lib.NameUtf8) *lib.NameUtf8Internal__ {
+			if x == nil {
+				return nil
+			}
+			return (*x).Export()
+		})(r.LastSender),
 	}
 }
 func (r *RTInboxRowView) Encode(enc rpc.Encoder) error {

--- a/proto/lcl/realtime.go
+++ b/proto/lcl/realtime.go
@@ -780,7 +780,7 @@ type RTInboxRowView struct {
 	ReadThrough  lib.RTMsgSeq
 	LastSeq      lib.RTMsgSeq
 	LastTime     lib.Time
-	Unread       uint64
+	NumUnread    uint64
 	Hidden       bool
 	Muted        bool
 	TeamName     *lib.NameUtf8
@@ -794,7 +794,7 @@ type RTInboxRowViewInternal__ struct {
 	ReadThrough  *lib.RTMsgSeqInternal__
 	LastSeq      *lib.RTMsgSeqInternal__
 	LastTime     *lib.TimeInternal__
-	Unread       *uint64
+	NumUnread    *uint64
 	Hidden       *bool
 	Muted        *bool
 	TeamName     *lib.NameUtf8Internal__
@@ -834,12 +834,12 @@ func (r RTInboxRowViewInternal__) Import() RTInboxRowView {
 			}
 			return x.Import()
 		})(r.LastTime),
-		Unread: (func(x *uint64) (ret uint64) {
+		NumUnread: (func(x *uint64) (ret uint64) {
 			if x == nil {
 				return ret
 			}
 			return *x
-		})(r.Unread),
+		})(r.NumUnread),
 		Hidden: (func(x *bool) (ret bool) {
 			if x == nil {
 				return ret
@@ -897,7 +897,7 @@ func (r RTInboxRowView) Export() *RTInboxRowViewInternal__ {
 		ReadThrough:  r.ReadThrough.Export(),
 		LastSeq:      r.LastSeq.Export(),
 		LastTime:     r.LastTime.Export(),
-		Unread:       &r.Unread,
+		NumUnread:    &r.NumUnread,
 		Hidden:       &r.Hidden,
 		Muted:        &r.Muted,
 		TeamName: (func(x *lib.NameUtf8) *lib.NameUtf8Internal__ {

--- a/proto/rem/extras.go
+++ b/proto/rem/extras.go
@@ -78,6 +78,17 @@ func (k TeamRemovalKey) Eq(k2 TeamRemovalKey) bool {
 	return hmac.Equal(k[:], k2[:])
 }
 
+// Eq compares bearer tokens in constant time (they're secrets, so a
+// short-circuiting comparison could leak via timing if ever used against
+// attacker-supplied input). Pointer form since tokens are optional in many
+// spots; nil equals only nil.
+func (t *TeamVOBearerToken) Eq(t2 *TeamVOBearerToken) bool {
+	if t == nil || t2 == nil {
+		return t == t2
+	}
+	return hmac.Equal(t[:], t2[:])
+}
+
 func (r TeamRawInboxRowVar) Token() (lib.TeamRSVP, error) {
 	var zed lib.TeamRSVP
 	typ, err := r.GetT()

--- a/server/realtime/messages.go
+++ b/server/realtime/messages.go
@@ -31,7 +31,7 @@ type messageSender struct {
 	parentTeam proto.TeamID
 	writeRole  proto.Role
 	readRole   proto.Role
-	prevSeq    int64
+	prevSeq    proto.RTMsgSeq
 	appID      proto.RTAppID
 
 	// members whose inbox versions the fanout bumped; the caller wakes their
@@ -47,7 +47,7 @@ func (s *messageSender) channelID() int64 { return int64(s.arg.Chid) }
 func (s *messageSender) lockChannel(m shared.MetaContext) error {
 	var teamRaw []byte
 	var wrt, wvl, rrt, rvl int
-	var prevSeq *int64
+	var prevSeqRaw *int64
 	var appRaw string
 	err := s.tx.QueryRow(
 		m.Ctx(),
@@ -58,7 +58,7 @@ func (s *messageSender) lockChannel(m shared.MetaContext) error {
 		 FOR UPDATE`,
 		m.ShortHostID(),
 		s.channelID(),
-	).Scan(&teamRaw, &wrt, &wvl, &rrt, &rvl, &prevSeq, &appRaw)
+	).Scan(&teamRaw, &wrt, &wvl, &rrt, &rvl, &prevSeqRaw, &appRaw)
 	if err == pgx.ErrNoRows {
 		return core.RowNotFoundError{}
 	}
@@ -81,8 +81,8 @@ func (s *messageSender) lockChannel(m shared.MetaContext) error {
 	if err != nil {
 		return err
 	}
-	if prevSeq != nil {
-		s.prevSeq = *prevSeq
+	if prevSeqRaw != nil {
+		s.prevSeq = proto.RTMsgSeq(*prevSeqRaw)
 	}
 	return nil
 }
@@ -154,7 +154,7 @@ func (s *messageSender) internSender(m shared.MetaContext) (int, error) {
 func (s *messageSender) insertMessage(
 	m shared.MetaContext,
 	senderNo int,
-	seq int64,
+	seq proto.RTMsgSeq,
 ) (
 	proto.Time,
 	error,
@@ -204,7 +204,7 @@ func (s *messageSender) insertMessage(
 		 RETURNING insert_time`,
 		m.ShortHostID(),
 		s.channelID(),
-		seq,
+		seq.Int64(),
 		s.arg.Md.MsgID.Bytes(),
 		typ,
 		naclctxt,
@@ -256,7 +256,7 @@ func (s *messageSender) insertMessage(
 func (s *messageSender) fanoutInboxVersions(
 	m shared.MetaContext,
 	insertTime time.Time,
-	seq int64,
+	seq proto.RTMsgSeq,
 ) error {
 	// Bump each member's (uid, app) global inbox version. The insert arm is
 	// paranoia -- the channel-creation fanout writes user_inbox before
@@ -323,7 +323,7 @@ func (s *messageSender) fanoutInboxVersions(
 		s.channelID(),
 		insertTime,
 		s.sender.ExportToDB(),
-		seq,
+		seq.Int64(),
 	)
 	return err
 }
@@ -340,7 +340,7 @@ func (s *messageSender) run(m shared.MetaContext) (*rem.RTSendRes, error) {
 	seq := s.prevSeq + 1
 	// Optional optimistic-concurrency check from the client.
 	if s.arg.ExpectedPrevSeq.IsValid() &&
-		s.arg.ExpectedPrevSeq.Int64() != s.prevSeq {
+		s.arg.ExpectedPrevSeq != s.prevSeq {
 		return nil, core.RTRaceError{Which: "messages"}
 	}
 	senderNo, err := s.internSender(m)

--- a/server/realtime/messages.go
+++ b/server/realtime/messages.go
@@ -256,6 +256,7 @@ func (s *messageSender) insertMessage(
 func (s *messageSender) fanoutInboxVersions(
 	m shared.MetaContext,
 	insertTime time.Time,
+	seq int64,
 ) error {
 	// Bump each member's (uid, app) global inbox version. The insert arm is
 	// paranoia -- the channel-creation fanout writes user_inbox before
@@ -301,11 +302,19 @@ func (s *messageSender) fanoutInboxVersions(
 
 	// Stamp each membership row at its owner's just-bumped global version, and
 	// refresh the denormalized last-message time for inbox ordering. Reads the
-	// user_inbox rows written above in the same transaction.
+	// user_inbox rows written above in the same transaction. Sending implies
+	// reading: the sender's own read pointer advances to the new message in the
+	// same stamp (GREATEST keeps it monotonic), so a member's own messages never
+	// count against their unread badge. No extra version is consumed -- the row
+	// was bumping for the delivery anyway, so other devices pick the read state
+	// up along with the message.
 	_, err = s.tx.Exec(
 		m.Ctx(),
 		`UPDATE user_channels uc
-		 SET inbox_version = ui.inbox_version, last_msg_time = $3, mtime = NOW()
+		 SET inbox_version = ui.inbox_version, last_msg_time = $3, mtime = NOW(),
+		     read_through = CASE WHEN uc.uid = $4
+		                         THEN GREATEST(uc.read_through, $5)
+		                         ELSE uc.read_through END
 		 FROM user_inbox ui
 		 WHERE ui.short_host_id = uc.short_host_id
 		   AND ui.uid = uc.uid AND ui.app_id = uc.app_id
@@ -313,6 +322,8 @@ func (s *messageSender) fanoutInboxVersions(
 		m.ShortHostID(),
 		s.channelID(),
 		insertTime,
+		s.sender.ExportToDB(),
+		seq,
 	)
 	return err
 }
@@ -340,7 +351,7 @@ func (s *messageSender) run(m shared.MetaContext) (*rem.RTSendRes, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = s.fanoutInboxVersions(m, insertTime.Import())
+	err = s.fanoutInboxVersions(m, insertTime.Import(), seq)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Stacked on #307; addresses its review comments. Merges down into `chat/1d-inbox-persist` after review.

## (1) Team name, not ID

- New `libclient.TeamnameLoader` (FQTeam → display name). Per review, the two-tier machinery (memory map in front of soft-DB rows, jittered ~6h TTL, write-time-anchored expiry) is factored out of `UsernameLoader` into a generic `nameCache[K]` shared by both; `UsernameLoader` keeps only its single-flight load integration.
- Filled at the team-load choke point (`LoadTeamWithFQTeam`), so any team load warms it. No integrated network load on miss yet — the render falls back to the raw ID, and wiring the cache into more display paths is the follow-up you suggested.
- **Ad-hoc teams render DM-style**: the cache stores the canonical full member list (`alice,bob,charlie` — viewer-agnostic, since the GlobalContext cache spans local users) and the inbox render strips the viewer (`bob,charlie` in alice's inbox). Two loader fixes feed this: `LoadTeamWithFQTeam` now sets `LoadMemberNames` for ad-hoc teams (previously only the explore path did), and the member-name walk calls the lazy `index()` itself (`AllFQAdHocTeamStrings` had relied on callers having indexed, and silently truncated its UID list when a name was missing — both now fixed).

## (2) Own messages don't count as unread

Sending implies reading: the send fanout stamps the sender's `read_through` at the new message inside the `user_channels` write it already does (`GREATEST` keeps it monotonic, no extra inbox-version bump). Unread badges now only count other people's messages, including for interleaved histories — no client-side heuristics.

## (3) Last-message snippet

- `SyncInbox` prefetches each changed channel's last message into the local (ciphertext) message cache — best-effort, after the page apply, skipped when already cached (e.g. your own sends).
- `LocalInbox` decrypts it at render into a first-line snippet plus the sender's resolved display name (`RTInboxRowView.snippet` / `lastSender` / `teamName`).
- Snippet length is not display policy: librt only applies a generous payload bound; the CLI sizes the snippet column to the live terminal width (via `libterm`), and doesn't truncate piped/captured output at all.

## Also: stale bearer-token recovery

`resolveSenderName` now recovers when the server rejects a cached team view token as stale (the caller's own membership changed inside the team-cache freshness window): it force-refreshes the team party (`PLCOpts.ForceRefresh` / `BaseMinder.GetPartyForceRefresh`, minting a fresh token) and retries once. Previously both the inbox and `GetThreadView` rendered nameless senders until the team cache timed out (15s default, but a config knob). Surfaced by dave's promote-then-render sequence in the test.

## Tests

- `TestRTSendReadPermissions`: inbox asserts extended with team names, snippets, and senders; send-stamps-read pinned at the SQL level; all unread expectations recomputed (bluey/coco drop to zero — their last messages are their own; dave keeps real unread counts from bluey's messages, exercising the prefetch and the stale-token retry).
- `TestRTAdHocTeamSendAndReceive`: DM-style inbox asserts for both viewers (each sees the other's name, own name stripped).
- `TestRTSendAndRead` (cli): team name + snippet in JSON and text output.
- Full lib and cli suites pass; RT tests clean under `-race`.

Co-authored-by: Claude Code