### PR TITLE
team: block self-invite demotion and ownerless-team edits

### DIFF
--- a/client/libclient/team_minder_edit.go
+++ b/client/libclient/team_minder_edit.go
@@ -266,7 +266,7 @@ func (t *TeamEditor) runGameplan(m MetaContext) error {
 		t.cp.FQParty().Host,
 		mrq,
 		vk.GetEntityID(),
-		nil,
+		&team.GameplanOpts{RequireOwner: true},
 	)
 	if err != nil {
 		return err

--- a/client/libclient/team_minder_inbox.go
+++ b/client/libclient/team_minder_inbox.go
@@ -1180,6 +1180,30 @@ func (t *TeamMinder) getOrLoadInboxRow(
 	return nil, core.NotFoundError("inbox row")
 }
 
+// checkAdmitteesNotAlreadyMembers refuses RSVPs for parties already in the
+// roster. Such an RSVP is almost certainly a mistake — typically an admin who
+// accepted their own invite (issue #309). Admitting it would silently rewrite
+// the existing membership (e.g. demote an owner to member), so refuse and
+// point at change-roles, which exists for that purpose.
+func checkAdmitteesNotAlreadyMembers(
+	rows []proto.MemberRole,
+	host proto.HostID,
+	roster *team.Roster,
+) error {
+	for _, mr := range rows {
+		isMemb, err := roster.HasMemberRole(mr, host)
+		if err != nil {
+			return err
+		}
+		if isMemb {
+			return core.TeamRosterError(
+				"party is already a member of the team; use change-roles to change their role",
+			)
+		}
+	}
+	return nil
+}
+
 func (t *TeamMinder) TeamAdmit(
 	m MetaContext,
 	arg lcl.TeamAdmitArg,
@@ -1240,6 +1264,11 @@ func (t *TeamMinder) TeamAdmit(
 
 	tr.Lock()
 	defer tr.Unlock()
+
+	err = checkAdmitteesNotAlreadyMembers(rows, fqt.Host, tr.ldr.rosterPost)
+	if err != nil {
+		return err
+	}
 
 	editor := TeamEditor{
 		tl:      tr.ldr,

--- a/integration-tests/cli/team_test.go
+++ b/integration-tests/cli/team_test.go
@@ -751,3 +751,54 @@ func TestTeamChangeMembershipClosedViewershipTestReload(t *testing.T) {
 
 	checkMembershipChain(proto.OwnerRole)
 }
+
+// Issue #309: an owner accepts their own team invite and admits themselves at
+// a lower role, demoting themselves and — as the sole owner — bricking the
+// team. Admitting a party that's already a member must fail, as must any
+// change that would leave the team without an owner.
+func TestIssue309SelfInviteDemotion(t *testing.T) {
+	x := newTestAgent(t)
+	x.runAgent(t)
+	defer x.stop(t)
+	stopper := runMerkleActivePoker(t)
+	defer stopper()
+	newUserWithAgentAtVHost(t, x, 0)
+	merklePoke(t)
+	merklePoke(t)
+
+	var res lcl.TeamCreateRes
+	teamName := "selfies"
+	x.runCmdToJSON(t, &res, "team", "create", teamName)
+	merklePoke(t)
+
+	var res3 proto.TeamInvite
+	x.runCmdToJSON(t, &res3, "team", "invite", teamName)
+	inviteStr, err := team.ExportTeamInvite(res3)
+	require.NoError(t, err)
+
+	// x can still accept its own invite (it just parks an RSVP in the inbox)...
+	x.runCmd(t, nil, "team", "accept", inviteStr)
+	merklePoke(t)
+
+	// ...but admitting the RSVP would demote the owner, and must fail.
+	var inb lcl.TeamInbox
+	x.runCmdToJSON(t, &inb, "team", "inbox", teamName)
+	require.Equal(t, 1, len(inb.Rows))
+	err = x.runCmdErr(nil, "team", "admit", teamName, string(inb.Rows[0].Tok.String())+"/m/0")
+	require.Error(t, err)
+	require.Equal(t, core.TeamRosterError(
+		"party is already a member of the team; use change-roles to change their role"), err)
+
+	// A direct self-demotion of the sole owner must also fail — it would
+	// leave the team with no owner, permanently stuck.
+	xusername := x.status(t).Users[0].Info.Username.NameUtf8
+	err = x.runCmdErr(nil, "team", "change-roles", teamName, xusername.String()+"->m/0")
+	require.Error(t, err)
+	require.Equal(t, core.TeamRosterError("change would leave team without an owner"), err)
+
+	// The owner is unharmed.
+	var ros lcl.TeamRoster
+	x.runCmdToJSON(t, &ros, "team", "ls", teamName)
+	require.Equal(t, 1, len(ros.Members))
+	require.Equal(t, proto.OwnerRole, ros.Members[0].DstRole)
+}

--- a/lib/team/core.go
+++ b/lib/team/core.go
@@ -69,6 +69,37 @@ func (r *RosterCore) Len() int {
 	return len(r.members)
 }
 
+func (r *RosterCore) hasOwnerLocked() bool {
+	for _, mi := range r.members {
+		if mi.Role.Typ == proto.RoleType_OWNER {
+			return true
+		}
+	}
+	return false
+}
+
+// HasOwner returns true if at least one member of the roster holds the
+// owner role.
+func (r *RosterCore) HasOwner() bool {
+	if r == nil {
+		return false
+	}
+	r.Lock()
+	defer r.Unlock()
+	return r.hasOwnerLocked()
+}
+
+// Has returns true if the given member is currently in the roster.
+func (r *RosterCore) Has(m MemberID) bool {
+	if r == nil {
+		return false
+	}
+	r.Lock()
+	defer r.Unlock()
+	_, found := r.members[m]
+	return found
+}
+
 func (r *RosterCore) Add(m MemberID, k core.RoleKey, g proto.Generation, q proto.Seqno, t proto.Time) {
 	r.Lock()
 	defer r.Unlock()
@@ -521,6 +552,16 @@ func (d ChangeSet) Gameplan(
 	}
 
 	rPost = rPre.Clone().Apply(d)
+
+	// Refuse to take the team from having at least one owner to having none:
+	// nobody would be left who could ever add an owner back, so the team
+	// would be permanently stuck (issue #309). Only enforced when the caller
+	// opts in — replay of already-accepted chains must stay lenient — and
+	// only on the >=1 -> 0 transition, so teams that are already ownerless
+	// can still rekey.
+	if opts != nil && opts.RequireOwner && rPre.hasOwnerLocked() && !rPost.hasOwnerLocked() {
+		return nil, nil, nil, core.TeamRosterError("change would leave team without an owner")
+	}
 
 	sched, keysPost = rPre.planChangesLocked(d, keysPre, rPost, forcedNewKeyGens)
 	return rPost, sched, keysPost, nil

--- a/lib/team/hilev.go
+++ b/lib/team/hilev.go
@@ -156,6 +156,21 @@ func MakeChange(mrq proto.MemberRoleSeqno, mh proto.HostID) (*Change, *proto.Tea
 	return chng, &tk, nil
 }
 
+// HasMemberRole reports whether the party named in mr, at its source role, is
+// currently in the roster. Host scoping matches MakeChange, so the answer is
+// exactly "would a change set containing mr touch an existing member?"
+func (r *RosterCore) HasMemberRole(mr proto.MemberRole, mh proto.HostID) (bool, error) {
+	fqef, err := mr.Member.Id.WithHost(mh).Fixed()
+	if err != nil {
+		return false, err
+	}
+	srcRole, err := core.ImportRole(mr.Member.SrcRole)
+	if err != nil {
+		return false, err
+	}
+	return r.Has(MemberID{Fqe: *fqef, SrcRole: *srcRole}), nil
+}
+
 func MakeChangeSet(v []proto.MemberRoleSeqno, mh proto.HostID) (ChangeSet, *MemberKeysSet, error) {
 	ret := make(ChangeSet, len(v))
 	ads := NewMemberKeysSet()
@@ -223,6 +238,12 @@ func (r *Roster) Load(
 
 type GameplanOpts struct {
 	TestingNoCheck bool
+
+	// RequireOwner refuses a change set that takes the roster from having at
+	// least one owner to having none. Set when building or accepting new
+	// links; left unset when replaying existing chains, which must load even
+	// if they contain a link that stranded the team (issue #309).
+	RequireOwner bool
 }
 
 func (r *Roster) Gameplan(

--- a/server/engine/team_admin.go
+++ b/server/engine/team_admin.go
@@ -587,6 +587,17 @@ func (c *teamEditor) openLink(m shared.MetaContext) (*team.OpenTeamLinkRes, erro
 	if err != nil {
 		return nil, err
 	}
+
+	// Refuse an edit that takes the team from having at least one owner to
+	// having none — nobody would be left who could ever add an owner back
+	// (issue #309). This is the authoritative guard: the client enforces the
+	// same rule via GameplanOpts.RequireOwner, but a doctored client can skip
+	// it. Only the >=1 -> 0 transition is blocked, so teams that are already
+	// ownerless can still rekey.
+	if roster.HasOwner() && !res.RosterPost.HasOwner() {
+		return nil, core.TeamRosterError("edit would leave team without an owner")
+	}
+
 	return res, nil
 }
 


### PR DESCRIPTION
Fixes #309.

An owner could accept their own team invite, admit the RSVP at a lower role, and silently demote themselves — bricking the team if they were the sole owner, since nobody left could ever add an owner back. Repro'd in `TestIssue309SelfInviteDemotion` (fails on main at the self-admit, which succeeds and demotes the owner).

Three guards, all surfacing the existing wire-mapped `TeamRosterError`:

- **Admit guard (client)**: `TeamAdmit` refuses an RSVP for a party already in the roster — "party is already a member of the team; use change-roles to change their role". Membership is checked via a new `RosterCore.HasMemberRole`, which builds the `MemberID` exactly as `MakeChange` does so host-scoping can't drift.
- **Owner invariant (client link-building)**: `Gameplan` gains `GameplanOpts.RequireOwner`, rejecting any change set that takes the roster from ≥1 owners to zero — this also blocks the equivalent brick via plain `change-roles me->m/0` by a sole owner. It's opt-in so chain replay stays lenient (already-stranded teams still load and keep data access), and only the ≥1→0 transition is blocked, so already-ownerless teams can still rekey.
- **Server enforcement**: the server's `teamEditor` independently applies the same owner rule to newly posted links (a doctored client can skip its local check), following the existing authoritative-guard pattern in that file.

Verified: new test passes with both errors asserted and the owner intact; no regressions in `lib/team` unit tests, the CLI team suite (invite/admit/change-roles/rejoin/team-as-member/malicious-client), or the CLKR rekey tests.

Deliberate non-changes: accepting your own invite still succeeds (it just parks an inbox row the admin can reject) — blocking at accept time would require the acceptor to load the team, which isn't always possible for invitees, and the admit guard makes the row harmless. The server-side owner guard is only exercised indirectly by CLI tests since the client guard fires first; a doctored-client test could cover it explicitly if wanted.

Co-authored-by: Claude Code