### PR TITLE
foks-tool: add --vhost mode to write-public-zone

### DIFF
--- a/integration-tests/cli/vhost_test.go
+++ b/integration-tests/cli/vhost_test.go
@@ -8,8 +8,10 @@ import (
 
 	"github.com/foks-proj/go-foks/client/libclient"
 	"github.com/foks-proj/go-foks/integration-tests/common"
+	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/proto/lcl"
 	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/server/shared"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,4 +61,46 @@ func TestVhostSimpleSignup(t *testing.T) {
 	y.runCmdToJSON(t, &st, "status")
 	require.Equal(t, len(st.Users), 1)
 	require.Equal(t, st.Users[0].Info.Fqu.HostID, tvh.HostID.Id)
+
+	// Refresh the vhost's public zone via WritePublicZoneForVHost (the
+	// engine behind `foks-tool write-public-zone --vhost`). First doctor the
+	// stored zone the way a naive refresh would (nil hostname map, so
+	// services get the config's external addresses rather than the vhost's
+	// own hostname), then check the refresh restores the vhost-shaped zone.
+	m := env.MetaContext().WithHostID(&tvh.HostID)
+
+	zoneServices := func() []proto.TCPAddr {
+		spz, err := shared.LoadPublicZone(m)
+		require.NoError(t, err)
+		pz, err := spz.Inner.AllocAndDecode(core.DecoderFactory{})
+		require.NoError(t, err)
+		return []proto.TCPAddr{
+			pz.Services.Probe, pz.Services.Reg, pz.Services.User,
+			pz.Services.MerkleQuery, pz.Services.KvStore, pz.Services.Realtime,
+		}
+	}
+	requireAllAtHost := func(hn proto.Hostname) {
+		for _, addr := range zoneServices() {
+			require.Equal(t, hn.Normalize(), addr.Hostname().Normalize())
+		}
+	}
+
+	requireAllAtHost(tvh.Hostname)
+
+	ioer, err := m.PrivateHostKeyIOer(tvh.HostID.Id, proto.EntityType_HostMetadataSigner)
+	require.NoError(t, err)
+	hk, err := shared.ReadHostKey(m.Ctx(), ioer)
+	require.NoError(t, err)
+	err = shared.StorePublicZoneWithProbe(m, *hk, nil)
+	require.NoError(t, err)
+
+	// the doctored zone must actually differ, or the refresh proves nothing
+	require.NotEqual(t,
+		tvh.Hostname.Normalize(),
+		zoneServices()[0].Hostname().Normalize(),
+	)
+
+	err = shared.WritePublicZoneForVHost(env.MetaContext(), tvh.Hostname)
+	require.NoError(t, err)
+	requireAllAtHost(tvh.Hostname)
 }

--- a/server/foks-tool/write_public_zone.go
+++ b/server/foks-tool/write_public_zone.go
@@ -7,21 +7,34 @@ import (
 	"errors"
 
 	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/server/shared"
 	"github.com/spf13/cobra"
 )
 
 type WritePublicZone struct {
 	CLIAppBase
-	key string
+	key   string
+	vhost string
 }
 
 func (i *WritePublicZone) CobraConfig() *cobra.Command {
 	ret := &cobra.Command{
 		Use:   "write-public-zone",
 		Short: "Write the public zone file",
+		Long: `Write the public zone file.
+
+With --key, write the zone for the host the tool is scoped to (by default
+the config's primary host), signing with the given metadata key file, and
+addressing services at the config's external listen addresses.
+
+With --vhost, refresh the named virtual host's zone instead: the vhost's
+short host ID, hostname, and metadata signing key are all resolved
+automatically, and services are addressed at the vhost's own hostname, as
+they were when the vhost was first created.`,
 	}
 	ret.Flags().StringVarP(&i.key, "key", "", "", "where to read the metadata signing key from")
+	ret.Flags().StringVarP(&i.vhost, "vhost", "", "", "hostname of the virtual host to write the zone for")
 	return ret
 }
 
