### PR TITLE
fix(team): verify rekeyed team certs in stacked-signature order

### DIFF
--- a/client/libclient/team_minder_inbox.go
+++ b/client/libclient/team_minder_inbox.go
@@ -461,38 +461,17 @@ func (t *TeamMinder) lookupCert(
 	return &cert, nil
 }
 
+// openCert verifies a team cert and additionally checks that it was issued for
+// the host we expect. The verify itself lives in exactly one place on purpose:
+// this used to carry its own copy, which had drifted to the wrong
+// stacked-signature order and so rejected every cert from a rekeyed team.
 func openCert(c *rem.TeamCert, hostID proto.HostID) (*rem.TeamCertV1Payload, error) {
-	v, err := c.GetV()
-	if err != nil {
-		return nil, err
-	}
-	if v != rem.TeamCertVersion_V1 {
-		return nil, core.VersionNotSupportedError("team cert != v1")
-	}
-	signed := c.V1()
-	ret, err := signed.Payload.AllocAndDecode(core.DecoderFactory{})
+	ret, err := team.OpenTeamCert(*c)
 	if err != nil {
 		return nil, err
 	}
 	if !ret.Team.Host.Eq(hostID) {
 		return nil, core.HostMismatchError{}
-	}
-	var verifiers []core.Verifier
-	ep, err := core.ImportEntityPublic(ret.Team.Team.EntityID())
-	if err != nil {
-		return nil, err
-	}
-	verifiers = append(verifiers, ep)
-	if !ret.Ptk.Gen.IsFirst() {
-		ep, err := core.ImportEntityPublic(ret.Ptk.VerifyKey)
-		if err != nil {
-			return nil, err
-		}
-		verifiers = append(verifiers, ep)
-	}
-	err = core.VerifyStackedSignature(&signed, verifiers)
-	if err != nil {
-		return nil, err
 	}
 	return ret, nil
 }

--- a/integration-tests/lib/team_common_test.go
+++ b/integration-tests/lib/team_common_test.go
@@ -36,6 +36,25 @@ type teamObj struct {
 	tir            *core.RationalRange
 }
 
+// teamMinderFor builds a TeamMinder for u. Chain posts need the merkle tree to
+// advance before the next read, which in production happens on the server's own
+// schedule, so the hook pokes it here.
+func (te *TestEnvWrapper) teamMinderFor(
+	t *testing.T,
+	u *TestUser,
+) (libclient.MetaContext, *libclient.TeamMinder) {
+	m := te.NewClientMetaContext(t, u)
+	tmm, err := m.G().TeamMinder()
+	require.NoError(t, err)
+	tmm.TestHooks = &libclient.TeamMinderTestHooks{
+		PostChainHook: func() error {
+			te.DirectDoubleMerklePokeInTest(t)
+			return nil
+		},
+	}
+	return m, tmm
+}
+
 func (tm *teamObj) absorb(x *core.HEPKSet) {
 	tm.hepks = tm.hepks.Merge(x)
 }

