### PR TITLE
perf(roster): list team members by name, not by full member load

### DIFF
--- a/client/libclient/team_loader.go
+++ b/client/libclient/team_loader.go
@@ -31,12 +31,27 @@ type rosterPackage struct {
 	uw       *UserWrapper
 	tw       *TeamWrapper
 
-	// cachedName is set instead of uw when the member's user-chain load was
+	// cached is set instead of uw when the member's user-chain load was
 	// skipped (LoadMemberNames) because the username was already in the
-	// UsernameLoader cache. The name is captured here at skip time -- rather than
-	// re-read from the cache later -- so a TTL eviction between the skip
-	// decision and the naming pass can't lose it.
-	cachedName proto.NameUtf8
+	// UsernameLoader cache. Both fields are captured at skip time -- rather
+	// than re-read from the cache later -- so a TTL eviction between the skip
+	// decision and the naming pass can't lose them.
+	cached cachedMemberName
+}
+
+// cachedMemberName is a roster member's display name and hostname as captured
+// on a username-cache hit; name and host are either both set or both zero.
+// The host is the *active user's* hostname, not necessarily the team's: the
+// cache skip is gated on !isRemote, which puts the member on the active
+// user's host, but a user on host B can load a roster for a team on host A
+// that both it and its cohosts on B are members of.
+type cachedMemberName struct {
+	name proto.NameUtf8
+	host proto.Hostname
+}
+
+func (c cachedMemberName) IsZero() bool {
+	return c.name.IsZero()
 }
 
 type HistoricalSenders struct {
@@ -254,10 +269,10 @@ func (t *TeamWrapper) adHocMemberIDsAndNames() (
 			switch {
 			case lst.uw != nil:
 				names = append(names, lst.uw.prot.Username.B.NameUtf8)
-			case !lst.cachedName.IsZero():
+			case !lst.cached.IsZero():
 				// The user-chain load was skipped (LoadMemberNames); the name
 				// was captured from the cache at skip time.
-				names = append(names, lst.cachedName)
+				names = append(names, lst.cached.name)
 			default:
 				badNameList = true
 			}
@@ -498,11 +513,7 @@ func (w *TeamWrapper) BookendSigningKey(
 	}, nil
 }
 
-// Export renders one roster row. localHostname is the loaded team's own
-// hostname, used for members whose chain load was skipped on a username-cache
-// hit: the cache stores bare names, and that skip is gated on !isRemote, so
-// such a member is always on the team's host.
-func (r *rosterPackage) Export(localHostname proto.Hostname) lcl.TeamRosterMember {
+func (r *rosterPackage) Export() lcl.TeamRosterMember {
 	ret := lcl.TeamRosterMember{
 		Mem: lcl.NamedFQParty{
 			Fqp: r.fqp,
@@ -524,13 +535,13 @@ func (r *rosterPackage) Export(localHostname proto.Hostname) lcl.TeamRosterMembe
 		ret.Mem.Name = r.tw.prot.Name.B.NameUtf8
 		ret.Mem.Host = r.tw.hostname
 		ret.NumMembers = int64(len(r.tw.prot.Members))
-	case !r.cachedName.IsZero():
+	case !r.cached.IsZero():
 		// LoadMemberNames hit the username cache and skipped the chain load, so
-		// there's no UserWrapper to read from. NumMembers (a device count) needs
-		// the chain and stays zero -- callers wanting it must ask for
-		// LoadMembers.
-		ret.Mem.Name = r.cachedName
-		ret.Mem.Host = localHostname
+		// there's no UserWrapper to read from. Both name and host were captured
+		// at skip time. NumMembers (a device count) needs the chain and stays
+		// zero -- callers wanting it must ask for LoadMembers.
+		ret.Mem.Name = r.cached.name
+		ret.Mem.Host = r.cached.host
 	}
 	return ret
 }
@@ -553,7 +564,7 @@ func (w *TeamWrapper) ExportToRoster() (*lcl.TeamRoster, error) {
 			// note that we still export the roster details even if we failed to load
 			// the user, since we still can display uid/hostid (just not username).
 			// i.e. we are not checking v.err here.
-			x := v.Export(w.hostname)
+			x := v.Export()
 			roster = append(roster, x)
 		}
 	}
@@ -1512,7 +1523,14 @@ func (p *rosterPackage) load(m MetaContext, l *TeamLoader) error {
 			if uw != nil {
 				p.uw = uw
 			} else {
-				p.cachedName = nm
+				// The !isRemote gate above means this member is on the active
+				// user's host, which need not be the team's host: capture the
+				// au's hostname now rather than defaulting to the team's at
+				// export time.
+				p.cached = cachedMemberName{
+					name: nm,
+					host: l.au.HomeServer().Hostname(),
+				}
 			}
 			return nil
 		}

--- a/client/libclient/team_loader.go
+++ b/client/libclient/team_loader.go
@@ -498,7 +498,11 @@ func (w *TeamWrapper) BookendSigningKey(
 	}, nil
 }
 
-func (r *rosterPackage) Export() lcl.TeamRosterMember {
+// Export renders one roster row. localHostname is the loaded team's own
+// hostname, used for members whose chain load was skipped on a username-cache
+// hit: the cache stores bare names, and that skip is gated on !isRemote, so
+// such a member is always on the team's host.
+func (r *rosterPackage) Export(localHostname proto.Hostname) lcl.TeamRosterMember {
 	ret := lcl.TeamRosterMember{
 		Mem: lcl.NamedFQParty{
 			Fqp: r.fqp,
@@ -520,6 +524,13 @@ func (r *rosterPackage) Export() lcl.TeamRosterMember {
 		ret.Mem.Name = r.tw.prot.Name.B.NameUtf8
 		ret.Mem.Host = r.tw.hostname
 		ret.NumMembers = int64(len(r.tw.prot.Members))
+	case !r.cachedName.IsZero():
+		// LoadMemberNames hit the username cache and skipped the chain load, so
+		// there's no UserWrapper to read from. NumMembers (a device count) needs
+		// the chain and stays zero -- callers wanting it must ask for
+		// LoadMembers.
+		ret.Mem.Name = r.cachedName
+		ret.Mem.Host = localHostname
 	}
 	return ret
 }
@@ -542,7 +553,7 @@ func (w *TeamWrapper) ExportToRoster() (*lcl.TeamRoster, error) {
 			// note that we still export the roster details even if we failed to load
 			// the user, since we still can display uid/hostid (just not username).
 			// i.e. we are not checking v.err here.
-			x := v.Export()
+			x := v.Export(w.hostname)
 			roster = append(roster, x)
 		}
 	}

--- a/client/libclient/team_minder.go
+++ b/client/libclient/team_minder.go
@@ -264,9 +264,15 @@ func (t *TeamRecord) Member() CryptoPartier {
 }
 
 type LoadTeamOpts struct {
-	LoadMembers bool
-	Refresh     bool
-	NoUpdates   bool
+	// LoadMembers loads every member in full -- each one's user chain is
+	// fetched from the server, bypassing the UsernameLoader cache and its
+	// singleflight. Only ask for this if you need per-member chain data
+	// (device counts, keys); for a roster of names and roles, use
+	// LoadMemberNames, which is cheap and deduplicated.
+	LoadMembers     bool
+	LoadMemberNames bool
+	Refresh         bool
+	NoUpdates       bool
 }
 
 func (t *TeamMinder) GetTeam(fqt proto.FQTeam) *TeamRecord {
@@ -385,11 +391,19 @@ func (t *TeamMinder) LoadTeamWithFQTeam(
 
 	tr.Lock()
 	defer tr.Unlock()
-	if !opts.Refresh && (!opts.LoadMembers || tr.ldr.Arg.LoadMembersFull) {
+	if !opts.Refresh &&
+		(!opts.LoadMembers || tr.ldr.Arg.LoadMembersFull) &&
+		(!opts.LoadMemberNames || tr.ldr.Arg.LoadMemberNames || tr.ldr.Arg.LoadMembersFull) {
 		return tr, nil
 	}
 
 	tr.ldr.Arg.LoadMembersFull = opts.LoadMembers
+	// Sticky, unlike LoadMembersFull: a later full-member load also yields the
+	// names, so once a caller has asked for names we keep supplying them rather
+	// than silently dropping back to a roster with blank usernames.
+	if opts.LoadMemberNames {
+		tr.ldr.Arg.LoadMemberNames = true
+	}
 
 	// An ad-hoc team is named by its member list, so have the loader capture
 	// member usernames (cheap: username-cache hits skip the user-chain loads),
@@ -1438,7 +1452,12 @@ func (t *TeamMinder) ListTeamRoster(
 	err := t.withLoadedTeam(
 		m,
 		arg,
-		LoadTeamOpts{LoadMembers: true, Refresh: true},
+		// Names, not full member loads: the roster shows usernames and roles,
+		// none of which needs a member's user chain. LoadMembers used to be set
+		// here, which re-fetched every member's chain from the server on every
+		// call -- with Refresh defeating the memo, a roster of N members cost N
+		// chain loads each time the screen asked for it.
+		LoadTeamOpts{LoadMemberNames: true, Refresh: true},
 		func(m MetaContext, tm *TeamRecord) error {
 			tmp, err := tm.Tw().ExportToRoster()
 			if err != nil {

--- a/integration-tests/cli/team_test.go
+++ b/integration-tests/cli/team_test.go
@@ -174,6 +174,7 @@ func TestCreateInviteSequence(t *testing.T) {
 		proto.NewRoleWithMember(-1),
 		roster.Members[2].DstRole,
 	)
+
 }
 
 func TestCreateAdmitLoad(t *testing.T) {
@@ -240,13 +241,24 @@ func TestCreateAdmitLoad(t *testing.T) {
 	merklePoke(t)
 	hostId, err := team.Fqp.Host.StringErr()
 	require.NoError(t, err)
-	z.runCmdToJSON(t, &ros, "team", "ls", teamName+"@"+hostId)
-	require.Equal(t, 3, len(ros.Members))
 
-	require.Equal(t, xUser.Fqu.ToFQParty(), ros.Members[0].Mem.Fqp)
-	require.Equal(t, yUser.Fqu.ToFQParty(), ros.Members[1].Mem.Fqp)
-	require.Equal(t, zUser.Fqu.ToFQParty(), ros.Members[2].Mem.Fqp)
+	// Cross-host roster listing: z (vhost 1, admitted at m/0 -- at the member
+	// load floor) lists the team on vhost 0. z's own row takes the
+	// username-cache path (z is local to z's loader but on a different host
+	// than the team), which used to stamp the row with the team's hostname
+	// instead of z's. List twice so the second pass renders from a warm
+	// username cache.
+	for i := range 2 {
+		z.runCmdToJSON(t, &ros, "team", "ls", teamName+"@"+hostId)
+		require.Equal(t, 3, len(ros.Members), "iteration %d", i)
 
+		require.Equal(t, xUser.Fqu.ToFQParty(), ros.Members[0].Mem.Fqp)
+		require.Equal(t, yUser.Fqu.ToFQParty(), ros.Members[1].Mem.Fqp)
+		require.Equal(t, zUser.Fqu.ToFQParty(), ros.Members[2].Mem.Fqp)
+
+		require.Equal(t, zUser.State.Username.B.NameUtf8, ros.Members[2].Mem.Name, "iteration %d", i)
+		require.Equal(t, zUser.Hostname, ros.Members[2].Mem.Host, "iteration %d", i)
+	}
 }
 
 // We start with:


### PR DESCRIPTION
Supersedes #326 — @st3v3y's perf change, carried as their commit with authorship preserved (the SECO-PBC fork is org-owned, so maintainer pushes to the PR branch 403 despite `maintainerCanModify`), plus a fix for the cross-host hostname bug found in review.

**First commit (st3v3y's, unchanged):** `ListTeamRoster` stops asking for full member loads — which re-fetched every member's user chain, uncached and un-deduplicated, on every listing — and asks for `LoadMemberNames`, served from the global username cache. See #326 for the full writeup and measurements.

**Second commit (the review fix):** the original change stamped cache-hit rows with the loaded team's hostname, on the reasoning that the cache skip is gated on `!isRemote`. But `isRemote` is computed relative to the **active user's** host, not the team's — they diverge for cross-host membership. A user on host B listing a team on host A saw their own row rendered with host A. The fix captures the hostname alongside the name at skip time (the gate does guarantee the member is on the active user's host), pairs them in a `cachedMemberName` struct whose fields are either both set or both zero, and drops the `localHostname` parameter threading.

Regression coverage in `TestCreateAdmitLoad`, which already had the right fixture: z (vhost 1, admitted at m/0) lists the team on vhost 0 twice — cold pass loads the chain, warm pass renders from the username cache. Without the fix the warm pass renders z's host as the team's. Verified failing on the unfixed branch at exactly that assertion, passing with the fix; team suite (invite/admit/change-roles/refresh/team-as-member) all green.

One scoping note from debugging: a viewer below the member load floor gets bare uid/role rows with no names at all — by design, and unchanged by this PR. That's why the regression test uses the m/0 fixture rather than an m/-1 member.

Co-authored-by: Claude Code