@@ -29,13 +42,16 @@ func (i *WritePublicZone) CheckArgs(args []string) error {
 	if len(args) != 0 {
 		return core.BadArgsError("no args allowed")
 	}
-	if i.key == "" {
-		return errors.New("must specify file")
+	if (i.key == "") == (i.vhost == "") {
+		return errors.New("must specify exactly one of --key or --vhost")
 	}
 	return nil
 }
 
 func (i *WritePublicZone) Run(m shared.MetaContext) error {
+	if i.vhost != "" {
+		return shared.WritePublicZoneForVHost(m, proto.Hostname(i.vhost))
+	}
 	return doWritePublicZone(m, core.Path(i.key))
 }
 

--- a/server/shared/vhosts.go
+++ b/server/shared/vhosts.go
@@ -69,6 +69,36 @@ func (v *vHostInit) writePublicZone(m MetaContext) error {
 	return StorePublicZoneWithProbe(m, *k, ufsMap)
 }
 
+// WritePublicZoneForVHost re-signs and re-stores the public zone for the
+// vhost with the given hostname; use it to refresh existing vhosts after the
+// fleet grows a new front-facing service (as with realtime/chat) that their
+// zones predate. It mirrors what vHostInit.writePublicZone wrote at creation
+// time: every front-facing service is addressed at the vhost's own hostname
+// (not the config's external addresses, which name the primary host), and
+// the zone is signed with the vhost's metadata signing key, loaded from the
+// standard per-vhost private keys directory.
+func WritePublicZoneForVHost(m MetaContext, hn proto.Hostname) error {
+	hn = hn.Normalize()
+	hid, err := m.G().HostIDMap().LookupByHostname(m, hn)
+	if err != nil {
+		return err
+	}
+	m = m.WithHostID(hid)
+	ioer, err := m.PrivateHostKeyIOer(hid.Id, proto.EntityType_HostMetadataSigner)
+	if err != nil {
+		return err
+	}
+	hk, err := ReadHostKey(m.Ctx(), ioer)
+	if err != nil {
+		return err
+	}
+	ufsMap := make(map[proto.ServerType]proto.Hostname)
+	for _, st := range proto.FrontFacingServers {
+		ufsMap[st] = hn
+	}
+	return StorePublicZoneWithProbe(m, *hk, ufsMap)
+}
+
 func (v *vHostInit) checkLimits(m MetaContext) error {
 	db, err := m.Db(DbTypeUsers)
 	if err != nil {


### PR DESCRIPTION
`write-public-zone` previously only worked correctly for the config's primary host: it took a metadata key file path, and addressed services at the config's external listen addresses. Running it against a vhost (via the global `--short-host-id` flag) would silently repoint the vhost's services at the primary host's hostnames — whereas `init-vhost` originally wrote every front-facing service at the vhost's own hostname.

This matters now because vhost zones created before the realtime server existed have an empty `Realtime` slot and need a refresh to pick up chat.

The new mode:

```
foks-tool write-public-zone --vhost <hostname>
```

resolves the vhost's host ID by hostname from the DB, loads its metadata signing key from the standard `v<host-id>` directory under the vhosts private-keys dir, and rewrites the zone with every front-facing service at the vhost's own hostname — exactly the shape `init-vhost` wrote at creation time. `--key` and `--vhost` are mutually exclusive; `--key` behavior is unchanged. The engine is `shared.WritePublicZoneForVHost`, placed next to the `vHostInit.writePublicZone` code it mirrors.

Testing:

- Integration test folded into `TestVhostSimpleSignup`: doctors the vhost's stored zone the way a naive refresh would (services at the config's external addresses), then asserts the refresh restores all six services — including `Realtime` — to the vhost's hostname.
- Validated in production on `b0.foks.app`'s vhost `test-a1.foks.cloud`: before, its zone had `Realtime` empty; after, `Realtime: test-a1.foks.cloud:4436` with all other services unchanged, and the probe's signature check confirms the correct per-vhost signing key was used.

Co-authored-by: Claude Code