### PR TITLE
refactor(teams): replace member-load flag pair with ordered MemberLoadLevel

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -2,6 +2,15 @@ project: foks
 maintaner: Maxwell Krohn <max@ne43.com>
 
 changelog:
+  - version: 0.1.10
+    urgency: low
+    stable: false
+    date: TBD
+    changes:
+      - desc: speed up team roster listing; serve member names from the username cache instead of full per-member chain loads
+        closes: ["#332"]
+      - desc: internal; replace team member-load flag pair with one ordered MemberLoadLevel
+        closes: ["#333"]
   - version: 0.1.9
     urgency: medium
     stable: true
@@ -10,23 +19,25 @@ changelog:
       - desc: add 'foks git delete' (aliases rm/remove) to delete a git repository
         closes: ["#279"]
       - desc: normalize all server DB timestamps to UTC
-        closes: []
+        closes: ["#271"]
       - desc: work in progress on realtime chat (channels, send/read, ad-hoc teams); not yet ready for use
-        closes: []
+        closes: ["#272"]
       - desc: speed up username display with a global client-side cache
         closes: ["#296"]
       - desc: fixes for iOS embedding (shared-home crash guard, standalone config setters)
-        closes: []
+        closes: ["#289", "#290"]
       - desc: fix propagation of passphrase lock state to the background user loader
-        closes: []
+        closes: ["#287"]
       - desc: show FOKS name and icon for the macOS agent in Login Items & Extensions
         closes: ["#312"]
       - desc: allow former members to rejoin a team via invite after removal
         closes: ["#314"]
       - desc: fix background team rekey (CLKR) bug that changed member roles during rekeying
-        closes: []
+        closes: ["#317"]
       - desc: block admitting an existing member and any change leaving a team without an owner
         closes: ["#309"]
+      - desc: foks-tool write-public-zone support for refreshing vhost zones
+        closes: ["#321"]
   - version: 0.1.8
     urgency: low
     stable: true
@@ -67,9 +78,9 @@ changelog:
       - desc: Improve log rotation on `standup` 
         closes: ["#228"]
       - desc: MCP interface for KV
-        closes : []
+        closes : ["#237"]
       - desc: Claude security audit; 2 highs, and 1 medium; all server-side
-        closes : []
+        closes : ["#235"]
       - desc: MCP interface for teams
         closes : ["#238"]
   - version: 0.1.5
@@ -143,7 +154,7 @@ changelog:
     date: 2025-07-02 13:00:00 -0400
     changes:
       - desc: cli - log rotation for agent logs (not for error, just for output)
-        closes: []
+        closes: ["#121"]
       - desc: logsend feature for debugging problems
         closes: ["#119"]
       - desc: invite codes are optional for some hosts
@@ -181,7 +192,7 @@ changelog:
       - desc: Remove old version clash warning
         closes: ["#48"]
       - desc: Retire TypeScript-based snowpack compiler; move over to Go-based compiler
-        closes : []
+        closes : ["#50"]
       - desc: Fix panic in `team add` from failing to load a user by username a second time
         closes: ["#52"]
       - desc: Fix bug in kv-store big objects as a team
@@ -194,7 +205,7 @@ changelog:
     date: 2025-05-12 13:44:00 -0400
     changes:
       - desc: On macOS, change plist name from "pub.ne43.foks.agent" to "com.ne43.foks.agent"
-        closes: []
+        closes: ["#42"]
       - desc: Don't spam-create connection loops for merkleQuery
         closes: [ "#41" ]
       - desc: Assert snowpack structures are canonical when performing sigs, verify, hmac and hash upon them
@@ -208,6 +219,7 @@ changelog:
       - desc: Add `team change-roles` CLI command
         closes: [ "#33" ]
       - desc: Fix online documentation for `team add` command
+        closes: ["#39"]
   - version: 0.0.18
     urgency: low
     stable: false
@@ -216,9 +228,9 @@ changelog:
       - desc: Better CLI output if no keys or users.
         closes: [ "#21" ]
       - desc: Upgrade x/net to v0.0.39 via upgraded go-snowpack-rpc
-        closes: []
+        closes: ["#23"]
       - desc: bump github.com/gohugoio/hugo from 0.134.3 to 0.139.4; closing med security vuln
