### PR TITLE
perf(roster): list team members by name, not by full member load

### DIFF
--- a/client/libclient/team_loader.go
+++ b/client/libclient/team_loader.go
@@ -498,7 +498,11 @@ func (w *TeamWrapper) BookendSigningKey(
 	}, nil
 }
 
-func (r *rosterPackage) Export() lcl.TeamRosterMember {
+// Export renders one roster row. localHostname is the loaded team's own
+// hostname, used for members whose chain load was skipped on a username-cache
+// hit: the cache stores bare names, and that skip is gated on !isRemote, so
+// such a member is always on the team's host.
+func (r *rosterPackage) Export(localHostname proto.Hostname) lcl.TeamRosterMember {
 	ret := lcl.TeamRosterMember{
 		Mem: lcl.NamedFQParty{
 			Fqp: r.fqp,
@@ -520,6 +524,13 @@ func (r *rosterPackage) Export() lcl.TeamRosterMember {
 		ret.Mem.Name = r.tw.prot.Name.B.NameUtf8
 		ret.Mem.Host = r.tw.hostname
 		ret.NumMembers = int64(len(r.tw.prot.Members))
+	case !r.cachedName.IsZero():
+		// LoadMemberNames hit the username cache and skipped the chain load, so
+		// there's no UserWrapper to read from. NumMembers (a device count) needs
+		// the chain and stays zero -- callers wanting it must ask for
+		// LoadMembers.
+		ret.Mem.Name = r.cachedName
+		ret.Mem.Host = localHostname
 	}
 	return ret
 }
@@ -542,7 +553,7 @@ func (w *TeamWrapper) ExportToRoster() (*lcl.TeamRoster, error) {
 			// note that we still export the roster details even if we failed to load
 			// the user, since we still can display uid/hostid (just not username).
 			// i.e. we are not checking v.err here.
-			x := v.Export()
+			x := v.Export(w.hostname)
 			roster = append(roster, x)
 		}
 	}

--- a/client/libclient/team_minder.go
+++ b/client/libclient/team_minder.go
@@ -264,9 +264,15 @@ func (t *TeamRecord) Member() CryptoPartier {
 }
 
 type LoadTeamOpts struct {
-	LoadMembers bool
-	Refresh     bool
-	NoUpdates   bool
+	// LoadMembers loads every member in full -- each one's user chain is
+	// fetched from the server, bypassing the UsernameLoader cache and its
+	// singleflight. Only ask for this if you need per-member chain data
+	// (device counts, keys); for a roster of names and roles, use
+	// LoadMemberNames, which is cheap and deduplicated.
+	LoadMembers     bool
+	LoadMemberNames bool
+	Refresh         bool
+	NoUpdates       bool
 }
 
 func (t *TeamMinder) GetTeam(fqt proto.FQTeam) *TeamRecord {
@@ -385,11 +391,19 @@ func (t *TeamMinder) LoadTeamWithFQTeam(
 
 	tr.Lock()
 	defer tr.Unlock()
-	if !opts.Refresh && (!opts.LoadMembers || tr.ldr.Arg.LoadMembersFull) {
+	if !opts.Refresh &&
+		(!opts.LoadMembers || tr.ldr.Arg.LoadMembersFull) &&
+		(!opts.LoadMemberNames || tr.ldr.Arg.LoadMemberNames || tr.ldr.Arg.LoadMembersFull) {
 		return tr, nil
 	}
 
 	tr.ldr.Arg.LoadMembersFull = opts.LoadMembers
+	// Sticky, unlike LoadMembersFull: a later full-member load also yields the
+	// names, so once a caller has asked for names we keep supplying them rather
+	// than silently dropping back to a roster with blank usernames.
+	if opts.LoadMemberNames {
+		tr.ldr.Arg.LoadMemberNames = true
+	}
 
 	// An ad-hoc team is named by its member list, so have the loader capture
 	// member usernames (cheap: username-cache hits skip the user-chain loads),
@@ -1438,7 +1452,12 @@ func (t *TeamMinder) ListTeamRoster(
 	err := t.withLoadedTeam(
 		m,
 		arg,
-		LoadTeamOpts{LoadMembers: true, Refresh: true},
+		// Names, not full member loads: the roster shows usernames and roles,
+		// none of which needs a member's user chain. LoadMembers used to be set
+		// here, which re-fetched every member's chain from the server on every
+		// call -- with Refresh defeating the memo, a roster of N members cost N
+		// chain loads each time the screen asked for it.
+		LoadTeamOpts{LoadMemberNames: true, Refresh: true},
 		func(m MetaContext, tm *TeamRecord) error {
 			tmp, err := tm.Tw().ExportToRoster()
 			if err != nil {


### PR DESCRIPTION
## Purpose

`ListTeamRoster` renders a list of names and roles, but pays for every member's full user chain to do it — uncached and undeduplicated, on every call.

## The problem

`ListTeamRoster` asked for `LoadTeamOpts{LoadMembers: true, Refresh: true}`.

`LoadMembers` maps to `LoadMembersFull`, which takes the `LoadUser` branch in `rosterPackage.load` and so bypasses **both** tiers of `UsernameLoader` — its cache and its singleflight. `Refresh` defeats the memo in `LoadTeamWithFQTeam`. Together, every roster listing re-fetched every member's user chain from the server to render data the roster does not use.

Measured against staging with an 8-member community: one ~2-minute session produced **163 `uidMerkleKeys` loads over 14 distinct keys** — roughly 7 concurrent cold loads per member, all racing before any of them wrote state, plus ~17 revalidations each. At the ~100ms RTT of a remote host that is tens of seconds of round trips.

The cheap path already exists — `LoadMemberNames`, from the global username cache in #298. `LoadTeamArg` has carried the flag all along; `LoadTeamOpts` just had no way to ask for it.

## The change

- Add `LoadTeamOpts.LoadMemberNames` and plumb it through. It is **sticky** where `LoadMembersFull` is not: a full load also yields names, so a caller that asked for names must not be silently downgraded to blank ones by a later load.
- `ListTeamRoster` asks for names instead of full members.
- `rosterPackage.Export` handles the cache-hit case. It only sourced `Name`/`Host` from `uw` or `tw`, so on the names path a cache hit — which sets `cachedName` and leaves `uw` nil — would have rendered a **blank row**. It now takes the name from the cache and the host from the loaded team: that skip is gated on `!isRemote`, so a cached member is always on the team's own host.

## Tradeoffs

`NumMembers` is a device count that genuinely needs the chain, so it stays zero on the names path. Callers wanting it must ask for `LoadMembers`.

`Refresh` is deliberately kept. It is what preserves roster freshness, and the per-member cost it used to multiply is exactly what this removes.

## Outcome

Rendering a roster costs the team load plus username-cache hits, instead of N uncached user-chain fetches per call. Same rows, same freshness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)