### PR TITLE
fix(clkr): preserve each member's role when rekeying

### DIFF
--- a/client/libclient/team_clkr.go
+++ b/client/libclient/team_clkr.go
@@ -158,9 +158,13 @@ type CLKROneTeam struct {
 	parent *CLKR
 	fqt    proto.FQTeam
 
+	// actorRole is the role of the party we are running CLKR *as*. It gates
+	// whether we may act at all, and which members we may touch. It is never
+	// the role we write into a change; see doOneMember.
+	actorRole *core.RoleKey
+
 	// internal state fields that are updated as we go
 	changes []proto.MemberRole
-	dstRole *proto.Role
 	roster  *team.Roster
 	tw      *TeamWrapper
 	hepks   *core.HEPKSet
@@ -180,13 +184,8 @@ func (c *CLKROneTeam) run(
 		return err
 	}
 
-	doIt, err := c.checkAdmin(m)
-	if err != nil {
-		return err
-	}
-
-	if !doIt {
-		m.Infow("clkr", "team", c.tw.FQTeam(), "role", *c.dstRole,
+	if !c.actorRole.IsAdminOrAbove() {
+		m.Infow("clkr", "team", c.tw.FQTeam(), "actorRole", c.actorRole.Export(),
 			"why", "not admin or above", "action", "skip")
 		return nil
 	}
@@ -293,24 +292,17 @@ func (c *CLKROneTeam) loadTeam(m MetaContext) error {
 		return core.TeamExploreError("load as party not found in team")
 	}
 
+	actorRole, err := core.ImportRole(tmem.Mr.DstRole)
+	if err != nil {
+		return err
+	}
+
 	c.member = tr.member
-	c.dstRole = &tmem.Mr.DstRole
+	c.actorRole = actorRole
 	c.roster = ldr.rosterPost
 	c.tw = tw
 	c.ldr = ldr
 	return nil
-}
-
-func (c *CLKROneTeam) checkAdmin(m MetaContext) (bool, error) {
-	ok, err := c.dstRole.IsAdminOrAbove()
-	if err != nil {
-		return false, err
-	}
-
-	if !ok {
-		return false, nil
-	}
-	return true, nil
 }
 
 func (c *CLKROneTeam) checkMembers(m MetaContext) error {
@@ -336,6 +328,18 @@ func (c *CLKROneTeam) doOneMember(
 	fqe proto.FQEntityFixed,
 	deet *rosterPackage,
 ) error {
+
+	// A doer may not touch a member whose role is above its own; the roster
+	// would reject the whole change set (see RosterCore.checkChangesLocked),
+	// which in turn aborts the sweep for every remaining team. Skip them so one
+	// stale owner doesn't block an admin's rekey of everyone else. Such members
+	// must be picked up by an owner-run CLKR.
+	if c.actorRole.LessThan(deet.info.Role) {
+		m.Infow("doOneMember", "team", c.tw.FQTeam(), "member", fqe.Unfix(),
+			"memberRole", deet.info.Role.Export(), "actorRole", c.actorRole.Export(),
+			"why", "above actor role", "action", "skip")
+		return nil
+	}
 
 	srcRk, err := core.ImportRole(deet.srcRole)
 	if err != nil {
@@ -387,8 +391,10 @@ func (c *CLKROneTeam) doOneMember(
 
 	m.Infow("doOneMember", "tmk", tmk)
 
+	// CLKR refreshes keys; it never changes roles. Carry the member's own
+	// role through, not the actor's.
 	tmr := proto.MemberRole{
-		DstRole: *c.dstRole,
+		DstRole: deet.info.Role.Export(),
 		Member: proto.Member{
 			Id:      fqe.Unfix().AtHost(c.tw.prot.Fqt.Host),
 			SrcRole: deet.srcRole,

--- a/integration-tests/lib/team_clkr_test.go
+++ b/integration-tests/lib/team_clkr_test.go
@@ -229,3 +229,146 @@ func TestLongChainCLKR(t *testing.T) {
 
 	mu.Infow("TestSimpleCLKR", "stage", "success")
 }
+
+// TestMixedRoleCLKR checks that CLKR refreshes a member's keys without
+// changing that member's role.
+//
+// In the other CLKR tests here, the actor's role already equals the role of
+// every member CLKR actually rekeys, so a rekey that stamped the actor's role
+// onto each member it touched would pass all of them.
+//
+// Here v owns the team and u is a member at the default viz level. u revokes a
+// device, which rolls u's PUK and is the condition CLKR keys off of; then v's
+// CLKR run picks u up. u must come back at the role they started with.
+func TestMixedRoleCLKR(t *testing.T) {
+	tew := testEnvBeta(t)
+	v := tew.NewTestUser(t)
+	u := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	m := tew.MetaContext()
+	A := tew.makeTeamForOwner(t, v)
+	readerRole := proto.NewRoleWithMember(0)
+
+	runLocalJoinSequenceForUser(t, m, A, v, u, readerRole, nil)
+	tew.DirectMerklePokeInTest(t)
+
+	// Roll u's PUK, so that CLKR has something to do.
+	// The double poke is required, not belt-and-braces: provision_epno is
+	// written by the batcher pass *after* the one that stages the leaf, and
+	// RevokeDevice rejects a signer whose provision_epno is still NULL.
+	cpu2 := u.ProvisionNewDevice(t, u.eldest, "cpu2", proto.DeviceType_Computer, proto.OwnerRole)
+	tew.DirectDoubleMerklePokeInTest(t)
+	u.RevokeDevice(t, u.eldest, cpu2)
+	tew.DirectMerklePokeInTest(t)
+
+	// v, the owner, runs the background rekey.
+	mv := tew.NewClientMetaContextWithDevice(t, v, v.eldest)
+	mv = mv.WithLogTag("testrun")
+	av := mv.G().ActiveUser()
+	require.NotNil(t, av)
+	tmm := libclient.NewTeamMinder(av)
+
+	clkr := libclient.NewCLKR(tmm, tew.clkrOpts(t))
+	err := clkr.Run(mv)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(clkr.Rekeys()))
+
+	twr, err := libclient.LoadTeam(mv, libclient.LoadTeamArg{
+		Team:            A.FQTeam(t),
+		As:              v.FQUser().FQParty(),
+		SrcRole:         proto.OwnerRole,
+		Keys:            v.KeySeq(t, proto.OwnerRole),
+		LoadMembersFull: true,
+	})
+	require.NoError(t, err)
+	x, err := twr.ExportToRoster()
+	require.NoError(t, err)
+
+	require.Len(t, x.Members, 2)
+	roles := make(map[proto.NameUtf8]proto.Role)
+	for _, mem := range x.Members {
+		roles[mem.Mem.Name] = mem.DstRole
+	}
+	require.Equal(t, proto.OwnerRole, roles[v.name], "owner's role should be untouched")
+	require.Equal(t, readerRole, roles[u.name], "CLKR must not change the role of the member it rekeys")
+}
+
+// TestAdminCLKRSkipsStaleHigherRoleMember covers the other half of the same
+// hunk: an admin cannot submit a change for a member who outranks it, because
+// checkChangesLocked rejects the whole change set, and visitAllTeams returns on
+// the first team error. So a single stale owner used to abort the sweep for
+// every remaining team. The admin should now rekey what it may and leave the
+// owner to an owner-run CLKR.
+func TestAdminCLKRSkipsStaleHigherRoleMember(t *testing.T) {
+	tew := testEnvBeta(t)
+	v := tew.NewTestUser(t)
+	w := tew.NewTestUser(t)
+	u := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	m := tew.MetaContext()
+	A := tew.makeTeamForOwner(t, v)
+	A.setIndexRange(t, m, v, index0)
+	readerRole := proto.NewRoleWithMember(0)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	runLocalJoinSequenceForUser(t, m, A, v, w, proto.AdminRole, nil)
+	tew.DirectDoubleMerklePokeInTest(t)
+	runLocalJoinSequenceForUser(t, m, A, v, u, readerRole, nil)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	// w, an admin, is the one who will run the background rekey.
+	mw := tew.NewClientMetaContextWithDevice(t, w, w.eldest)
+	mw = mw.WithLogTag("testrun")
+	aw := mw.G().ActiveUser()
+	require.NotNil(t, aw)
+	tmm := libclient.NewTeamMinder(aw)
+	tmm.TestHooks = &libclient.TeamMinderTestHooks{
+		PostChainHook: func() error {
+			tew.DirectDoubleMerklePokeInTest(t)
+			return nil
+		},
+	}
+
+	clkr := libclient.NewCLKR(tmm, libclient.CLKROpts{})
+	err := clkr.Run(mw)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(clkr.Rekeys()))
+
+	// Both the owner and the reader go stale, so the admin's sweep sees one
+	// member it may not touch and one it may.
+	rollPUK := func(x *TestUser, dev string) {
+		d := x.ProvisionNewDevice(t, x.eldest, dev, proto.DeviceType_Computer, proto.OwnerRole)
+		tew.DirectDoubleMerklePokeInTest(t)
+		x.RevokeDevice(t, x.eldest, d)
+		tew.DirectMerklePokeInTest(t)
+	}
+	rollPUK(v, "vcpu2")
+	rollPUK(u, "ucpu2")
+
+	clkr = libclient.NewCLKR(tmm, tew.clkrOpts(t))
+	err = clkr.Run(mw)
+	require.NoError(t, err, "a stale owner must not abort an admin's sweep")
+	require.Equal(t, 1, len(clkr.Rekeys()))
+
+	twr, err := libclient.LoadTeam(mw, libclient.LoadTeamArg{
+		Team:            A.FQTeam(t),
+		As:              w.FQUser().FQParty(),
+		SrcRole:         proto.OwnerRole,
+		Keys:            w.KeySeq(t, proto.OwnerRole),
+		LoadMembersFull: true,
+	})
+	require.NoError(t, err)
+	x, err := twr.ExportToRoster()
+	require.NoError(t, err)
+
+	require.Len(t, x.Members, 3)
+	roles := make(map[proto.NameUtf8]proto.Role)
+	for _, mem := range x.Members {
+		roles[mem.Mem.Name] = mem.DstRole
+	}
+	require.Equal(t, proto.OwnerRole, roles[v.name], "the skipped owner keeps their role")
+	require.Equal(t, proto.AdminRole, roles[w.name], "the actor keeps their role")
+	require.Equal(t, readerRole, roles[u.name], "CLKR must not change the role of the member it rekeys")
+}


### PR DESCRIPTION
## What

`CLKROneTeam.doOneMember` set `DstRole` on every `proto.MemberRole` it emitted from the **acting** party's member record rather than from the member being rekeyed. `RosterCore.Apply` writes `chng.Info.Role` unconditionally, and nothing compares a change's `DstRole` against the target's existing role, so a background CLKR run by an owner silently promoted lower-role members to owner.

A second effect worth flagging: the promotion takes the `cmp < 0` branch in `planChangesLocked`, which calls `keySingle`. That sets `includes` and `rekeys` but never `incrs`, so the promoted member is boxed into the **existing** owner and admin PTK generations and no key is actually rotated. In the case CLKR exists to handle, a member's PUK rolling after a device revoke, the old code rotated nothing.

## Changes

1. `DstRole: deet.info.Role.Export()`, carrying the member's own role. This is the fix.
2. `dstRole` → `actorRole`, typed `*core.RoleKey`. The field only ever held the actor's role, and its name is most of why the line above read as correct. This also lets `checkAdmin()` collapse into its one call site, since `core.ImportRole` now happens once in `loadTeam`.
3. Skip members ranked above the actor. `checkChangesLocked` rejects the entire change set when the doer is below a target's existing role, and `visitAllTeams` returns on the first team error, so one stale-key owner aborted the sweep for every remaining team.

## Tests

Two, one per behavior change, both following the existing CLKR pattern:

- **`TestMixedRoleCLKR`**: an owner runs CLKR over a team where the rekeyed member is at the default viz level. Without the fix, that member comes back as owner.
- **`TestAdminCLKRSkipsStaleHigherRoleMember`**: an admin runs CLKR with both a stale owner and a stale lower-role member. Without the skip, the whole sweep dies with `doer role insufficient for change`.

They are in the first commit so the failure is reproducible on its own. At `66a9805` (tests only):

```
--- PASS: TestSingleTeamCLKR
--- PASS: TestSimpleDiamondGraphCLKR
--- PASS: TestLongChainCLKR
--- FAIL: TestMixedRoleCLKR                        expected T:1, actual T:3
--- FAIL: TestAdminCLKRSkipsStaleHigherRoleMember   doer role insufficient for change
```

At `449fd38` (fix applied), all five pass. The three existing CLKR tests pass either way, since the actor's role already equals the role of every member they actually rekey.

## Provenance

Found and written with Claude, then independently reviewed. Flagging it up front since it's relevant to how closely you'll want to read this.
