### PR TITLE
server: make merkle pipeline background loops resilient to DB interruptions

### DIFF
--- a/server/shared/lock.go
+++ b/server/shared/lock.go
@@ -209,6 +209,17 @@ func (l *Lock) getHeartbeatFailure() bool {
 	return l.heartbeatFailed
 }
 
+// LostLock reports whether the most recent Heartbeat found the lock had been
+// taken over by another process — the lock row no longer matches our pid +
+// lock_id, so the UPDATE affected zero rows. This is deliberately distinct from
+// a transient DB/connection error returned by Heartbeat (e.g. "connection
+// refused" or a timeout): after a transient error the caller still owns the
+// lock and should retry, whereas after a genuine takeover it must stand down.
+// Set once by Heartbeat and never cleared.
+func (l *Lock) LostLock() bool {
+	return l.getHeartbeatFailure()
+}
+
 func (l *Lock) setHeartbeatFailure() {
 	l.Lock()
 	defer l.Unlock()

--- a/server/shared/looper.go
+++ b/server/shared/looper.go
@@ -65,6 +65,29 @@ func (b *BaseServer) DoOnePoll(m MetaContext, looper Looper) error {
 	return nil
 }
 
+// looperDbTimeout bounds every database operation a background poll loop makes
+// (the lock heartbeat and each poll). It is a hang detector, not a
+// normal-operation bound: heartbeats and incremental polls complete in well
+// under a second, so this only ever fires when a pooled connection has gone
+// stale (the pool sets no MaxConnLifetime / statement_timeout, so a query on a
+// dead connection would otherwise block forever and silently wedge the loop —
+// stalling the merkle pipeline until a full server restart). On timeout pgx
+// aborts the query and discards the bad connection, so the next iteration gets
+// a fresh one and the loop self-recovers.
+const looperDbTimeout = 60 * time.Second
+
+func (b *BaseServer) heartbeatWithTimeout(m MetaContext, looper Looper) error {
+	m, cancel := m.WithContextTimeout(looperDbTimeout)
+	defer cancel()
+	return looper.GetLock().Heartbeat(m)
+}
+
+func (b *BaseServer) pollWithTimeout(m MetaContext, looper Looper) error {
+	m, cancel := m.WithContextTimeout(looperDbTimeout)
+	defer cancel()
+	return b.DoOnePoll(m, looper)
+}
+
 func (b *BaseServer) runPoolLoopWithLooper(
 	m MetaContext,
 	shutdownCh chan<- error,
@@ -73,27 +96,38 @@ func (b *BaseServer) runPoolLoopWithLooper(
 	keepGoing := true
 	for keepGoing {
 
-		// If we fail the lock heartbeat, it's because someone else is acting as the merkle Batcher,
-		// and we should get out of the way.
-		err := looper.GetLock().Heartbeat(m)
-		if err != nil {
-			m.Warnw("heartbeat", "err", err)
-			shutdownCh <- err
+		// Renew the lock lease. A heartbeat error is only fatal when the lock
+		// was genuinely taken over by another instance (LostLock) — then we
+		// stand down. A transient DB/connection error (a stale pooled conn, a
+		// brief postgres outage on `compose up`, a network blip) leaves the
+		// lock ours, so we log and retry on the next tick rather than exiting
+		// permanently, which used to kill the merkle pipeline until a full
+		// server restart.
+		hbErr := b.heartbeatWithTimeout(m, looper)
+		if hbErr != nil && looper.GetLock().LostLock() {
+			m.Warnw("runPollLoop", "stage", "lock-lost", "err", hbErr)
+			shutdownCh <- hbErr
 			keepGoing = false
-		} else {
+			continue
+		}
+		if hbErr != nil {
+			m.Warnw("runPollLoop", "stage", "heartbeat-transient", "err", hbErr)
+		}
 
-			select {
-			case <-time.After(looper.GetConfig().PollWait()):
-				err := b.DoOnePoll(m, looper)
-				if err != nil {
-					m.Warnw("runPollLoop", "stage", "doOnePoll", "err", err)
-				}
-			case retCh := <-looper.GetPokeCh():
-				err := b.DoOnePoll(m, looper)
-				retCh <- err
-			case <-m.Ctx().Done():
-				keepGoing = false
+		select {
+		case <-time.After(looper.GetConfig().PollWait()):
+			if hbErr != nil {
+				// The DB was unreachable this round; skip the poll and retry
+				// the heartbeat after the poll-wait backoff.
+				continue
 			}
+			if err := b.pollWithTimeout(m, looper); err != nil {
+				m.Warnw("runPollLoop", "stage", "doOnePoll", "err", err)
+			}
+		case retCh := <-looper.GetPokeCh():
+			retCh <- b.pollWithTimeout(m, looper)
+		case <-m.Ctx().Done():
+			keepGoing = false
 		}
 	}
 	m.Infow("runPollLoop", "stage", "exit")


### PR DESCRIPTION
## Purpose

A transient database interruption permanently stops the merkle pipeline. The loops do not come back on their own — it takes an operator restarting the process.

## The problem

The merkle pipeline (builder / batcher / signer) runs on `BaseServer` background poll loops. Each loop renews a postgres lock lease every tick so that only one instance drives it. Two independent flaws let a temporary DB condition kill it for good:

**1. A transient heartbeat failure was treated as fatal.** On *any* heartbeat error the loop did `shutdownCh <- err; keepGoing = false` and exited the goroutine, with no path back. But a heartbeat error only means "another instance took over, stand down" when the lock row no longer matches us — the `UPDATE` affected zero rows. A momentary `connection refused` (postgres restart, `compose up`, a network blip) is transient, the lock is still ours, and it killed the loops anyway.

**2. A hung DB operation wedged the loop silently.** The pool sets no `MaxConnLifetime`, `statement_timeout`, or `HealthCheckPeriod`, so on long uptime a pooled connection can go stale and a query on it blocks indefinitely. Both the heartbeat and the poll ran on the never-cancelled server context, so a stuck query stalled the loop with no error and no log line.

Observed downstream as clients failing team and invite operations with `signature verify error`, because the merkle root had quietly stopped advancing.

## The change

- Expose `Lock.LostLock()` — true only on a genuine takeover. It reads the existing `heartbeatFailed` flag, which is already set solely on `RowsAffected != 1`, so this names a distinction the lock was tracking but not exporting. Exit only when the lock was really lost; on a transient error, log and retry next tick.
- Bound each heartbeat and each poll with a per-iteration timeout (`WithContextTimeout`, 60s). This is a hang detector, not a normal-operation bound — heartbeats and incremental polls finish in well under a second. On timeout pgx aborts the query and discards the bad connection, so the next tick gets a fresh one and the loop self-recovers.
- When the DB was unreachable for a round, skip that round's poll and retry the heartbeat after the poll-wait backoff, rather than polling against a database we just failed to reach.

## Outcome

The loops tolerate DB restarts, failovers, and stale connections instead of dying until someone restarts the process. A real lock takeover still stands the loop down immediately, which is the behaviour the lock exists to provide.

No schema change, no config change, no new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)