### PR TITLE
server: make merkle pipeline background loops resilient to DB interruptions

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -23,6 +23,8 @@ changelog:
         closes: ["#330"]
       - desc: fix KV operations failing with "team bearer token is stale" after admission or a role change; re-mint the token and retry
         closes: ["#324"]
+      - desc: server; merkle pipeline loops survive transient DB interruptions instead of stopping until restart
+        closes: ["#323"]
   - version: 0.1.9
     urgency: medium
     stable: true

--- a/integration-tests/lib/merkle_pipeline_test.go
+++ b/integration-tests/lib/merkle_pipeline_test.go
@@ -5,6 +5,8 @@ package lib
 
 import (
 	"bytes"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -336,4 +338,70 @@ func TestSimpleBatch(t *testing.T) {
 	pokepoke()
 	epnoPost := check(alice4.key, true, 2)
 	require.Equal(t, epno+1, epnoPost)
+}
+
+// An "ambiguous commit": commitBatch's transaction lands server-side, but the
+// batcher observes an error (in production: a context cancellation racing
+// tx.Commit, or a dropped connection eating the ack). The batcher's memoized
+// batch counter is then behind the database, and without dropping its cached
+// state it would rebuild the same batch number every round and die on the
+// raft_kv_store primary key forever -- while still holding the loop's lock, so
+// no other instance could take over. The recovery contract: the very next
+// round re-reads committed state and proceeds.
+func TestMerkleBatcherAmbiguousCommitRecovery(t *testing.T) {
+	env := globalTestEnv.Fork(t, common.SetupOpts{
+		MerklePollWait: time.Hour,
+	})
+	defer func() {
+		_ = env.ShutdownFn()
+	}()
+	m := env.MetaContext()
+
+	shortHostID := m.G().HostChain().HostID().Short
+	alice := core.RandomUID().EntityID()
+	aliceDev := core.RandomDeviceID()
+
+	insertBatch(t, m, []*workQueueItem{
+		randomWorkQueueItem(t, shortHostID, alice, aliceDev, proto.ChainType_User, 1),
+	})
+
+	var calls int32
+	env.MerkleBatcherSrv().SetTestPostCommitHook(func() error {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return errors.New("synthetic ambiguous commit")
+		}
+		return nil
+	})
+
+	cli, closeFn := common.TestMerkleBatcherCli(t, m)
+	defer func() {
+		err := closeFn()
+		require.NoError(t, err)
+	}()
+
+	// Round 1: the batch commits, but the poke reports the synthetic failure.
+	err := cli.Poke(m.Ctx())
+	require.Error(t, err)
+
+	state, batch, err := selectCurrentBatch(t, m)
+	require.NoError(t, err)
+	require.Equal(t, proto.MerkleBatchNo(2), state.Next)
+	require.Equal(t, proto.MerkleBatchNo(1), batch.Batchno)
+
+	// Round 2: new work on an independent chain (a second user, since the
+	// batcher won't batch alice's seqno 2 while her seqno 1 is still
+	// in-flight). The batcher must pick up at batch 2, not rebuild batch 1
+	// against the primary key.
+	bob := core.RandomUID().EntityID()
+	bobDev := core.RandomDeviceID()
+	insertBatch(t, m, []*workQueueItem{
+		randomWorkQueueItem(t, shortHostID, bob, bobDev, proto.ChainType_User, 1),
+	})
+	err = cli.Poke(m.Ctx())
+	require.NoError(t, err)
+
+	state, batch, err = selectCurrentBatch(t, m)
+	require.NoError(t, err)
+	require.Equal(t, proto.MerkleBatchNo(3), state.Next)
+	require.Equal(t, proto.MerkleBatchNo(2), batch.Batchno)
 }