-        closes: []
+        closes: ["#24"]
       - desc: Fix `team add` so that it can handle teams being added to other teams.
         closes: [ "#13" ]
   - version: 0.0.17

--- a/client/libclient/team_clkr.go
+++ b/client/libclient/team_clkr.go
@@ -276,7 +276,7 @@ func (c *CLKROneTeam) refreshTeam(m MetaContext) error {
 }
 
 func (c *CLKROneTeam) loadTeam(m MetaContext) error {
-	tr, err := c.parent.tm.LoadTeamWithFQTeam(m, c.fqt, LoadTeamOpts{Refresh: true, LoadMembers: true})
+	tr, err := c.parent.tm.LoadTeamWithFQTeam(m, c.fqt, LoadTeamOpts{Refresh: true, Members: MemberLoadFull})
 	if err != nil {
 		return err
 	}

--- a/client/libclient/team_loader.go
+++ b/client/libclient/team_loader.go
@@ -32,7 +32,7 @@ type rosterPackage struct {
 	tw       *TeamWrapper
 
 	// cached is set instead of uw when the member's user-chain load was
-	// skipped (LoadMemberNames) because the username was already in the
+	// skipped (MemberLoadNames) because the username was already in the
 	// UsernameLoader cache. Both fields are captured at skip time -- rather
 	// than re-read from the cache later -- so a TTL eviction between the skip
 	// decision and the naming pass can't lose them.
@@ -234,7 +234,7 @@ func (t *TeamWrapper) IsAdHocTeam() bool {
 // adHocMemberIDsAndNames collects the local-host user members of an ad-hoc
 // team: their UIDs, and their usernames when every member's name is known
 // (from its loaded user chain, or captured from the username cache when the
-// chain load was skipped -- see LoadMemberNames). nameListOK is false when any
+// chain load was skipped -- see MemberLoadNames). nameListOK is false when any
 // member's name is missing; the UID list is complete regardless.
 func (t *TeamWrapper) adHocMemberIDsAndNames() (
 	uids []proto.UID,
@@ -270,7 +270,7 @@ func (t *TeamWrapper) adHocMemberIDsAndNames() (
 			case lst.uw != nil:
 				names = append(names, lst.uw.prot.Username.B.NameUtf8)
 			case !lst.cached.IsZero():
-				// The user-chain load was skipped (LoadMemberNames); the name
+				// The user-chain load was skipped (MemberLoadNames); the name
 				// was captured from the cache at skip time.
 				names = append(names, lst.cached.name)
 			default:
@@ -536,10 +536,10 @@ func (r *rosterPackage) Export() lcl.TeamRosterMember {
 		ret.Mem.Host = r.tw.hostname
 		ret.NumMembers = int64(len(r.tw.prot.Members))
 	case !r.cached.IsZero():
-		// LoadMemberNames hit the username cache and skipped the chain load, so
+		// MemberLoadNames hit the username cache and skipped the chain load, so
 		// there's no UserWrapper to read from. Both name and host were captured
 		// at skip time. NumMembers (a device count) needs the chain and stays
-		// zero -- callers wanting it must ask for LoadMembers.
+		// zero -- callers wanting it must ask for MemberLoadFull.
 		ret.Mem.Name = r.cached.name
 		ret.Mem.Host = r.cached.host
 	}
@@ -1018,7 +1018,7 @@ func (l *TeamLoader) loadTeamFromServer(m MetaContext) error {
 			S: l.existing.Name.S + 1,
 		}
 	}
-	if (l.Arg.LoadMembersFull || l.Arg.LoadMemberNames) && (l.existing == nil || len(l.existing.RemoteViewTokens) == 0) {
+	if l.Arg.MemberLoad >= MemberLoadNames && (l.existing == nil || len(l.existing.RemoteViewTokens) == 0) {
 		arg.LoadRemoteViewTokens = true
 	}
 	res, err := l.rpcLoader.LoadTeamChain(m.Ctx(), arg)
@@ -1509,12 +1509,12 @@ func (p *rosterPackage) load(m MetaContext, l *TeamLoader) error {
 			arg.TeamVOBearerToken = tok
 		}
 
-		// If we only need this member's username (LoadMemberNames without
-		// LoadMembersFull), go through the UsernameLoader: a cache hit skips
+		// If we only need this member's username (MemberLoadNames), go
+		// through the UsernameLoader: a cache hit skips
 		// the user-chain load, concurrent loads of the same user are
 		// single-flighted, and if this call did perform the load we keep the
 		// wrapper anyway.
-		if !l.Arg.LoadMembersFull && !p.isRemote {
+		if l.Arg.MemberLoad < MemberLoadFull && !p.isRemote {
 			fqu := proto.FQUser{Uid: *uid, HostID: p.fqp.Host}
 			nm, uw, err := m.G().UsernameLoader().Load(m, fqu, arg)
 			if err != nil {
@@ -1542,7 +1542,7 @@ func (p *rosterPackage) load(m MetaContext, l *TeamLoader) error {
 		p.uw = uw
 
 		// Memoize the loaded username so later explores can skip this load
-		// (see LoadMemberNames) and RT sender-name resolution can avoid its
+		// (see MemberLoadNames) and RT sender-name resolution can avoid its
 		// own user-chain load. Cache-write failure is not a load failure.
 		err = m.G().UsernameLoader().Set(m,
 			proto.FQUser{Uid: *uid, HostID: p.fqp.Host}, uw.Name())
@@ -1633,7 +1633,7 @@ func (l *TeamLoader) destRoleForLoader(m MetaContext) (*core.RoleKey, error) {
 func (l *TeamLoader) loadTokensAndMembers(
 	m MetaContext,
 ) error {
-	if !l.Arg.LoadMembersFull && !l.Arg.LoadMemberNames {
+	if l.Arg.MemberLoad < MemberLoadNames {
 		return nil
 	}
 	if l.Arg.Keys == nil {
@@ -2003,7 +2003,7 @@ func (l *TeamLoader) saveState(m MetaContext) error {
 	res.Sctlsc = *l.sctlsc
 
 	switch {
-	case l.Arg.LoadMembersFull || l.Arg.LoadMemberNames:
+	case l.Arg.MemberLoad >= MemberLoadNames:
 		lst := make([]proto.TeamRemoteMemberViewTokenInner, 0, len(l.rosterDetails))
 		for _, v := range l.rosterDetails {
 			// Just save the first remote view token for all srcRoles.
@@ -2218,13 +2218,10 @@ type LoadTeamArg struct {
 	Keys               SharedKeySequence
 	Tok                *proto.PermissionToken
 	LocalParentTeamTok *rem.TeamVOBearerToken
-	LoadMembersFull    bool
-	// LoadMemberNames loads the members' usernames (e.g., to name an ad-hoc
-	// team by its participant list) without requiring full member loads: a
-	// member whose name is already in the global UsernameLoader cache is skipped;
-	// misses are loaded (and cached). LoadMembers subsumes this -- it always
-	// loads every member, which yields the names too.
-	LoadMemberNames  bool
+	// MemberLoad is how much detail to load per roster member; see
+	// MemberLoadLevel. Levels are ordered: a loader that ran at some level
+	// has everything any lower level would have produced.
+	MemberLoad       MemberLoadLevel
 	TestSkipArgCheck bool
 	TestTokenVariant *rem.TokenVariant
 

--- a/client/libclient/team_minder.go
+++ b/client/libclient/team_minder.go
@@ -263,16 +263,45 @@ func (t *TeamRecord) Member() CryptoPartier {
 	return t.member
 }
 
+// MemberLoadLevel is how much detail a team load fetches per roster member.
+// Levels are strictly ordered -- each includes everything below it -- so
+// "does this loader satisfy that request?" is just >=.
+type MemberLoadLevel int
+
+const (
+	// MemberLoadNone loads the roster only: uids, roles, no names.
+	MemberLoadNone MemberLoadLevel = iota
+	// MemberLoadNames adds display names, served from the global
+	// UsernameLoader cache; misses load the user chain once and fill it.
+	MemberLoadNames
+	// MemberLoadFull loads every member's full user chain from the server,
+	// bypassing the username cache and its singleflight. Only ask for this
+	// if you need per-member chain data (device counts, keys).
+	MemberLoadFull
+)
+
 type LoadTeamOpts struct {
-	// LoadMembers loads every member in full -- each one's user chain is
-	// fetched from the server, bypassing the UsernameLoader cache and its
-	// singleflight. Only ask for this if you need per-member chain data
-	// (device counts, keys); for a roster of names and roles, use
-	// LoadMemberNames, which is cheap and deduplicated.
-	LoadMembers     bool
-	LoadMemberNames bool
-	Refresh         bool
-	NoUpdates       bool
+	// Members is the per-member detail level for this load; see
+	// MemberLoadLevel. The zero value loads no member detail.
+	Members   MemberLoadLevel
+	Refresh   bool
+	NoUpdates bool
+}
+
+// nextMemberLoad decides the level a reloading TeamRecord's loader runs at,
+// given what it ran at before and what this caller asked for. Full is
+// expensive and must be requested per-load -- if it stuck, one CLKR sweep
+// (which loads Full) would silently put every team it visited back on the
+// N-chain-fetches-per-listing plan. Names, once requested or implied by an
+// ad-hoc team (which is *named* by its member list), persists as a floor:
+// it's username-cache-cheap, and consumers may later render names off the
+// shared record, so a lesser load must not blank them.
+func nextMemberLoad(prev, req MemberLoadLevel, adhoc bool) MemberLoadLevel {
+	ret := req
+	if ret < MemberLoadNames && (prev >= MemberLoadNames || adhoc) {
+		ret = MemberLoadNames
+	}
+	return ret
 }
 
 func (t *TeamMinder) GetTeam(fqt proto.FQTeam) *TeamRecord {
@@ -391,27 +420,15 @@ func (t *TeamMinder) LoadTeamWithFQTeam(
 
 	tr.Lock()
 	defer tr.Unlock()
-	if !opts.Refresh &&
-		(!opts.LoadMembers || tr.ldr.Arg.LoadMembersFull) &&
-		(!opts.LoadMemberNames || tr.ldr.Arg.LoadMemberNames || tr.ldr.Arg.LoadMembersFull) {
+	if !opts.Refresh && tr.ldr.Arg.MemberLoad >= opts.Members {
 		return tr, nil
 	}
 
-	tr.ldr.Arg.LoadMembersFull = opts.LoadMembers
-	// Sticky, unlike LoadMembersFull: a later full-member load also yields the
-	// names, so once a caller has asked for names we keep supplying them rather
-	// than silently dropping back to a roster with blank usernames.
-	if opts.LoadMemberNames {
-		tr.ldr.Arg.LoadMemberNames = true
-	}
-
-	// An ad-hoc team is named by its member list, so have the loader capture
-	// member usernames (cheap: username-cache hits skip the user-chain loads),
-	// as the explore path already does. The teamname-cache fill below needs
-	// them.
-	if fqt.Team.IsAdHocTeam() {
-		tr.ldr.Arg.LoadMemberNames = true
-	}
+	// Ad-hoc teams always carry at least Names: such a team is *named* by its
+	// member list (the explore path relies on this), and the teamname-cache
+	// fill below needs the names.
+	tr.ldr.Arg.MemberLoad = nextMemberLoad(
+		tr.ldr.Arg.MemberLoad, opts.Members, fqt.Team.IsAdHocTeam())
 
 	tw, err := tr.ldr.Run(m)
 	if err != nil {
@@ -765,7 +782,7 @@ func (tm *TeamMinder) loadTeamArg(
 	// participant list; members already in the global UsernameLoader cache are named
 	// from the cache without a user-chain load.
 	if exnode.Fqt.Team.IsAdHocTeam() {
-		arg.LoadMemberNames = true
+		arg.MemberLoad = MemberLoadNames
 	}
 
 	return cp, &arg, nil
@@ -1453,11 +1470,11 @@ func (t *TeamMinder) ListTeamRoster(
 		m,
 		arg,
 		// Names, not full member loads: the roster shows usernames and roles,
-		// none of which needs a member's user chain. LoadMembers used to be set
-		// here, which re-fetched every member's chain from the server on every
-		// call -- with Refresh defeating the memo, a roster of N members cost N
-		// chain loads each time the screen asked for it.
-		LoadTeamOpts{LoadMemberNames: true, Refresh: true},
+		// none of which needs a member's user chain. MemberLoadFull used to be
+		// requested here, which re-fetched every member's chain from the server
+		// on every call -- with Refresh defeating the memo, a roster of N
+		// members cost N chain loads each time the screen asked for it.
+		LoadTeamOpts{Members: MemberLoadNames, Refresh: true},
 		func(m MetaContext, tm *TeamRecord) error {
 			tmp, err := tm.Tw().ExportToRoster()
 			if err != nil {

--- a/client/libclient/team_minder_add.go
+++ b/client/libclient/team_minder_add.go
@@ -77,7 +77,7 @@ func (t *teamAdder) loadTeam(m MetaContext, tm lib.FQTeamParsed, srcRole core.Ro
 	return t.tm.withLoadedTeam(
 		m,
 		tm,
-		LoadTeamOpts{LoadMembers: false, Refresh: true},
+		LoadTeamOpts{Refresh: true},
 		func(m MetaContext, tr *TeamRecord) error {
 			id := tr.FQT().ToFQEntity().AtHost(t.hostID())
 			tmk, hepk, err := tr.tw.TeamMemberKeys(srcRole)
@@ -202,7 +202,7 @@ func (t *TeamMinder) Add(m MetaContext, arg lcl.TeamAddArg) error {
 	return t.withLoadedTeamAndAdminToken(
 		m,
 		arg.Team,
-		LoadTeamOpts{LoadMembers: false, Refresh: true},
+		LoadTeamOpts{Refresh: true},
 		func(m MetaContext, tr *TeamRecord, tok *rem.TeamBearerToken) error {
 			adder := newTeamAdder(t, tr, tok, arg)
 			return adder.run(m)

--- a/client/libclient/team_minder_change.go
+++ b/client/libclient/team_minder_change.go
@@ -91,7 +91,7 @@ func (t *TeamMinder) TeamChangeRoles(
 	err := t.withLoadedTeamAndAdminToken(
 		m,
 		arg.Team,
-		LoadTeamOpts{LoadMembers: true, Refresh: true},
+		LoadTeamOpts{Members: MemberLoadFull, Refresh: true},
 		func(m MetaContext, tr *TeamRecord, tok *rem.TeamBearerToken) error {
 			cli, err := t.au.TeamAdminClient(m)
 			if err != nil {

--- a/integration-tests/lib/open_view_test.go
+++ b/integration-tests/lib/open_view_test.go
@@ -201,11 +201,11 @@ func TestOpenViewTeamList(t *testing.T) {
 	testLoadFor := func(user *TestUser) {
 		mc := tew.NewClientMetaContext(t, user)
 		twr, err := libclient.LoadTeam(mc, libclient.LoadTeamArg{
-			Team:            tm.FQTeam(t),
-			As:              user.FQUser().FQParty(),
-			SrcRole:         proto.OwnerRole,
-			Keys:            user.KeySeq(t, proto.OwnerRole),
-			LoadMembersFull: true,
+			Team:       tm.FQTeam(t),
+			As:         user.FQUser().FQParty(),
+			SrcRole:    proto.OwnerRole,
+			Keys:       user.KeySeq(t, proto.OwnerRole),
+			MemberLoad: libclient.MemberLoadFull,
 		},
 		)
 		require.NoError(t, err)

--- a/integration-tests/lib/team_clkr_test.go
+++ b/integration-tests/lib/team_clkr_test.go
@@ -275,11 +275,11 @@ func TestMixedRoleCLKR(t *testing.T) {
 	require.Equal(t, 1, len(clkr.Rekeys()))
 
 	twr, err := libclient.LoadTeam(mv, libclient.LoadTeamArg{
-		Team:            A.FQTeam(t),
-		As:              v.FQUser().FQParty(),
-		SrcRole:         proto.OwnerRole,
-		Keys:            v.KeySeq(t, proto.OwnerRole),
-		LoadMembersFull: true,
+		Team:       A.FQTeam(t),
+		As:         v.FQUser().FQParty(),
+		SrcRole:    proto.OwnerRole,
+		Keys:       v.KeySeq(t, proto.OwnerRole),
+		MemberLoad: libclient.MemberLoadFull,
 	})
 	require.NoError(t, err)
 	x, err := twr.ExportToRoster()
@@ -353,11 +353,11 @@ func TestAdminCLKRSkipsStaleHigherRoleMember(t *testing.T) {
 	require.Equal(t, 1, len(clkr.Rekeys()))
 
 	twr, err := libclient.LoadTeam(mw, libclient.LoadTeamArg{
-		Team:            A.FQTeam(t),
-		As:              w.FQUser().FQParty(),
-		SrcRole:         proto.OwnerRole,
-		Keys:            w.KeySeq(t, proto.OwnerRole),
-		LoadMembersFull: true,
+		Team:       A.FQTeam(t),
+		As:         w.FQUser().FQParty(),
+		SrcRole:    proto.OwnerRole,
+		Keys:       w.KeySeq(t, proto.OwnerRole),
+		MemberLoad: libclient.MemberLoadFull,
 	})
 	require.NoError(t, err)
 	x, err := twr.ExportToRoster()

--- a/integration-tests/lib/team_loader_test.go
+++ b/integration-tests/lib/team_loader_test.go
@@ -465,11 +465,11 @@ func TestTeamLoadMembers(t *testing.T) {
 
 	mc := tew.NewClientMetaContext(t, coco)
 	twr, err := libclient.LoadTeam(mc, libclient.LoadTeamArg{
-		Team:            t1.FQTeam(t),
-		As:              coco.FQUser().FQParty(),
-		SrcRole:         proto.OwnerRole,
-		Keys:            coco.KeySeq(t, proto.OwnerRole),
-		LoadMembersFull: true,
+		Team:       t1.FQTeam(t),
+		As:         coco.FQUser().FQParty(),
+		SrcRole:    proto.OwnerRole,
+		Keys:       coco.KeySeq(t, proto.OwnerRole),
+		MemberLoad: libclient.MemberLoadFull,
 	})
 	require.NoError(t, err)
 	x, err := twr.ExportToRoster()
@@ -540,11 +540,11 @@ func TestTeamLoadMembersAsNonAdmin(t *testing.T) {
 
 	mc := tew.NewClientMetaContext(t, sprigatito)
 	twr, err := libclient.LoadTeam(mc, libclient.LoadTeamArg{
-		Team:            t0.FQTeam(t),
-		As:              sprigatito.FQUser().FQParty(),
-		SrcRole:         proto.OwnerRole,
-		Keys:            sprigatito.KeySeq(t, proto.OwnerRole),
-		LoadMembersFull: true,
+		Team:       t0.FQTeam(t),
+		As:         sprigatito.FQUser().FQParty(),
+		SrcRole:    proto.OwnerRole,
+		Keys:       sprigatito.KeySeq(t, proto.OwnerRole),
+		MemberLoad: libclient.MemberLoadFull,
 	})
 	require.NoError(t, err)
 	x, err := twr.ExportToRoster()


### PR DESCRIPTION
Stacked on #332 (base branch is `max/pr-326-roster-names`); should merge after it, or the base can be retargeted to main once #332 lands.

`LoadTeamOpts` carried `LoadMembers` + `LoadMemberNames`, mapping to `LoadTeamArg`'s `LoadMembersFull` + `LoadMemberNames`, with the "full subsumes names" relationship re-derived as boolean algebra at every consumer: a three-clause memo condition in `LoadTeamWithFQTeam`, three `||`-gates in the loader, and asymmetric stickiness (names ratchet, full is overwritten) documented only by a comment on one of the two flags.

This replaces both pairs with a single ordered enum at both layers:

```go
type MemberLoadLevel int
const (
    MemberLoadNone  MemberLoadLevel = iota // roster only: uids, roles
    MemberLoadNames                        // + names, username-cache-served
    MemberLoadFull                         // + full user chains
)
```

- The memo is now `tr.ldr.Arg.MemberLoad >= opts.Members` — subsumption *is* the ordering.
- Loader gates are level comparisons (`>= MemberLoadNames`, `< MemberLoadFull`).
- Call sites read as intent: CLKR and change-roles ask for `MemberLoadFull`, `ListTeamRoster` asks for `MemberLoadNames`, everyone else takes the zero value.
- The one deliberate policy asymmetry is stated once, in `nextMemberLoad` with its rationale: Full must be re-requested per load — if it ratcheted, a single CLKR sweep (which loads Full) would silently put every team it visited back on the N-chain-fetches-per-listing plan that #326/#332 removed — while Names persists as a floor (cache-cheap, and consumers may render names off the shared record). Ad-hoc teams clamp to at least Names since they're named by their member lists.

No behavior change intended. Verified against the existing coverage of every consumer: CLI team suite (invite/admit/roster/change-roles/refresh/team-as-member/#309 guards), lib team-loader and open-viewership tests, CLKR suite, ad-hoc naming, RT ad-hoc send/receive, and the #332 cross-host warm-cache roster test.

Co-authored-by: Claude Code