### PR TITLE
fix(db): allow former members to rejoin a team (partial unique index)

### DIFF
--- a/integration-tests/cli/team_test.go
+++ b/integration-tests/cli/team_test.go
@@ -630,6 +630,27 @@ func TestTeamChangeMembershipClosedViewership(t *testing.T) {
 	// specify the source role
 	x.runCmd(t, nil, "team", "change-roles", teamName, yuid+"/o->m/0")
 	merklePoke(t)
+
+	// Issue #314: remove y from the team, then let y re-accept the same
+	// invite. The insert into local_joinreqs used to hit the "one join
+	// request per joiner EVER" unique index and fail with
+	// TeamInviteAlreadyAcceptedError, leaving no way back in via the
+	// normal flow.
+	x.runCmd(t, nil, "team", "change-roles", teamName, yusername.String()+"->n")
+	merklePoke(t)
+
+	var ros lcl.TeamRoster
+	x.runCmdToJSON(t, &ros, "team", "ls", teamName)
+	require.Equal(t, 1, len(ros.Members))
+
+	y.runCmd(t, nil, "team", "accept", inviteStr)
+	x.runCmdToJSON(t, &inb, "team", "inbox", teamName)
+	require.Equal(t, 1, len(inb.Rows))
+	x.runCmd(t, nil, "team", "admit", teamName, string(inb.Rows[0].Tok.String())+"/m/0")
+	merklePoke(t)
+
+	x.runCmdToJSON(t, &ros, "team", "ls", teamName)
+	require.Equal(t, 2, len(ros.Members))
 }
 
 func TestTeamChangeMembershipClosedViewershipTestReload(t *testing.T) {

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -56,6 +56,9 @@ var usersPatch5 string
 //go:embed patches/foks_users/p6.sql
 var usersPatch6 string
 
+//go:embed patches/foks_users/p7.sql
+var usersPatch7 string
+
 //go:embed patches/foks_server_config/p1.sql
 var serverConfigPatch1 string
 
@@ -85,6 +88,7 @@ var Patches = map[string]map[int]string{
 		4: usersPatch4,
 		5: usersPatch5,
 		6: usersPatch6,
+		7: usersPatch7,
 	},
 	"foks_server_config": {
 		1: serverConfigPatch1,

--- a/server/sql/foks_users.sql
+++ b/server/sql/foks_users.sql
@@ -623,7 +623,9 @@ CREATE TABLE local_joinreqs (
     PRIMARY KEY(short_host_id, team_id, token),
     FOREIGN KEY(short_host_id, team_id) REFERENCES teams(short_host_id, team_id)
 );
-CREATE UNIQUE INDEX local_joinreq_joiner_idx ON local_joinreqs(short_host_id, team_id, joiner_party_id, joiner_src_role_type, joiner_src_viz_level);
+/* Partial (state='pending'): one PENDING join request per joiner at a time;
+   historical approved/rejected rows don't block a rejoin (see patch p7). */
+CREATE UNIQUE INDEX local_joinreq_joiner_idx ON local_joinreqs(short_host_id, team_id, joiner_party_id, joiner_src_role_type, joiner_src_viz_level) WHERE state = 'pending';
 CREATE INDEX local_joinreqs_inbox_idx ON local_joinreqs(short_host_id, team_id, state, ctime);
 
 CREATE TYPE team_bearer_token_state as ENUM('inert', 'active', 'expired', 'revoked');
@@ -1006,3 +1008,4 @@ INSERT INTO schema_patches (id, ctime) VALUES (3, NOW());
 INSERT INTO schema_patches (id, ctime) VALUES (4, NOW());
 INSERT INTO schema_patches (id, ctime) VALUES (5, NOW());
 INSERT INTO schema_patches (id, ctime) VALUES (6, NOW());
+INSERT INTO schema_patches (id, ctime) VALUES (7, NOW());

--- a/server/sql/patches/foks_users/p7.sql
+++ b/server/sql/patches/foks_users/p7.sql
@@ -1,0 +1,22 @@
+/*
+ * Rejoin-after-leave fix (SECO): allow a former member to create a NEW join
+ * request once their earlier one is no longer pending.
+ *
+ * The original index enforced "one join request per joiner per team, EVER" —
+ * but admit/reject only UPDATE the row's state (never delete), so a user who
+ * joined once, left, and was re-invited could never re-RSVP: the insert hit
+ * the index and returned TeamInviteAlreadyAcceptedError ("team invite
+ * already accepted" — observed in the wild on 2026-06-10).
+ *
+ * The partial index preserves the original intent (no duplicate PENDING
+ * requests — the insert handler's IsDuplicateKeyError check keeps working,
+ * same index name) while letting historical approved/rejected/withdrawn rows
+ * accumulate harmlessly. All readers are state- or token-scoped; the parallel
+ * remote_joinreqs table never had joiner uniqueness at all.
+ */
+
+DROP INDEX IF EXISTS local_joinreq_joiner_idx;
+CREATE UNIQUE INDEX local_joinreq_joiner_idx
+    ON local_joinreqs(short_host_id, team_id, joiner_party_id,
+                      joiner_src_role_type, joiner_src_viz_level)
+    WHERE state = 'pending';


### PR DESCRIPTION
Supersedes #288 — same fix, rebased onto current main. The first commit is @st3v3y's original work, authorship preserved; it couldn't be updated in place because the fork is org-owned, where GitHub ignores "allow edits by maintainers".

Changes relative to #288 as filed:

- **Renumbered p6 → p7**: main took `p6.sql` for `user_membership_vers` (#306) after the PR was opened, so the patch, `embed.go` registration, and base-schema comment all move to 7.
- **Added the `schema_patches (7, NOW())` row** to `foks_users.sql`, which the original PR missed — without it a fresh install would re-run the patch through the patch engine.
- **Added an integration test for issue #314** (which this fixes): `TestTeamChangeMembershipClosedViewership` now admits a member via invite, removes them (`->n`), has them re-accept the same invite, and re-admits them from the inbox. Verified failing with `TeamInviteAlreadyAcceptedError` on main, passing with the fix.

Fixes #314.

Co-authored-by: Claude Code