--- a/server/engine/merkle_batcher.go
+++ b/server/engine/merkle_batcher.go
@@ -25,6 +25,20 @@ type MerkleBatcherVHostState struct {
 type MerkleBatcherServer struct {
 	MerklePipelineBaseServer
 	vhosts map[core.ShortHostID]*MerkleBatcherVHostState
+
+	// testPostCommitHook, when set, runs after commitBatch's transaction has
+	// committed and its result replaces commitBatch's nil error. It simulates
+	// an ambiguous commit -- the commit landed server-side but the client
+	// observed a failure (context cancellation racing tx.Commit, a dropped
+	// connection eating the ack) -- to test that the batcher recovers instead
+	// of wedging on its now-behind in-memory batch counter. Production code
+	// never sets this.
+	testPostCommitHook func() error
+}
+
+// SetTestPostCommitHook arms testPostCommitHook; see its comment. Tests only.
+func (s *MerkleBatcherServer) SetTestPostCommitHook(f func() error) {
+	s.testPostCommitHook = f
 }
 
 func NewMerkleBatcherServer() *MerkleBatcherServer {
@@ -406,6 +420,18 @@ func (s *MerkleBatcherServer) commitBatch(m shared.MetaContext, batch *proto.Mer
 		if err == nil && tmp != nil {
 			err = tmp
 		}
+		if err != nil {
+			// The commit may have landed server-side even though we observed
+			// an error (a context cancellation racing tx.Commit, a dropped
+			// connection eating the ack). Our memoized batch counter would
+			// then be behind the database, and every later round would
+			// rebuild the same batch number and die on the raft_kv_store
+			// primary key -- forever, and while still holding the loop's
+			// lock, so no other instance could take over either. Drop the
+			// cached state so the next round re-reads committed truth, which
+			// self-heals both outcomes of the ambiguity.
+			delete(s.vhosts, vh.shid)
+		}
 	}()
 
 	batchRaw, err := core.EncodeToBytes(batch)
@@ -446,6 +472,12 @@ func (s *MerkleBatcherServer) commitBatch(m shared.MetaContext, batch *proto.Mer
 	err = tx.Commit(m.Ctx())
 	if err != nil {
 		return err
+	}
+
+	if s.testPostCommitHook != nil {
+		if herr := s.testPostCommitHook(); herr != nil {
+			return herr
+		}
 	}
 
 	m.Debugw("commitBatch",

--- a/server/shared/lock.go
+++ b/server/shared/lock.go
@@ -209,6 +209,17 @@ func (l *Lock) getHeartbeatFailure() bool {
 	return l.heartbeatFailed
 }
 
+// LostLock reports whether the most recent Heartbeat found the lock had been
+// taken over by another process — the lock row no longer matches our pid +
+// lock_id, so the UPDATE affected zero rows. This is deliberately distinct from
+// a transient DB/connection error returned by Heartbeat (e.g. "connection
+// refused" or a timeout): after a transient error the caller still owns the
+// lock and should retry, whereas after a genuine takeover it must stand down.
+// Set once by Heartbeat and never cleared.
+func (l *Lock) LostLock() bool {
+	return l.getHeartbeatFailure()
+}
+
 func (l *Lock) setHeartbeatFailure() {
 	l.Lock()
 	defer l.Unlock()

--- a/server/shared/looper.go
+++ b/server/shared/looper.go
@@ -65,6 +65,29 @@ func (b *BaseServer) DoOnePoll(m MetaContext, looper Looper) error {
 	return nil
 }
 
+// looperDbTimeout bounds every database operation a background poll loop makes
+// (the lock heartbeat and each poll). It is a hang detector, not a
+// normal-operation bound: heartbeats and incremental polls complete in well
+// under a second, so this only ever fires when a pooled connection has gone
+// stale (the pool sets no MaxConnLifetime / statement_timeout, so a query on a
+// dead connection would otherwise block forever and silently wedge the loop —
+// stalling the merkle pipeline until a full server restart). On timeout pgx
+// aborts the query and discards the bad connection, so the next iteration gets
+// a fresh one and the loop self-recovers.
+const looperDbTimeout = 60 * time.Second
+
+func (b *BaseServer) heartbeatWithTimeout(m MetaContext, looper Looper) error {
+	m, cancel := m.WithContextTimeout(looperDbTimeout)
+	defer cancel()
+	return looper.GetLock().Heartbeat(m)
+}
+
+func (b *BaseServer) pollWithTimeout(m MetaContext, looper Looper) error {
+	m, cancel := m.WithContextTimeout(looperDbTimeout)
+	defer cancel()
+	return b.DoOnePoll(m, looper)
+}
+
 func (b *BaseServer) runPoolLoopWithLooper(
 	m MetaContext,
 	shutdownCh chan<- error,
@@ -73,27 +96,38 @@ func (b *BaseServer) runPoolLoopWithLooper(
 	keepGoing := true
 	for keepGoing {
 
-		// If we fail the lock heartbeat, it's because someone else is acting as the merkle Batcher,
-		// and we should get out of the way.
-		err := looper.GetLock().Heartbeat(m)
-		if err != nil {
-			m.Warnw("heartbeat", "err", err)
-			shutdownCh <- err
+		// Renew the lock lease. A heartbeat error is only fatal when the lock
+		// was genuinely taken over by another instance (LostLock) — then we
+		// stand down. A transient DB/connection error (a stale pooled conn, a
+		// brief postgres outage on `compose up`, a network blip) leaves the
+		// lock ours, so we log and retry on the next tick rather than exiting
+		// permanently, which used to kill the merkle pipeline until a full
+		// server restart.
+		hbErr := b.heartbeatWithTimeout(m, looper)
+		if hbErr != nil && looper.GetLock().LostLock() {
+			m.Warnw("runPollLoop", "stage", "lock-lost", "err", hbErr)
+			shutdownCh <- hbErr
 			keepGoing = false
-		} else {
+			continue
+		}
+		if hbErr != nil {
+			m.Warnw("runPollLoop", "stage", "heartbeat-transient", "err", hbErr)
+		}
 
-			select {
-			case <-time.After(looper.GetConfig().PollWait()):
-				err := b.DoOnePoll(m, looper)
-				if err != nil {
-					m.Warnw("runPollLoop", "stage", "doOnePoll", "err", err)
-				}
-			case retCh := <-looper.GetPokeCh():
-				err := b.DoOnePoll(m, looper)
-				retCh <- err
-			case <-m.Ctx().Done():
-				keepGoing = false
+		select {
+		case <-time.After(looper.GetConfig().PollWait()):
+			if hbErr != nil {
+				// The DB was unreachable this round; skip the poll and retry
+				// the heartbeat after the poll-wait backoff.
+				continue
 			}
+			if err := b.pollWithTimeout(m, looper); err != nil {
+				m.Warnw("runPollLoop", "stage", "doOnePoll", "err", err)
+			}
+		case retCh := <-looper.GetPokeCh():
+			retCh <- b.pollWithTimeout(m, looper)
+		case <-m.Ctx().Done():
+			keepGoing = false
 		}
 	}
 	m.Infow("runPollLoop", "stage", "exit")


### PR DESCRIPTION
Supersedes #323 — @st3v3y's resilience change, carried as their commit with authorship preserved (org-owned fork blocks maintainer pushes), plus a hardening fix for a cancellation hazard the review turned up.

**First commit (st3v3y's, unchanged, rebased onto main):** transient DB failures no longer permanently kill the merkle pipeline loops. `Lock.LostLock()` distinguishes a genuine lock takeover (stand down) from a transient heartbeat error (log and retry); each heartbeat and poll gets a 60s hang-detector timeout so a stale pooled connection can't silently wedge the loop. See #323 for the full writeup.

**Second commit (review finding + fix):** the review question was whether a canceled `DoOnePoll` can leave merkle state inconsistent. For the tree itself, no — the builder advances bookkeeping in the same transaction as each leaf insert, the signer's work predicate (`sig IS NULL`) is the column it updates, and the batcher's staged→processing markings self-heal via `WorkTimeout`. But there is one real hazard, which the per-iteration timeout makes systematically reachable: an **ambiguous commit** in `commitBatch`. If cancellation races `tx.Commit` and the commit lands server-side while the client observes an error, the batcher's memoized batch counter falls behind the database — and every later round rebuilds the same batch number and dies on the `raft_kv_store` primary key, *forever*, while still heartbeating successfully. That's strictly worse than the pre-PR failure mode: the loop holds the lock, so no failover instance can take over, and no progress is possible until process restart.

The fix extends `commitBatch`'s existing cleanup defer: once the final error is settled, any failure drops the memoized per-vhost state, so the next round re-reads committed truth and either outcome of the ambiguity self-heals in one tick. (The desync predates #323 — a dropped connection could always eat a commit ack — the timeout just turns a rare event into an expected one.)

Tested with a post-commit test hook that simulates the ambiguous commit (`TestMerkleBatcherAmbiguousCommitRecovery`): the batch commits, the batcher observes a synthetic failure, and the next round must proceed at the correct batch number. Verified both directions — with the invalidation disabled the next round fails on `raft_kv_store_pkey` exactly as predicted. `TestSimpleBatch` and the team/CLKR/KV suites stay green.

Changelog entry included.

Co-authored-by: Claude Code