### PR TITLE
fix(libkv): re-mint stale team VO bearer tokens instead of failing

### DIFF
--- a/client/libclient/party_loader_cache.go
+++ b/client/libclient/party_loader_cache.go
@@ -14,10 +14,28 @@ type PLCNode struct {
 	sync.RWMutex
 	id            proto.FQParty
 	au            proto.FQUser
+	tm            *lcl.ConfigTeam // how this party was named on load; nil for the active user
 	skm           SharedKeyManager
 	voTok         *rem.TeamVOBearerToken
 	refreshTime   time.Time
 	directDstRole *proto.Role // might be null if we don't have direct membership
+}
+
+// Invalidate expires the node's cached state -- crucially its VO bearer token --
+// so the next Load re-mints rather than handing back a token the server has
+// already rejected. The stale token is deliberately left in place: if the reload
+// fails we'd rather retry with a doomed token than fail differently ("no VO
+// token") on a path that only wanted to refresh it.
+func (p *PLCNode) Invalidate() {
+	p.Lock()
+	defer p.Unlock()
+	p.refreshTime = time.Time{}
+}
+
+func (p *PLCNode) configTeam() *lcl.ConfigTeam {
+	p.RLock()
+	defer p.RUnlock()
+	return p.tm
 }
 
 func (p *PLCNode) DirectDstRole() *proto.Role {
@@ -146,10 +164,12 @@ func (n *PLCNode) isFresh(m MetaContext) (bool, error) {
 
 func (k *PLCNode) refresh(
 	m MetaContext,
+	tm lcl.ConfigTeam,
 	tw *TeamWrapper,
 	userRoleInTeam *proto.Role,
 ) {
 	k.refreshTime = m.G().Now()
+	k.tm = &tm
 	k.skm = tw.KeyRing()
 	k.voTok = tw.VOBearerToken()
 	k.directDstRole = userRoleInTeam
@@ -234,9 +254,31 @@ func (p *PartyLoaderCache) loadTeam(
 	if memb != nil {
 		mr = &memb.Mr.DstRole
 	}
-	plcn.refresh(m, tw, mr)
+	plcn.refresh(m, tm, tw, mr)
 
 	return plcn, nil
+}
+
+// Refresh forces a reload of a node whose cached VO bearer token the server has
+// rejected, bypassing the TeamCacheTimeout freshness window. Without it a token
+// invalidated by a roster change (see the "stale member" rejection in
+// CheckTeamVOBearerToken) keeps being replayed until the window expires -- on
+// mobile that window is minutes, so every team KV op fails in the meantime.
+// Reloading via TeamMinder alone does not help: it refreshes a different cache,
+// and the token callers actually present comes from here.
+//
+// A no-op for the active user's own node, which carries no token.
+func (p *PartyLoaderCache) Refresh(m MetaContext, n *PLCNode) error {
+	if n == nil {
+		return nil
+	}
+	tm := n.configTeam()
+	if tm == nil {
+		return nil
+	}
+	n.Invalidate()
+	_, err := p.loadTeam(m, *tm, &PLCOpts{})
+	return err
 }
 
 // Load a PLCNode, from a FQTeamParsed if specified. Return a PLCNode, which

--- a/client/libkv/getfile.go
+++ b/client/libkv/getfile.go
@@ -417,11 +417,19 @@ func (k *Minder) GetFileChunk(
 	if err != nil {
 		return nil, err
 	}
-	_, seed, err := k.getFileMetadata(m, kvp, id)
+	var res *lcl.GetFileChunkRes
+	err = k.withFreshToken(m, kvp, func(m MetaContext) error {
+		_, seed, err := k.getFileMetadata(m, kvp, id)
+		if err != nil {
+			return err
+		}
+		res, err = k.getLargeFileChunkAtOffsetWithSeed(m, kvp, id, offset, seed)
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
-	return k.getLargeFileChunkAtOffsetWithSeed(m, kvp, id, offset, seed)
+	return res, nil
 }
 
 func GetFile(

--- a/client/libkv/gitrefs.go
+++ b/client/libkv/gitrefs.go
@@ -101,17 +101,19 @@ func (g *gitRefDirExplorer) loadDir(m MetaContext) error {
 	})
 }
 
+// client memoizes the RPC connection but never the auth token: the token can be
+// re-minted underneath us (see withFreshToken), and a memoized copy would keep
+// presenting the rejected one for the rest of the explore.
 func (g *gitRefDirExplorer) client(m MetaContext) (*rem.KVAuth, *rem.KVStoreClient, error) {
-	if g.cli != nil {
-		return g.auth, g.cli, nil
-	}
 	auth, cli, err := g.minder.client(m, g.kvp)
 	if err != nil {
 		return nil, nil, err
 	}
-	g.cli = cli
+	if g.cli == nil {
+		g.cli = cli
+	}
 	g.auth = auth
-	return auth, cli, nil
+	return auth, g.cli, nil
 }
 
 func (g *gitRefDirExplorer) loadCache(m MetaContext) error {
@@ -136,19 +138,22 @@ func (g *gitRefDirExplorer) loadCache(m MetaContext) error {
 }
 
 func (g *gitRefDirExplorer) getNextPage(m MetaContext) error {
-	auth, cli, err := g.client(m)
-	if err != nil {
+	var res rem.KVListRes
+	err := g.minder.withFreshToken(m, g.kvp, func(m MetaContext) error {
+		auth, cli, err := g.client(m)
+		if err != nil {
+			return err
+		}
+		res, err = cli.KvList(m.Ctx(), rem.KvListArg{
+			Auth: *auth,
+			Dir:  *g.did,
+			Opts: rem.KVListOpts{
+				Start:          g.start,
+				Num:            uint64(g.opts.PageSize),
+				LoadSmallFiles: true,
+			},
+		})
 		return err
-	}
-
-	res, err := cli.KvList(m.Ctx(), rem.KvListArg{
-		Auth: *auth,
-		Dir:  *g.did,
-		Opts: rem.KVListOpts{
-			Start:          g.start,
-			Num:            uint64(g.opts.PageSize),
-			LoadSmallFiles: true,
-		},
 	})
 	if err != nil {
 		return err

--- a/client/libkv/minder.go
+++ b/client/libkv/minder.go
@@ -1612,11 +1612,15 @@ func (k *Minder) GetUsage(
 	if err != nil {
 		return nil, err
 	}
-	auth, cli, err := k.client(m, kvp)
-	if err != nil {
-		return nil, err
-	}
-	res, err := cli.KvUsage(m.Ctx(), *auth)
+	var res proto.KVUsage
+	err = k.withFreshToken(m, kvp, func(m MetaContext) error {
+		auth, cli, err := k.client(m, kvp)
+		if err != nil {
+			return err
+		}
+		res, err = cli.KvUsage(m.Ctx(), *auth)
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -1896,10 +1900,6 @@ func (k *Minder) AcquireLock(
 	if err != nil {
 		return nil, err
 	}
-	auth, cli, err := k.client(m, kvp)
-	if err != nil {
-		return nil, err
-	}
 	var lockID rem.LockID
 	err = core.RandomFill(lockID[:])
 	if err != nil {
@@ -1920,10 +1920,16 @@ func (k *Minder) AcquireLock(
 		timeout = kvcfg.LockTimeout
 	}
 
-	err = cli.KvLockAcquire(m.Ctx(), rem.KvLockAcquireArg{
-		Auth:    *auth,
-		Lock:    plock,
-		Timeout: proto.ExportDurationMilli(timeout),
+	err = k.withFreshToken(m, kvp, func(m MetaContext) error {
+		auth, cli, err := k.client(m, kvp)
+		if err != nil {
+			return err
+		}
+		return cli.KvLockAcquire(m.Ctx(), rem.KvLockAcquireArg{
+			Auth:    *auth,
+			Lock:    plock,
+			Timeout: proto.ExportDurationMilli(timeout),
+		})
 	})
 	if err != nil {
 		return nil, err
@@ -1943,16 +1949,14 @@ func (l *Lock) Release(m MetaContext) error {
 		return err
 	}
 
-	auth, cli, err := l.Minder.client(m, kvp)
-	if err != nil {
-		return err
-	}
-	err = cli.KvLockRelease(m.Ctx(), rem.KvLockReleaseArg{
-		Auth: *auth,
-		Lock: l.KVLock,
+	return l.Minder.withFreshToken(m, kvp, func(m MetaContext) error {
+		auth, cli, err := l.Minder.client(m, kvp)
+		if err != nil {
+			return err
+		}
+		return cli.KvLockRelease(m.Ctx(), rem.KvLockReleaseArg{
+			Auth: *auth,
+			Lock: l.KVLock,
+		})
 	})
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/client/libkv/putfile.go
+++ b/client/libkv/putfile.go
@@ -447,19 +447,21 @@ func (k *Minder) PutFileChunk(
 	us.sz = sz
 	us.off += proto.Offset(len(data))
 
-	auth, client, err := k.client(m, kvp)
-	if err != nil {
-		return err
-	}
-
-	arg := rem.KvFileUploadChunkArg{
-		Auth:   *auth,
-		FileID: id,
-		Chunk:  *ulc,
-	}
-
+	// Only the RPC is replayed on a stale token, not the chunk bookkeeping above
+	// -- us.off has already advanced, and a rejected upload never reached the
+	// server's chunk state.
 	start := time.Now()
-	err = client.KvFileUploadChunk(m.Ctx(), arg)
+	err = k.withFreshToken(m, kvp, func(m MetaContext) error {
+		auth, client, err := k.client(m, kvp)
+		if err != nil {
+			return err
+		}
+		return client.KvFileUploadChunk(m.Ctx(), rem.KvFileUploadChunkArg{
+			Auth:   *auth,
+			FileID: id,
+			Chunk:  *ulc,
+		})
+	})
 	if err != nil {
 		return err
 	}

--- a/client/libkv/retry.go
+++ b/client/libkv/retry.go
@@ -149,6 +149,11 @@ func (k *Minder) withFreshToken(
 		m.Warnw("withFreshToken", "stage", "refresh", "err", rerr, "orig", err)
 		return err
 	}
+	// Logged because a successful recovery is otherwise invisible: the server
+	// returns both rejections without logging, and a replayed op looks exactly
+	// like one that never went stale. Without this line the only way to tell
+	// whether this path ran is a negative control against a build without it.
+	m.Infow("withFreshToken", "stage", "re-minted", "party", kvp.Id(), "rejection", err)
 	return f(m)
 }
 

--- a/client/libkv/retry.go
+++ b/client/libkv/retry.go
@@ -4,6 +4,7 @@
 package libkv
 
 import (
+	"errors"
 	"time"
 
 	"github.com/foks-proj/go-foks/lib/core"
@@ -105,6 +106,52 @@ type kvRetryOptions struct {
 	skipCacheCheck bool
 }
 
+// isStaleTeamTokenError reports the server refusing the team VO bearer token
+// that this party has cached. It goes stale on any roster write touching the
+// member it was minted for -- the token is pinned to one team_members row --
+// and also once it ages out. Both are cured by minting a new one.
+func isStaleTeamTokenError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var stale core.TeamBearerTokenStaleError
+	if errors.As(err, &stale) {
+		return true
+	}
+	var nf core.NotFoundError
+	if errors.As(err, &nf) && nf == core.NotFoundError("team vo bearer token") {
+		return true
+	}
+	return false
+}
+
+// withFreshToken runs f, and if the server rejected the party's cached VO bearer
+// token, re-mints it and runs f exactly once more. The rejection happens in the
+// server's auth step, before any part of the operation is applied, so replaying
+// f is safe.
+//
+// This is what makes a freshly-admitted member's first write work: admission
+// supersedes the team_members row their token was minted against, and nothing
+// else in the client notices until the freshness window expires.
+func (k *Minder) withFreshToken(
+	m MetaContext,
+	kvp *KVParty,
+	f func(m MetaContext) error,
+) error {
+	err := f(m)
+	if !isStaleTeamTokenError(err) {
+		return err
+	}
+	rerr := k.au.PartyLoaderCache().Refresh(m.Base(), kvp.plcn)
+	if rerr != nil {
+		// Report the rejection, not the refresh failure -- the former is what
+		// the caller's operation actually hit.
+		m.Warnw("withFreshToken", "stage", "refresh", "err", rerr, "orig", err)
+		return err
+	}
+	return f(m)
+}
+
 func (k *Minder) retryCacheLoop(
 	m MetaContext,
 	kvp *KVParty,
@@ -114,6 +161,19 @@ func (k *Minder) retryCacheLoop(
 }
 
 func (k *Minder) retryCacheLoopWithOptions(
+	m MetaContext,
+	kvp *KVParty,
+	opts kvRetryOptions,
+	f func(m MetaContext) error,
+) error {
+	// Wraps the whole cache-race loop rather than f alone, so a stale token
+	// surfacing from the loop's own cache check is caught too.
+	return k.withFreshToken(m, kvp, func(m MetaContext) error {
+		return k.cacheRaceLoop(m, kvp, opts, f)
+	})
+}
+
+func (k *Minder) cacheRaceLoop(
 	m MetaContext,
 	kvp *KVParty,
 	opts kvRetryOptions,

--- a/client/libkv/retry_test.go
+++ b/client/libkv/retry_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package libkv
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/foks-proj/go-foks/lib/core"
+)
+
+func TestIsStaleTeamTokenError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"stale member", core.TeamBearerTokenStaleError{Which: "stale member"}, true},
+		{"aged out", core.TeamBearerTokenStaleError{Which: "age"}, true},
+		{"wrapped", fmt.Errorf("kv put: %w",
+			core.TeamBearerTokenStaleError{Which: "stale member"}), true},
+		{"token row gone", core.NotFoundError("team vo bearer token"), true},
+		{"unrelated not-found", core.NotFoundError("dirent"), false},
+		{"permission", core.PermissionError("nope"), false},
+		{"stale cache", core.KVStaleCacheError{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isStaleTeamTokenError(c.err); got != c.want {
+				t.Fatalf("isStaleTeamTokenError(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Purpose

A freshly-admitted team member's first KV write fails, and keeps failing for minutes.

## The problem

A team VO bearer token is pinned to the `team_members` row it was minted against. Admission supersedes that row — so the token the client cached moments earlier is already dead, and the server rejects the member's first write with `team bearer token is stale: stale member`.

Nothing in the client noticed. `PartyLoaderCache` hands out the cached token for the length of `TeamCacheTimeout`, and no caller treated the server's rejection as recoverable, so every team KV op kept failing until the freshness window expired. On mobile that window is minutes.

Refreshing through `TeamMinder` does not help: it refreshes a different cache, and the token callers actually present comes from `PartyLoaderCache`.

The same rejection also arrives from age-based expiry (`TeamBearerTokenStaleError{Which: "age"}`) and from a GC'd token row. All three are cured by minting a new token.

## The change

**`libclient`** — `PLCNode` remembers the `ConfigTeam` it was loaded under, and `PartyLoaderCache.Refresh` invalidates and reloads a node on demand, bypassing the freshness window. `Invalidate` deliberately leaves the old token in place, so a concurrent reader fails the way it did before rather than newly failing on a nil token.

**`libkv`** — `withFreshToken` runs an operation and, if the server rejected the token, re-mints and replays it exactly once. Replay is safe because the rejection happens in the server's auth step, before any part of the operation is applied.

It wraps the whole cache-race loop, so the loop's own `KvCacheCheck` is covered too, plus the operations that bypass that loop: `GetUsage`, `AcquireLock`, `Lock.Release`, `GetFileChunk`, `PutFileChunk`. `PutFileChunk` replays only the RPC — the chunk bookkeeping above it has already advanced `us.off`, and a rejected upload never reached the server's chunk state.

Also stops `gitRefDirExplorer` from memoizing the auth token for the life of an explore. It memoized the token alongside the connection, so after a re-mint it would have gone on presenting the rejected one for the rest of the walk. The connection is still memoized; only the token is re-read.

## Outcome

Admission, role changes, and token expiry stop producing a window of hard failures. Recovery is one extra round trip on the first rejected op and nothing at all thereafter.

## Testing

Unit coverage for the error classification is included. The end-to-end path needs a live server stack, so the regression to run by hand is: **admit member → write → change role → write again.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)