--- a/integration-tests/lib/team_inbox_cancel_reject_test.go
+++ b/integration-tests/lib/team_inbox_cancel_reject_test.go
@@ -34,18 +34,7 @@ type inboxFixture struct {
 }
 
 func (f *inboxFixture) minderFor(t *testing.T, u *TestUser) (libclient.MetaContext, *libclient.TeamMinder) {
-	m := f.tew.NewClientMetaContext(t, u)
-	tmm, err := m.G().TeamMinder()
-	require.NoError(t, err)
-	// Chain posts need the merkle tree to advance before the next read, which
-	// in production happens on the server's own schedule.
-	tmm.TestHooks = &libclient.TeamMinderTestHooks{
-		PostChainHook: func() error {
-			f.tew.DirectDoubleMerklePokeInTest(t)
-			return nil
-		},
-	}
-	return m, tmm
+	return f.tew.teamMinderFor(t, u)
 }
 
 func newInboxFixture(t *testing.T) *inboxFixture {

--- a/integration-tests/lib/team_rekey_invite_test.go
+++ b/integration-tests/lib/team_rekey_invite_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+package lib
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	"github.com/foks-proj/go-foks/proto/lcl"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/stretchr/testify/require"
+)
+
+// A team cert is stacked-signed by the current PTK and then by the gen-1 PTK,
+// so the verifier list has to be in that same order. At gen 1 the two keys
+// coincide and any order works, which is why only rekeyed teams hit this. Once
+// the team has rotated its admin PTK, a swapped verifier order makes every
+// invite to it unacceptable with a signature verify error.
+func TestAcceptInviteToRekeyedTeam(t *testing.T) {
+	tew := testEnvBeta(t)
+	owner := tew.NewTestUser(t)
+	joiner := tew.NewTestUser(t)
+	transient := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	tm := tew.makeTeamForOwner(t, owner)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	m := tew.MetaContext()
+
+	// Add and then remove an admin, which forces the team to rotate its admin
+	// PTK; the cert is signed with that key, so this is what puts the cert at
+	// gen > 1.
+	tm.makeChanges(t, m, owner, []proto.MemberRole{
+		transient.toMemberRole(t, proto.AdminRole, tm.hepks),
+	}, nil)
+	tew.DirectDoubleMerklePokeInTest(t)
+	tm.makeChanges(t, m, owner, []proto.MemberRole{
+		transient.toMemberRole(t, proto.NewRoleDefault(proto.RoleType_NONE), tm.hepks),
+	}, nil)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	adminPtk, ok := tm.ptks[core.AdminRole]
+	require.True(t, ok)
+	require.False(t, adminPtk.Metadata().Gen.IsFirst(),
+		"the team must actually have rekeyed for this test to mean anything")
+
+	// An invite carries a team index range, so the team needs one before the
+	// owner can issue invites.
+	tm.setIndexRange(t, m, owner, index0)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	fqtp := *tm.ToFQTeamParsed(t)
+
+	mo, tmo := tew.teamMinderFor(t, owner)
+	mj, tmj := tew.teamMinderFor(t, joiner)
+
+	inv, err := tmo.CreateInvite(mo, fqtp)
+	require.NoError(t, err)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	_, err = tmj.AcceptInvite(mj, lcl.TeamAcceptInviteArg{I: *inv})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Accepting an invite to a team that has rotated its PTK always fails with `signature verify error: signature verification failed`. Gen-1 teams are fine, and a fresh invite does not help, because the cert is stored and reused.

Team certs are stacked-signed, so the verifier list has to be in the same order as the signer list. `MakeTeamCert` signs with `[current PTK, gen-1 PTK]`, but `openCert` in `client/libclient/team_minder_inbox.go` verified with `[gen-1 PTK, current PTK]` — the team's entity ID is its gen-1 PTK verify key, so it stood in for the first key. At gen 1 there is one signature and the orders coincide; at gen > 1 both positions mismatch and verification can never succeed.

`team.OpenTeamCert` in `lib/team/cert.go` already gets this right, so this was a second copy of the same verify that had drifted. Rather than reorder in place, `openCert` now calls `team.OpenTeamCert` and keeps only the host check specific to that path, leaving one implementation. That moves the host check to after the signature check; no caller depends on the precedence, and verifying before trusting payload fields seems the better order.

Fixing the verifier rather than the signer is deliberate: certs are persisted and reused, so changing the signing order would leave already-written gen > 1 certs permanently unverifiable.

Adds `TestAcceptInviteToRekeyedTeam`, which rotates a team's admin PTK, asserts the rotation happened, then accepts an invite. It reproduces the error before the change and passes after; re-checked by reintroducing the swap in `team.OpenTeamCert`, which the test also catches. Full `integration-tests/lib` and `golangci-lint` are green.