### PR TITLE
feat(libclient): TeamMinder cancel-request and reject methods

### DIFF
--- a/client/libclient/team_minder_inbox.go
+++ b/client/libclient/team_minder_inbox.go
@@ -1065,6 +1065,17 @@ func (t *TeamMinder) cacheInbox(tm proto.FQTeam, rows []lcl.TeamInboxRow) {
 	}
 }
 
+// uncacheInboxRow drops one RSVP from the inbox cache. The cache is held
+// indefinitely so that a later admit can find the row without a round trip
+// (see getOrLoadInboxRow), which means a row the server has moved out of
+// 'pending' stays admittable from cache until the process restarts. Anything
+// that retires an RSVP must evict it.
+func (t *TeamMinder) uncacheInboxRow(tok proto.TeamRSVP) {
+	t.inboxMu.Lock()
+	defer t.inboxMu.Unlock()
+	delete(t.inbox, tok)
+}
+
 func (t *TeamMinder) TeamInbox(
 	m MetaContext,
 	fqtp proto.FQTeamParsed,
@@ -1161,23 +1172,33 @@ func (t *TeamMinder) getOrLoadInboxRow(
 	*inboxCacheRow,
 	error,
 ) {
-	t.inboxMu.Lock()
-	defer t.inboxMu.Unlock()
-	if t.inbox != nil {
-		row, found := t.inbox[tok]
-		if found {
-			return &row, nil
-		}
+	row, found := t.lookupInboxRow(tok)
+	if found {
+		return row, nil
 	}
+	// Deliberately not under inboxMu: loadTeamInboxWithFQTeam ends in
+	// cacheInbox, which takes that same non-reentrant mutex. Holding it across
+	// the reload self-deadlocks -- reachable now that a retired RSVP is evicted
+	// rather than left in the cache forever.
 	_, err := t.loadTeamInboxWithFQTeam(m, fqt)
 	if err != nil {
 		return nil, err
 	}
-	row, found := t.inbox[tok]
+	row, found = t.lookupInboxRow(tok)
 	if found {
-		return &row, nil
+		return row, nil
 	}
 	return nil, core.NotFoundError("inbox row")
+}
+
+func (t *TeamMinder) lookupInboxRow(tok proto.TeamRSVP) (*inboxCacheRow, bool) {
+	t.inboxMu.Lock()
+	defer t.inboxMu.Unlock()
+	row, found := t.inbox[tok]
+	if !found {
+		return nil, false
+	}
+	return &row, true
 }
 
 // checkAdmitteesNotAlreadyMembers refuses RSVPs for parties already in the
@@ -1332,9 +1353,15 @@ func (t *TeamMinder) TeamCancelRequest(m MetaContext, inviteCode string) error {
 	return ucli.PostGenericLink(m.Ctx(), *arg)
 }
 
-// TeamReject removes a single pending join request by sending a server-side
-// RejectJoinReq RPC. The inbox entry is deleted on the server so it won't
-// reappear on subsequent TeamInbox / TeamListPending calls.
+// TeamReject retires a single pending join request via the server's
+// RejectJoinReq RPC, which moves the row to state='rejected'. The inbox lists
+// only pending rows, so a rejected request does not reappear on subsequent
+// TeamInbox / TeamListPending calls.
+//
+// The server does not filter its UPDATE on the current state, so rejecting an
+// already-rejected request succeeds -- which makes this safe to retry when the
+// caller cannot tell whether the first attempt landed.
+//
 // fqtp is the parsed team name (from core.ParseFQTeam); tok is the
 // proto.TeamRSVP returned from the inbox row.
 func (t *TeamMinder) TeamReject(m MetaContext, fqtp proto.FQTeamParsed, tok proto.TeamRSVP) error {
@@ -1349,8 +1376,16 @@ func (t *TeamMinder) TeamReject(m MetaContext, fqtp proto.FQTeamParsed, tok prot
 	if err != nil {
 		return err
 	}
-	return cli.RejectJoinReq(m.Ctx(), rem.RejectJoinReqArg{
+	err = cli.RejectJoinReq(m.Ctx(), rem.RejectJoinReqArg{
 		Tok: *adminTok,
 		Req: tok,
 	})
+	if err != nil {
+		return err
+	}
+	// Without this the row survives in the inbox cache, and a later
+	// TeamAdmit in the same process would happily admit the party the
+	// admin just refused.
+	t.uncacheInboxRow(tok)
+	return nil
 }

--- a/client/libclient/team_minder_inbox.go
+++ b/client/libclient/team_minder_inbox.go
@@ -1285,3 +1285,72 @@ func (t *TeamMinder) TeamAdmit(
 
 	return editor.Run(m)
 }
+
+// TeamCancelRequest posts a Removed-state TML link for the given team invite,
+// resetting the caller's "Requested" membership state. Accepts the raw FOKS
+// invite code (not the SECO_INVITE:: wrapped form) so we can resolve the
+// actual TeamID via the cert — ResolveAndReindex only indexes Approved teams
+// and would fail for Requested-state entries.
+func (t *TeamMinder) TeamCancelRequest(m MetaContext, inviteCode string) error {
+	invite, err := team.ImportTeamInvite(inviteCode)
+	if err != nil {
+		return err
+	}
+
+	i1, err := openInvite(*invite)
+	if err != nil {
+		return err
+	}
+
+	cli, closer, _, err := t.remoteGuestCli(m, i1.Host)
+	if err != nil {
+		return err
+	}
+	defer closer()
+
+	cert, err := t.lookupAndOpenCert(m, cli, *invite)
+	if err != nil {
+		return err
+	}
+
+	fqt := cert.cert.Team
+	glp := proto.NewGenericLinkPayloadWithTeammembership(
+		proto.TeamMembershipLink{
+			Team:    fqt,
+			SrcRole: team.UserSrcRole,
+			State:   proto.NewTeamMembershipDetailsDefault(proto.TeamMembershipLinkState_Removed),
+		},
+	)
+	arg, err := t.makeMembershipChainLink(m, nil, glp, nil)
+	if err != nil {
+		return err
+	}
+	ucli, err := t.au.UserClient(m)
+	if err != nil {
+		return err
+	}
+	return ucli.PostGenericLink(m.Ctx(), *arg)
+}
+
+// TeamReject removes a single pending join request by sending a server-side
+// RejectJoinReq RPC. The inbox entry is deleted on the server so it won't
+// reappear on subsequent TeamInbox / TeamListPending calls.
+// fqtp is the parsed team name (from core.ParseFQTeam); tok is the
+// proto.TeamRSVP returned from the inbox row.
+func (t *TeamMinder) TeamReject(m MetaContext, fqtp proto.FQTeamParsed, tok proto.TeamRSVP) error {
+	fqt, err := t.ResolveAndReindex(m, team.WrapNamed(fqtp), nil)
+	if err != nil {
+		return err
+	}
+	if fqt == nil {
+		return core.TeamNotFoundError{}
+	}
+	adminTok, cli, _, err := t.adminTokenAndClient(m, *fqt, LoadTeamOpts{})
+	if err != nil {
+		return err
+	}
+	return cli.RejectJoinReq(m.Ctx(), rem.RejectJoinReqArg{
+		Tok: *adminTok,
+		Req: tok,
+	})
+}

--- a/client/libclient/team_minder_inbox.go
+++ b/client/libclient/team_minder_inbox.go
@@ -1308,10 +1308,12 @@ func (t *TeamMinder) TeamAdmit(
 }
 
 // TeamCancelRequest posts a Removed-state TML link for the given team invite,
-// resetting the caller's "Requested" membership state. Accepts the raw FOKS
-// invite code (not the SECO_INVITE:: wrapped form) so we can resolve the
-// actual TeamID via the cert — ResolveAndReindex only indexes Approved teams
-// and would fail for Requested-state entries.
+// resetting the caller's "Requested" membership state.
+//
+// It takes the invite code itself, as produced by team.ExportTeamInvite,
+// rather than a team name: the TeamID is resolved from the cert, because
+// ResolveAndReindex only indexes Approved teams and would fail for a
+// Requested-state entry.
 func (t *TeamMinder) TeamCancelRequest(m MetaContext, inviteCode string) error {
 	invite, err := team.ImportTeamInvite(inviteCode)
 	if err != nil {

--- a/integration-tests/lib/team_inbox_cancel_reject_test.go
+++ b/integration-tests/lib/team_inbox_cancel_reject_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package lib
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/lib/team"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/stretchr/testify/require"
+)
+
+// inboxFixture is an owner with a team, a joiner, and an invite the joiner has
+// accepted -- i.e. exactly one pending RSVP sitting in the owner's inbox. It is
+// the starting point for both cancel (joiner withdraws) and reject (owner
+// refuses).
+type inboxFixture struct {
+	tew    *TestEnvWrapper
+	owner  *TestUser
+	joiner *TestUser
+	tm     *teamObj
+	fqtp   proto.FQTeamParsed
+
+	mo  libclient.MetaContext
+	tmo *libclient.TeamMinder // owner's minder
+	mj  libclient.MetaContext
+	tmj *libclient.TeamMinder // joiner's minder
+
+	invite    proto.TeamInvite
+	inviteStr string
+}
+
+func (f *inboxFixture) minderFor(t *testing.T, u *TestUser) (libclient.MetaContext, *libclient.TeamMinder) {
+	m := f.tew.NewClientMetaContext(t, u)
+	tmm, err := m.G().TeamMinder()
+	require.NoError(t, err)
+	// Chain posts need the merkle tree to advance before the next read, which
+	// in production happens on the server's own schedule.
+	tmm.TestHooks = &libclient.TeamMinderTestHooks{
+		PostChainHook: func() error {
+			f.tew.DirectDoubleMerklePokeInTest(t)
+			return nil
+		},
+	}
+	return m, tmm
+}
+
+func newInboxFixture(t *testing.T) *inboxFixture {
+	tew := testEnvBeta(t)
+	f := &inboxFixture{tew: tew}
+
+	f.owner = tew.NewTestUser(t)
+	f.joiner = tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	f.tm = tew.makeTeamForOwner(t, f.owner)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	// An invite carries a team index range, so the team needs one before the
+	// owner can issue invites.
+	f.tm.setIndexRange(t, tew.MetaContext(), f.owner, index0)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	f.fqtp = *f.tm.ToFQTeamParsed(t)
+	f.mo, f.tmo = f.minderFor(t, f.owner)
+	f.mj, f.tmj = f.minderFor(t, f.joiner)
+
+	inv, err := f.tmo.CreateInvite(f.mo, f.fqtp)
+	require.NoError(t, err)
+	f.invite = *inv
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	s, err := team.ExportTeamInvite(f.invite)
+	require.NoError(t, err)
+	f.inviteStr = s
+
+	_, err = f.tmj.AcceptInvite(f.mj, lcl.TeamAcceptInviteArg{I: f.invite})
+	require.NoError(t, err)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	return f
+}
+
+// inboxRows returns the owner's current pending RSVPs.
+func (f *inboxFixture) inboxRows(t *testing.T) []lcl.TeamInboxRow {
+	inbox, err := f.tmo.TeamInbox(f.mo, f.fqtp)
+	require.NoError(t, err)
+	return inbox.Rows
+}
+
+// membershipState reports the state the joiner's own membership chain records
+// for the team, and whether it has any entry at all. This is the chain
+// TeamCancelRequest writes to, and it is distinct from the team roster.
+func (f *inboxFixture) membershipState(t *testing.T) (proto.TeamMembershipLinkState, bool) {
+	// Forces the membership chain to load; the wrapper is nil until it does.
+	_, err := f.tmj.DumpMembershipChain(f.mj)
+	require.NoError(t, err)
+
+	tmw := f.tmj.UserTMW()
+	require.NotNil(t, tmw)
+	require.NotNil(t, tmw.Wrapper)
+
+	fqt, err := f.tmj.Resolve(f.mj, f.fqtp)
+	require.NoError(t, err)
+	require.NotNil(t, fqt)
+
+	var key libclient.FQTeamSrcRole
+	err = key.Import(*fqt, team.UserSrcRole)
+	require.NoError(t, err)
+
+	link, ok := tmw.Wrapper.Map[key]
+	if !ok {
+		return proto.TeamMembershipLinkState_Requested, false
+	}
+	typ, err := link.State.GetT()
+	require.NoError(t, err)
+	return typ, true
+}
+
+// A joiner withdraws their own pending request. The invite is accepted, the
+// RSVP lands in the owner's inbox, and cancelling flips the joiner's own
+// membership record from Requested to Removed.
+func TestTeamCancelRequest(t *testing.T) {
+	f := newInboxFixture(t)
+
+	require.Len(t, f.inboxRows(t), 1)
+
+	state, found := f.membershipState(t)
+	require.True(t, found, "accepting an invite should record a membership link")
+	require.Equal(t, proto.TeamMembershipLinkState_Requested, state)
+
+	err := f.tmj.TeamCancelRequest(f.mj, f.inviteStr)
+	require.NoError(t, err)
+	f.tew.DirectDoubleMerklePokeInTest(t)
+
+	state, found = f.membershipState(t)
+	require.True(t, found)
+	require.Equal(t, proto.TeamMembershipLinkState_Removed, state,
+		"cancelling should reset the requester's membership state")
+}
+
+// Cancel takes the raw FOKS invite code, not a team name, because
+// ResolveAndReindex only indexes Approved teams and cannot resolve a
+// Requested-state entry. A string that is not an invite must be refused
+// rather than silently resolving to something else.
+func TestTeamCancelRequestRejectsNonInvite(t *testing.T) {
+	f := newInboxFixture(t)
+
+	err := f.tmj.TeamCancelRequest(f.mj, "not-a-foks-invite")
+	require.Error(t, err)
+}
+
+// An admin refuses a pending request. The row is deleted server-side, so it
+// does not come back on a later inbox read -- unlike a row merely left
+// unadmitted.
+func TestTeamReject(t *testing.T) {
+	f := newInboxFixture(t)
+
+	rows := f.inboxRows(t)
+	require.Len(t, rows, 1)
+	require.Equal(t, f.joiner.uid.ToPartyID(), rows[0].Nfqp.Fqp.Party)
+
+	err := f.tmo.TeamReject(f.mo, f.fqtp, rows[0].Tok)
+	require.NoError(t, err)
+	f.tew.DirectDoubleMerklePokeInTest(t)
+
+	require.Empty(t, f.inboxRows(t), "a rejected request must not reappear in the inbox")
+}
+
+// Rejecting twice is safe. The server sets state='rejected' without filtering
+// on the current state, so the second call updates the same row again and
+// succeeds -- which makes reject retryable after a network failure, where the
+// admin cannot tell whether the first attempt landed. Pinned because a future
+// state filter would turn a harmless retry into an error.
+func TestTeamRejectIsRetryable(t *testing.T) {
+	f := newInboxFixture(t)
+
+	rows := f.inboxRows(t)
+	require.Len(t, rows, 1)
+
+	err := f.tmo.TeamReject(f.mo, f.fqtp, rows[0].Tok)
+	require.NoError(t, err)
+	f.tew.DirectDoubleMerklePokeInTest(t)
+
+	err = f.tmo.TeamReject(f.mo, f.fqtp, rows[0].Tok)
+	require.NoError(t, err, "a repeated reject should be a harmless no-op")
+	require.Empty(t, f.inboxRows(t))
+}
+
+// A rejected request cannot then be admitted in the same session.
+//
+// This is the case the inbox cache gets wrong if reject does not evict: the
+// cache is deliberately held indefinitely so a later admit can skip a round
+// trip, so a rejected row stays admittable from memory even though the server
+// has moved it out of 'pending'. The admin refuses the party and then, one
+// call later, admits them.
+func TestTeamRejectThenAdmitFails(t *testing.T) {
+	f := newInboxFixture(t)
+
+	rows := f.inboxRows(t)
+	require.Len(t, rows, 1)
+	tok := rows[0].Tok
+
+	err := f.tmo.TeamReject(f.mo, f.fqtp, tok)
+	require.NoError(t, err)
+	f.tew.DirectDoubleMerklePokeInTest(t)
+
+	err = f.tmo.TeamAdmit(f.mo, lcl.TeamAdmitArg{
+		Team: f.fqtp,
+		Members: []lcl.TokRole{
+			{Tok: tok, Role: proto.DefaultRole},
+		},
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Purpose

Two gaps in the team inbox API, both about a join request that should not proceed.

## `TeamCancelRequest`

Lets a requester withdraw their own pending request, by posting a Removed-state TML link that resets their `Requested` membership state. Today a request can be admitted or left pending forever, but not taken back.

It takes the raw FOKS invite code rather than a team name, deliberately: `ResolveAndReindex` only indexes Approved teams, so it cannot resolve a Requested-state entry. Going through the cert gets the real `TeamID`.

## `TeamReject`

Lets an admin deliberately reject a pending request, via the existing `RejectJoinReq` RPC.

That RPC is already called today — but only automatically, and only for rows carrying `TEAM_CYCLE_ERROR` or `TEAM_INDEX_RANGE_ERROR`. There is no path for an admin who simply does not want to admit someone.

`RejectJoinReq` moves the row to `state='rejected'` rather than deleting it; since the inbox lists only pending rows, a rejected request does not reappear.

## Tests, and the two bugs they found

Five integration tests in `integration-tests/lib`, driving `TeamMinder` directly — these methods have no CLI surface, so the CLI-level team tests cannot reach them.

| Test | Asserts |
|---|---|
| `TestTeamCancelRequest` | `Requested → Removed` on the joiner's own membership chain |
| `TestTeamCancelRequestRejectsNonInvite` | a non-invite string is refused |
| `TestTeamReject` | a rejected RSVP leaves the inbox |
| `TestTeamRejectIsRetryable` | a repeated reject is a harmless no-op |
| `TestTeamRejectThenAdmitFails` | a rejected RSVP cannot then be admitted |

Writing them turned up two real bugs, both now fixed here.

**1. `TeamReject` did not evict the rejected row from the inbox cache.** That cache is deliberately held indefinitely so a later admit can skip a round trip — so an admin could refuse a party and then, one call later, admit them straight from memory. Mine; `TestTeamRejectThenAdmitFails` failed on it.

**2. `getOrLoadInboxRow` self-deadlocks on a cache miss.** It holds `inboxMu` across `loadTeamInboxWithFQTeam`, which ends in `cacheInbox`, which takes the same non-reentrant mutex:

```
cacheInbox              → inboxMu.Lock()   ← blocked
loadTeamInboxWithFQTeam
getOrLoadInboxRow       → inboxMu.Lock()   ← held
TeamAdmit
```

Pre-existing and untouched by the original PR, but unreachable while the cache was never missed. Fixing (1) makes it reachable, and the test went from failing to hanging. The lookup is factored into `lookupInboxRow` and the reload now runs outside the lock. Happy to split this into its own PR if you would rather take it separately.

## Verification

Full `go test ./integration-tests/...` green — `cli` and `lib` both `ok`, no regressions. `golangci-lint` clean.

## Scope

Additive: two new methods, no protocol change.

We also carry a `TeamLeaveSelf` downstream and have **deliberately left it out** — it writes only the member's own membership chain, so a member who "leaves" still holds the current PTK and still appears in the roster until an admin runs `EditTeam` with role `NONE`. That seemed like a design question rather than a patch, especially after #319, so it is issue #331 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)