### PR TITLE
fix(libclient): resolve RPCLogOptions via flag, env, then config file

### DIFF
--- a/client/libclient/config.go
+++ b/client/libclient/config.go
@@ -1084,9 +1084,15 @@ func (c *Config) JSONOutput() bool {
 }
 
 func (c *Config) RPCLogOptions() (rpc.LogOptions, error) {
-	c.Lock()
-	defer c.Unlock()
-	return rpc.ParseStandardLogOptions(c.fl.rpcLogOpts)
+	// Resolve the same way as every other setting -- flag, then env, then
+	// config file. Reading c.fl.rpcLogOpts alone meant RPC tracing could only
+	// ever be turned on by a command-line flag, which the mobile agent has no
+	// way to pass; there the env var and config file are the only handles.
+	opts, err := c.RpcLogOpts()
+	if err != nil {
+		return nil, err
+	}
+	return rpc.ParseStandardLogOptions(opts)
 }
 
 type MerkleRaceRetryConfig struct {


### PR DESCRIPTION
## Purpose

RPC tracing can only be turned on by a command-line flag, so it cannot be turned on anywhere there is no command line.

## The problem

Every other `Config` setting resolves **flag → env → config file** through `getStringLocked`. `RPCLogOptions` read `c.fl.rpcLogOpts` directly:

```go
func (c *Config) RPCLogOptions() (rpc.LogOptions, error) {
	c.Lock()
	defer c.Unlock()
	return rpc.ParseStandardLogOptions(c.fl.rpcLogOpts)
}
```

So `FOKS_RPC_LOG_OPTS` and the config file's `RPCLogOpts` were both silently ignored — despite `RpcLogOpts()` already existing a few hundred lines up, resolving that exact setting the standard way, and the config file already carrying the field.

The practical effect: an embedded or mobile agent has no command line, so env var and config file are its only handles, and neither worked. Tracing was unreachable in exactly the environment where attaching a debugger is hardest.

## The change

Call `RpcLogOpts()`. It takes the `Config` lock itself, so the direct lock here is dropped rather than nested.

Nine lines. No behaviour change when the flag is passed — the flag still wins, as it does for every other setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)