### PR TITLE
feat(libclient): TeamMinder cancel-request and reject methods

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -11,6 +11,8 @@ changelog:
         closes: ["#332"]
       - desc: internal; replace team member-load flag pair with one ordered MemberLoadLevel
         closes: ["#333"]
+      - desc: TeamMinder API to cancel your own pending join request and to reject a pending request as admin
+        closes: ["#330"]
   - version: 0.1.9
     urgency: medium
     stable: true

--- a/client/libclient/team_minder_inbox.go
+++ b/client/libclient/team_minder_inbox.go
@@ -1285,3 +1285,72 @@ func (t *TeamMinder) TeamAdmit(
 
 	return editor.Run(m)
 }
+
+// TeamCancelRequest posts a Removed-state TML link for the given team invite,
+// resetting the caller's "Requested" membership state. Accepts the raw FOKS
+// invite code (not the SECO_INVITE:: wrapped form) so we can resolve the
+// actual TeamID via the cert — ResolveAndReindex only indexes Approved teams
+// and would fail for Requested-state entries.
+func (t *TeamMinder) TeamCancelRequest(m MetaContext, inviteCode string) error {
+	invite, err := team.ImportTeamInvite(inviteCode)
+	if err != nil {
+		return err
+	}
+
+	i1, err := openInvite(*invite)
+	if err != nil {
+		return err
+	}
+
+	cli, closer, _, err := t.remoteGuestCli(m, i1.Host)
+	if err != nil {
+		return err
+	}
+	defer closer()
+
+	cert, err := t.lookupAndOpenCert(m, cli, *invite)
+	if err != nil {
+		return err
+	}
+
+	fqt := cert.cert.Team
+	glp := proto.NewGenericLinkPayloadWithTeammembership(
+		proto.TeamMembershipLink{
+			Team:    fqt,
+			SrcRole: team.UserSrcRole,
+			State:   proto.NewTeamMembershipDetailsDefault(proto.TeamMembershipLinkState_Removed),
+		},
+	)
+	arg, err := t.makeMembershipChainLink(m, nil, glp, nil)
+	if err != nil {
+		return err
+	}
+	ucli, err := t.au.UserClient(m)
+	if err != nil {
+		return err
+	}
+	return ucli.PostGenericLink(m.Ctx(), *arg)
+}
+
+// TeamReject removes a single pending join request by sending a server-side
+// RejectJoinReq RPC. The inbox entry is deleted on the server so it won't
+// reappear on subsequent TeamInbox / TeamListPending calls.
+// fqtp is the parsed team name (from core.ParseFQTeam); tok is the
+// proto.TeamRSVP returned from the inbox row.
+func (t *TeamMinder) TeamReject(m MetaContext, fqtp proto.FQTeamParsed, tok proto.TeamRSVP) error {
+	fqt, err := t.ResolveAndReindex(m, team.WrapNamed(fqtp), nil)
+	if err != nil {
+		return err
+	}
+	if fqt == nil {
+		return core.TeamNotFoundError{}
+	}
+	adminTok, cli, _, err := t.adminTokenAndClient(m, *fqt, LoadTeamOpts{})
+	if err != nil {
+		return err
+	}
+	return cli.RejectJoinReq(m.Ctx(), rem.RejectJoinReqArg{
+		Tok: *adminTok,
+		Req: tok,
+	})
+}

