### PR TITLE
test(teams): pin the cancel-reject-reaccept arc; changelog entry for #330

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -19,6 +19,8 @@ changelog:
         closes: ["#327"]
       - desc: add 'foks-tool patch-db --yes' for unattended deploys
         closes: ["#328"]
+      - desc: TeamMinder API to cancel your own pending join request and to reject a pending request as admin
+        closes: ["#330"]
   - version: 0.1.9
     urgency: medium
     stable: true

--- a/integration-tests/lib/team_inbox_cancel_reject_test.go
+++ b/integration-tests/lib/team_inbox_cancel_reject_test.go
@@ -216,3 +216,52 @@ func TestTeamRejectThenAdmitFails(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+// The full withdraw-and-return arc: the joiner cancels their request, the
+// admin retires the stale row, and the joiner asks again.
+//
+// Two behaviors pinned along the way:
+//
+//   - Cancel does not retire the server-side joinreq (issue #336): the row is
+//     still in the owner's inbox after the joiner has withdrawn, and it takes
+//     an explicit admin reject to clear it. When #336 is fixed, the
+//     post-cancel assertion should flip to require.Empty, and the reject leg
+//     can go away entirely.
+//
+//   - Re-accepting after rejection works: RejectJoinReq moves the joinreq to
+//     state='rejected', and the local_joinreq_joiner_idx partial unique index
+//     (#314) only constrains pending rows, so a fresh RSVP is not blocked by
+//     the retired one.
+func TestTeamCancelRejectThenReaccept(t *testing.T) {
+	f := newInboxFixture(t)
+
+	state, found := f.membershipState(t)
+	require.True(t, found)
+	require.Equal(t, proto.TeamMembershipLinkState_Requested, state)
+
+	err := f.tmj.TeamCancelRequest(f.mj, f.inviteStr)
+	require.NoError(t, err)
+	f.tew.DirectDoubleMerklePokeInTest(t)
+
+	state, found = f.membershipState(t)
+	require.True(t, found)
+	require.Equal(t, proto.TeamMembershipLinkState_Removed, state)
+
+	// Issue #336: the withdrawn request still sits in the owner's inbox.
+	rows := f.inboxRows(t)
+	require.Len(t, rows, 1)
+
+	err = f.tmo.TeamReject(f.mo, f.fqtp, rows[0].Tok)
+	require.NoError(t, err)
+	require.Empty(t, f.inboxRows(t))
+
+	// The joiner changes their mind and asks again.
+	_, err = f.tmj.AcceptInvite(f.mj, lcl.TeamAcceptInviteArg{I: f.invite})
+	require.NoError(t, err)
+	f.tew.DirectDoubleMerklePokeInTest(t)
+
+	state, found = f.membershipState(t)
+	require.True(t, found)
+	require.Equal(t, proto.TeamMembershipLinkState_Requested, state)
+	require.Len(t, f.inboxRows(t), 1)
+}


### PR DESCRIPTION
Small follow-ups to the merged #330, carrying over what #337's version had that the final revision didn't:

- **`TestTeamCancelRejectThenReaccept`** on @st3v3y's `inboxFixture`: the full withdraw-and-return arc. Pins two behaviors: cancel leaves the joinreq in the owner's inbox (#336 — the assertions are annotated to flip to `require.Empty` when that's fixed), and a rejected joiner can RSVP again, since `RejectJoinReq` sets `state='rejected'` and the #314 partial unique index only constrains pending rows.
- **Changelog entry for #330** in the 0.1.10 section.

Co-authored-by: Claude Code