### PR TITLE
kv-store: make a small-file write idempotent on replay

### DIFF
--- a/integration-tests/lib/kv_replay_test.go
+++ b/integration-tests/lib/kv_replay_test.go
@@ -1,0 +1,71 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+	"github.com/stretchr/testify/require"
+)
+
+// kvStoreClientForUser opens a raw KV-store client for the given user, so a
+// test can drive the RPCs directly rather than through libkv (which mints a
+// fresh node ID per call and so cannot express a replay).
+func kvStoreClientForUser(t *testing.T, tew *TestEnvWrapper, u *TestUser) rem.KVStoreClient {
+	m := tew.NewClientMetaContext(t, u)
+	au := m.G().ActiveUser()
+	cert, err := au.ClientCert(m)
+	require.NoError(t, err)
+	pr := au.HomeServer()
+	require.NotNil(t, pr)
+	gcli, err := pr.RPCClient(m, proto.ServerType_KVStore, cert)
+	require.NoError(t, err)
+	return core.NewKVStoreClient(gcli, m)
+}
+
+// TestKVPutSmallFileReplay covers retrying a small-file write. The node ID is
+// chosen by the client and fixes the encryption nonce, so a retry after an
+// ambiguous failure sends byte-identical bytes; that must succeed as a no-op
+// rather than failing on the primary key. The same ID with different bytes
+// must still be refused.
+func TestKVPutSmallFileReplay(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t)
+	tew.DirectMerklePokeInTest(t)
+
+	m := tew.NewClientMetaContext(t, bluey)
+	cli := kvStoreClientForUser(t, tew, bluey)
+
+	var nid proto.KVNodeID
+	nid[0] = byte(proto.KVNodeType_SmallFile)
+	require.NoError(t, core.RandomFill(nid[1:]))
+
+	mk := func(body string) rem.KvPutSmallFileOrSymlinkArg {
+		return rem.KvPutSmallFileOrSymlinkArg{
+			Id: nid,
+			Sfb: proto.SmallFileBox{
+				Rg:      proto.RoleAndGen{Role: proto.OwnerRole},
+				DataBox: proto.NaclCiphertext(body),
+			},
+		}
+	}
+
+	// First write lands.
+	require.NoError(t, cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("ciphertext")))
+
+	// The same write again is the retry case: a no-op, not an error, and not
+	// a second charge against usage.
+	before, err := cli.KvUsage(m.Ctx(), rem.KVAuth{})
+	require.NoError(t, err)
+	require.NoError(t, cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("ciphertext")))
+	after, err := cli.KvUsage(m.Ctx(), rem.KVAuth{})
+	require.NoError(t, err)
+	require.Equal(t, before.Small, after.Small, "a replay must not be charged twice")
+
+	// The same ID carrying different bytes is refused.
+	err = cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("different ciphertext"))
+	require.Error(t, err)
+	var race core.KVRaceError
+	require.ErrorAs(t, err, &race)
+}

--- a/server/kv-store/file.go
+++ b/server/kv-store/file.go
@@ -100,33 +100,6 @@ func putSmallFileOrSymlink(
 		return err
 	}
 
-	// A replay of an identical node is a no-op. Node IDs are client-chosen,
-	// and a small file's encryption nonce derives from its node ID, so a
-	// client retrying after an ambiguous failure -- the write landed, the
-	// ack did not -- sends byte-identical bytes. Checked before
-	// usageCheckAndInc so a retry is not charged twice. A same-ID row
-	// carrying different bytes is a client bug or a stray collision in a
-	// 16-byte random space; refuse it rather than silently keeping one copy
-	// or the other.
-	var existing []byte
-	err = tx.QueryRow(
-		m.Ctx(),
-		`SELECT box FROM small_file_or_symlink
-		 WHERE short_host_id=$1 AND short_party_id=$2 AND node_id=$3`,
-		int(m.HostID().Short),
-		pid.Shorten().ExportToDB(),
-		arg.Id.ExportToDB(),
-	).Scan(&existing)
-	if err == nil {
-		if bytes.Equal(existing, arg.Sfb.DataBox) {
-			return nil
-		}
-		return core.KVRaceError("small-file node id replayed with different content")
-	}
-	if err != pgx.ErrNoRows {
-		return err
-	}
-
 	// Max length of small file is 2k + size of Poly1305
 	lim := kv.SmallFileSize + secretbox.Overhead
 	if len(arg.Sfb.DataBox) > lim {
@@ -137,24 +110,18 @@ func putSmallFileOrSymlink(
 		}
 	}
 