--- a/integration-tests/lib/team_inbox_cancel_reject_test.go
+++ b/integration-tests/lib/team_inbox_cancel_reject_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package lib
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/client/libclient"
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/lib/team"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercise TeamMinder.TeamCancelRequest and TeamMinder.TeamReject through a
+// full join-request round trip: accept an invite, cancel the request
+// (requester side), reject the request (admin side), and re-accept after
+// rejection -- the last leg working because RejectJoinReq marks the joinreq
+// 'rejected' and the local_joinreq_joiner_idx partial index only constrains
+// pending rows.
+func TestTeamMinderCancelAndRejectJoinReq(t *testing.T) {
+	tew := testEnvBeta(t)
+	tew.DirectMerklePoke(t)
+	owner := tew.NewTestUser(t)
+	joiner := tew.NewTestUser(t)
+	m := tew.MetaContext()
+	tew.DirectMerklePokeForLeafCheck(t)
+
+	tm := tew.makeTeamForOwner(t, owner)
+	tm.setIndexRange(t, m, owner, index0)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	poke := &libclient.TeamMinderTestHooks{
+		PostChainHook: func() error {
+			tew.DirectDoubleMerklePokeInTest(t)
+			return nil
+		},
+	}
+
+	ownerMc := tew.NewClientMetaContext(t, owner)
+	ownerTmm, err := ownerMc.G().TeamMinder()
+	require.NoError(t, err)
+	ownerTmm.TestHooks = poke
+
+	joinerMc := tew.NewClientMetaContext(t, joiner)
+	joinerTmm, err := joinerMc.G().TeamMinder()
+	require.NoError(t, err)
+	joinerTmm.TestHooks = poke
+
+	fqtp, err := core.ParseFQTeam(proto.FQTeamString(tm.nm))
+	require.NoError(t, err)
+
+	invite, err := ownerTmm.CreateInvite(ownerMc, *fqtp)
+	require.NoError(t, err)
+	inviteStr, err := team.ExportTeamInvite(*invite)
+	require.NoError(t, err)
+
+	accept := func() {
+		_, err := joinerTmm.AcceptInvite(joinerMc, lcl.TeamAcceptInviteArg{I: *invite})
+		require.NoError(t, err)
+		tew.DirectDoubleMerklePokeInTest(t)
+	}
+
+	// The joiner's request state as recorded in their own team membership
+	// chain, reloaded from scratch each call.
+	joinerTMLState := func() proto.TeamMembershipLinkState {
+		tmlu, err := libclient.NewTMLUser(joinerMc, joinerMc.G().ActiveUser().Info.Role)
+		require.NoError(t, err)
+		lw, err := libclient.LoadTeamMembershipReturnLoader(joinerMc, tmlu)
+		require.NoError(t, err)
+		var key libclient.FQTeamSrcRole
+		err = key.Import(tm.FQTeam(t), team.UserSrcRole)
+		require.NoError(t, err)
+		link, found := lw.Wrapper.Map[key]
+		require.True(t, found)
+		typ, err := link.State.GetT()
+		require.NoError(t, err)
+		return typ
+	}
+
+	inboxLen := func() int {
+		inb, err := ownerTmm.TeamInbox(ownerMc, *fqtp)
+		require.NoError(t, err)
+		return len(inb.Rows)
+	}
+
+	accept()
+	require.Equal(t, proto.TeamMembershipLinkState_Requested, joinerTMLState())
+	require.Equal(t, 1, inboxLen())
+
+	// Requester withdraws: their chain flips to Removed. Note the
+	// server-side joinreq is not retired by cancel; the admin still sees
+	// the row until they act on it (issue #336 -- when fixed, this leg
+	// should instead assert the inbox row disappears and that re-accept
+	// works immediately, with no admin reject in between).
+	err = joinerTmm.TeamCancelRequest(joinerMc, inviteStr)
+	require.NoError(t, err)
+	tew.DirectDoubleMerklePokeInTest(t)
+	require.Equal(t, proto.TeamMembershipLinkState_Removed, joinerTMLState())
+
+	// Admin rejects the (now-withdrawn) request; the inbox row is retired
+	// and stays gone on subsequent loads.
+	inb, err := ownerTmm.TeamInbox(ownerMc, *fqtp)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(inb.Rows))
+	err = ownerTmm.TeamReject(ownerMc, *fqtp, inb.Rows[0].Tok)
+	require.NoError(t, err)
+	require.Equal(t, 0, inboxLen())
+
+	// A rejected joiner can ask again: rejection leaves no pending joinreq
+	// row, so the partial unique index doesn't block a fresh RSVP.
+	accept()
+	require.Equal(t, proto.TeamMembershipLinkState_Requested, joinerTMLState())
+	require.Equal(t, 1, inboxLen())
+}


### PR DESCRIPTION
Supersedes #330 — @st3v3y's feature, carried as their commit with authorship preserved (the SECO-PBC fork is org-owned, so maintainer pushes 403 despite `maintainerCanModify`), plus an integration test and changelog entry on top.

**First commit (st3v3y's, unchanged, rebased onto main):** two additive `TeamMinder` methods — `TeamCancelRequest` (requester withdraws a pending join request by posting a Removed-state TML link, resolving the team via the invite cert since `ResolveAndReindex` only indexes Approved teams) and `TeamReject` (admin rejects a pending request via the existing `RejectJoinReq` RPC). See #330 for the full writeup.

**Second commit:** `TestTeamMinderCancelAndRejectJoinReq` in `integration-tests/lib`, round-tripping one join request through both methods: accept (Requested state + one inbox row), cancel (requester's chain flips to Removed), reject (inbox row retired, stays gone), then re-accept after rejection — which works because `RejectJoinReq` sets `state='rejected'` and the #316 partial unique index only constrains pending rows. Also adds the 0.1.10 changelog entry.

**Known gap, filed as #336:** `TeamCancelRequest` doesn't retire the server-side joinreq — the admin still sees (and can still admit) a withdrawn request, and the canceller can't re-RSVP until an admin clears the stale pending row. The test asserts today's behavior with a pointer to the issue; fix to follow in a subsequent PR (likely a requester-authenticated `WithdrawJoinReq`, since `RejectJoinReq` needs an admin bearer token).

Co-authored-by: Claude Code