### PR TITLE
fix(foks-tool): fail an unknown --vhost instead of rewriting the primary zone

### DIFF
--- a/server/shared/vhosts.go
+++ b/server/shared/vhosts.go
@@ -79,7 +79,14 @@ func (v *vHostInit) writePublicZone(m MetaContext) error {
 // standard per-vhost private keys directory.
 func WritePublicZoneForVHost(m MetaContext, hn proto.Hostname) error {
 	hn = hn.Normalize()
-	hid, err := m.G().HostIDMap().LookupByHostname(m, hn)
+	// Strict: LookupByHostname falls back to the primary host when the
+	// hostname is unknown, which here would sign the PRIMARY host's zone
+	// while addressing every front-facing service at the unknown hostname --
+	// so a typo in --vhost silently overwrites the primary zone and points
+	// clients at a host that does not exist. An unknown vhost must fail.
+	hid, err := m.G().HostIDMap().LookupByHostnameWithFallbackBehavior(
+		m, hn, HostnameLookupFallbackNone,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Purpose

A typo in `foks-tool write-public-zone --vhost` silently corrupts the **primary** host's public zone instead of failing.

## The problem

`WritePublicZoneForVHost` resolves its hostname with `LookupByHostname`, which uses `HostnameLookupFallbackDefault` — on `pgx.ErrNoRows` it falls back to the primary short host ID. Nothing upstream of it validates the flag: `CheckArgs` only enforces "exactly one of `--key` or `--vhost`", and `Run` passes the string straight through.

So `--vhost typpo.example.com` does not error. It:

1. resolves to the **primary** host,
2. reads the **primary** host's metadata signing key,
3. builds a `ufsMap` addressing every entry in `FrontFacingServers` at the typo'd hostname, and
4. stores that as the **primary** host's public zone.

The primary host ends up advertising all of its front-facing services at a hostname that does not resolve — from one mistyped flag, with a zero exit code. The bogus hostname → primary mapping is also cached into `hn2Fwd`/`hn2Rev` for the life of the process.

It is recoverable by re-running `write-public-zone --key`, but only if the operator realises what happened. The failure surfaces later, as clients unable to reach services.

## The change

Use `LookupByHostnameWithFallbackBehavior(..., HostnameLookupFallbackNone)` so an unknown hostname returns `HostIDNotFoundError`. This is the same choice CKS already makes (`cks.go`) for the same reason: the fallback is right for request routing, wrong when the hostname names a specific host to *act on*.

One line plus a comment. No behaviour change for a `--vhost` that exists.

## How this was found

Reviewing #321 while merging v0.1.9 downstream. Flagged by an automated reviewer, then confirmed by reading the lookup path — I have not reproduced it against a live fleet, so treat the impact description as derived from the code rather than observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)