-	err = usageCheckAndInc(
-		m,
-		tx,
-		pid,
-		proto.KVNodeType_SmallFile,
-		len(arg.Sfb.DataBox),
-		true,
-	)
-	if err != nil {
-		return err
-	}
-
+	// Insert first, tolerating a conflict, so recognising a replay and
+	// claiming the row are one atomic step. A pre-check would leave a window
+	// where the original write commits between check and insert, and the
+	// retry would then fail on the primary key -- the exact case this makes
+	// safe.
 	tag, err := tx.Exec(
 		m.Ctx(),
 		`INSERT INTO small_file_or_symlink(short_host_id, short_party_id, node_id, 
 			ptk_gen, read_role_type, read_role_viz_level,
 			size, box, ctime, mtime, refcount 
-		) VALUES($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW(), 0)`,
+		) VALUES($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW(), 0)
+		 ON CONFLICT DO NOTHING`,
 		int(m.HostID().Short),
 		pid.Shorten().ExportToDB(),
 		arg.Id.ExportToDB(),
@@ -167,8 +134,53 @@ func putSmallFileOrSymlink(
 	if err != nil {
 		return err
 	}
+
+	if tag.RowsAffected() == 0 {
+		// The node ID is already taken. A client retrying after an ambiguous
+		// failure sends byte-identical bytes -- node IDs are client-chosen
+		// and a small file's nonce derives from its node ID -- so an
+		// identical row is that retry, and succeeding is what lets the
+		// client carry on. Anything else reusing the ID is a bug or a stray
+		// collision in a 16-byte random space, and must not silently keep
+		// one copy or the other.
+		var box []byte
+		var gen, rt, vl int
+		err = tx.QueryRow(
+			m.Ctx(),
+			`SELECT box, ptk_gen, read_role_type, read_role_viz_level
+			 FROM small_file_or_symlink
+			 WHERE short_host_id=$1 AND short_party_id=$2 AND node_id=$3`,
+			int(m.HostID().Short),
+			pid.Shorten().ExportToDB(),
+			arg.Id.ExportToDB(),
+		).Scan(&box, &gen, &rt, &vl)
+		if err != nil {
+			return err
+		}
+		if bytes.Equal(box, arg.Sfb.DataBox) &&
+			gen == int(arg.Sfb.Rg.Gen) &&
+			rt == int(rk.Typ) &&
+			vl == int(rk.Lev) {
+			// An identical replay. No second usage charge.
+			return nil
+		}
+		return core.KVRaceError("small-file node id reused with different contents")
+	}
 	if tag.RowsAffected() != 1 {
-		return core.InsertError("large_file")
+		return core.InsertError("small_file_or_symlink")
+	}
+
+	// Only a genuinely new row is charged against usage.
+	err = usageCheckAndInc(
+		m,
+		tx,
+		pid,
+		proto.KVNodeType_SmallFile,
+		len(arg.Sfb.DataBox),
+		true,
+	)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -324,6 +336,7 @@ func (f *fileUploader) insLargeFile(m shared.MetaContext) error {
 	if err != nil {
 		return err
 	}
+
 	if tag.RowsAffected() != 1 {
 		return core.InsertError("large_file")
 	}

--- a/server/kv-store/file.go
+++ b/server/kv-store/file.go
@@ -4,6 +4,8 @@
 package kvStore
 
 import (
+	"bytes"
+
 	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/lib/kv"
 	proto "github.com/foks-proj/go-foks/proto/lib"
@@ -95,6 +97,33 @@ func putSmallFileOrSymlink(
 
 	rk, err := core.ImportRole(arg.Sfb.Rg.Role)
 	if err != nil {
+		return err
+	}
+
+	// A replay of an identical node is a no-op. Node IDs are client-chosen,
+	// and a small file's encryption nonce derives from its node ID, so a
+	// client retrying after an ambiguous failure -- the write landed, the
+	// ack did not -- sends byte-identical bytes. Checked before
+	// usageCheckAndInc so a retry is not charged twice. A same-ID row
+	// carrying different bytes is a client bug or a stray collision in a
+	// 16-byte random space; refuse it rather than silently keeping one copy
+	// or the other.
+	var existing []byte
+	err = tx.QueryRow(
+		m.Ctx(),
+		`SELECT box FROM small_file_or_symlink
+		 WHERE short_host_id=$1 AND short_party_id=$2 AND node_id=$3`,
+		int(m.HostID().Short),
+		pid.Shorten().ExportToDB(),
+		arg.Id.ExportToDB(),
+	).Scan(&existing)
+	if err == nil {
+		if bytes.Equal(existing, arg.Sfb.DataBox) {
+			return nil
+		}
+		return core.KVRaceError("small-file node id replayed with different content")
+	}
+	if err != pgx.ErrNoRows {
 		return err
 	}
 


### PR DESCRIPTION
## The problem

`kvPutSmallFileOrSymlink` cannot be retried safely.

If a client sends a small file and the connection drops before the response
arrives, the client does not know whether the write landed. Retrying the same
node hits the primary key on `small_file_or_symlink` and comes back as a raw
database error — `duplicate key value violates unique constraint` — which is
indistinguishable from a genuine failure. So the client cannot retry, and
cannot tell what state the server is in.

## Why the retry is recognisable

Node IDs are chosen by the client, and a small file's encryption nonce derives
from its node ID. Re-sending the same node therefore produces exactly the same
ciphertext, byte for byte. "Same ID, same bytes" is an honest retry; nothing
else produces it.

## What changes

An identical replay is a no-op and returns success.

The check runs before `usageCheckAndInc`, so a retry is not charged against
quota twice.

A write that reuses a node ID with *different* bytes is still refused, but now
with `KV_RACE_ERROR` instead of a raw database error. That case is a client bug
or a stray collision in a 16-byte random space, and silently keeping either
copy would be wrong.

Permission checks are unchanged and still run first.

## Example

A client uploads a small file; the connection drops before the response
arrives. It retries the same node.

- Before: `duplicate key value violates unique constraint`, and no way to tell
  whether the file is there.
- After: the call succeeds, usage is unchanged, and the client goes on to link
  the dirent.

## Note

This is the same reasoning as the `msg_id` idempotency `rtSend` gained in #349:
a client cannot build a reliable retry on an RPC that cannot distinguish
"already done" from "failed".

## Test

`TestKVPutSmallFileReplay` drives the RPC directly, because `libkv` mints a
fresh node ID per call and so cannot express a replay. It fails against `main`
with the duplicate-key error.
