### PR TITLE
kv-store: make a directory creation idempotent on replay

### DIFF
--- a/integration-tests/lib/kv_mkdir_replay_test.go
+++ b/integration-tests/lib/kv_mkdir_replay_test.go
@@ -1,0 +1,62 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKVMkdirReplay covers retrying a directory creation. The directory ID is
+// chosen by the client, so a retry after an ambiguous failure carries the same
+// sealed seed; that must succeed as a no-op rather than failing on the primary
+// key. The same ID with a different seed box must still be refused.
+func TestKVMkdirReplay(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t)
+	tew.DirectMerklePokeInTest(t)
+
+	// Drive the RPC directly: libkv mints a fresh directory ID per call and
+	// so cannot express a replay.
+	m := tew.NewClientMetaContext(t, bluey)
+	au := m.G().ActiveUser()
+	cert, err := au.ClientCert(m)
+	require.NoError(t, err)
+	pr := au.HomeServer()
+	require.NotNil(t, pr)
+	gcli, err := pr.RPCClient(m, proto.ServerType_KVStore, cert)
+	require.NoError(t, err)
+	cli := core.NewKVStoreClient(gcli, m)
+
+	var dirID proto.DirID
+	require.NoError(t, core.RandomFill(dirID[:]))
+
+	mk := func(seed string) rem.KvMkdirArg {
+		return rem.KvMkdirArg{
+			Dir: proto.KVDir{
+				Id:      dirID,
+				Version: proto.KVVersion(1),
+				Box: proto.SeedBoxExternalNonce{
+					Rg:    proto.RoleAndGen{Role: proto.OwnerRole},
+					Ctext: proto.NaclCiphertext(seed),
+				},
+				WriteRole: proto.OwnerRole,
+				Status:    proto.KVDirStatus_Active,
+			},
+		}
+	}
+
+	// First creation lands.
+	require.NoError(t, cli.KvMkdir(m.Ctx(), mk("sealed seed")))
+
+	// The same creation again is the retry case: a no-op, not an error.
+	require.NoError(t, cli.KvMkdir(m.Ctx(), mk("sealed seed")))
+
+	// The same ID carrying a different seed box is refused.
+	err = cli.KvMkdir(m.Ctx(), mk("a different sealed seed"))
+	require.Error(t, err)
+	var race core.KVRaceError
+	require.ErrorAs(t, err, &race)
+}

--- a/server/kv-store/dir.go
+++ b/server/kv-store/dir.go
@@ -4,6 +4,8 @@
 package kvStore
 
 import (
+	"bytes"
+
 	"github.com/foks-proj/go-foks/lib/core"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/server/shared"
@@ -107,6 +109,32 @@ func putDir(
 		return core.BadArgsError("dir version must be 1 for mkdir")
 	}
 	spid := pid.Shorten()
+
+	// A replay of an identical mkdir is a no-op. Dir IDs are chosen by the
+	// client, so a retry after an ambiguous failure -- the write reached the
+	// server, the acknowledgement did not -- carries the same sealed seed
+	// bytes. A same-ID row holding a different box is a client bug or a
+	// stray collision in a 16-byte random space; refuse it rather than
+	// silently keeping one copy or the other.
+	var existingBox []byte
+	err = tx.QueryRow(m.Ctx(),
+		`SELECT seed_box FROM dir
+		 WHERE short_host_id=$1 AND short_party_id=$2 AND dir_id=$3 AND version=$4`,
+		int(m.HostID().Short),
+		spid.ExportToDB(),
+		dir.Id.ExportToDB(),
+		int(dir.Version),
+	).Scan(&existingBox)
+	if err == nil {
+		if bytes.Equal(existingBox, box) {
+			return nil
+		}
+		return core.KVRaceError("dir id replayed with different contents")
+	}
+	if err != pgx.ErrNoRows {
+		return err
+	}
+
 	tag, err := tx.Exec(m.Ctx(),
 		`INSERT INTO dir(
 			short_host_id, short_party_id, dir_id, version, ptk_gen,

--- a/server/kv-store/dir.go
+++ b/server/kv-store/dir.go
@@ -110,38 +110,14 @@ func putDir(
 	}
 	spid := pid.Shorten()
 
-	// A replay of an identical mkdir is a no-op. Dir IDs are chosen by the
-	// client, so a retry after an ambiguous failure -- the write reached the
-	// server, the acknowledgement did not -- carries the same sealed seed
-	// bytes. A same-ID row holding a different box is a client bug or a
-	// stray collision in a 16-byte random space; refuse it rather than
-	// silently keeping one copy or the other.
-	var existingBox []byte
-	err = tx.QueryRow(m.Ctx(),
-		`SELECT seed_box FROM dir
-		 WHERE short_host_id=$1 AND short_party_id=$2 AND dir_id=$3 AND version=$4`,
-		int(m.HostID().Short),
-		spid.ExportToDB(),
-		dir.Id.ExportToDB(),
-		int(dir.Version),
-	).Scan(&existingBox)
-	if err == nil {
-		if bytes.Equal(existingBox, box) {
-			return nil
-		}
-		return core.KVRaceError("dir id replayed with different contents")
-	}
-	if err != pgx.ErrNoRows {
-		return err
-	}
-
 	tag, err := tx.Exec(m.Ctx(),
 		`INSERT INTO dir(
 			short_host_id, short_party_id, dir_id, version, ptk_gen,
 			read_role_type, read_role_viz_level,
 			write_role_type, write_role_viz_level,
 			seed_box, status, ctime, mtime
-		) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW(),NOW())`,
+		) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW(),NOW())
+		 ON CONFLICT DO NOTHING`,
 		int(m.HostID().Short),
 		spid.ExportToDB(),
 		dir.Id.ExportToDB(),
@@ -157,6 +133,45 @@ func putDir(
 	}
 	if err != nil {
 		return err
+	}
+
+	if tag.RowsAffected() == 0 {
+		// The directory ID is already taken. Directory IDs are chosen by the
+		// client and the seed is sealed before the call, so a retry after an
+		// ambiguous failure carries exactly the same row; succeeding is what
+		// lets the client go on and link the directory. Inserting first and
+		// comparing here, rather than checking beforehand, keeps the two
+		// steps atomic: a pre-check would leave a window where the original
+		// commits in between and the retry fails on the primary key.
+		//
+		// Every persisted field is compared, not just the seed: a reused ID
+		// carrying the same seed under a different generation or role is not
+		// the same directory, and silently keeping the stored metadata would
+		// hide the difference.
+		var seed []byte
+		var gen, rt, rl, wt, wl int
+		err = tx.QueryRow(m.Ctx(),
+			`SELECT seed_box, ptk_gen,
+			        read_role_type, read_role_viz_level,
+			        write_role_type, write_role_viz_level
+			 FROM dir
+			 WHERE short_host_id=$1 AND short_party_id=$2 AND dir_id=$3 AND version=$4`,
+			int(m.HostID().Short),
+			spid.ExportToDB(),
+			dir.Id.ExportToDB(),
+			int(dir.Version),
+		).Scan(&seed, &gen, &rt, &rl, &wt, &wl)
+		if err != nil {
+			return err
+		}
+		if bytes.Equal(seed, box) &&
+			gen == int(dir.Box.Rg.Gen) &&
+			rt == rtyp && rl == rlev &&
+			wt == wtyp && wl == wlev {
+			// An identical replay; the refcount row is already there too.
+			return nil
+		}
+		return core.KVRaceError("dir id reused with different contents")
 	}
 	if tag.RowsAffected() != 1 {
 		return core.InsertError("dir")


### PR DESCRIPTION
## The problem

`kvMkdir` cannot be retried safely.

If a client creates a directory and the connection drops before the response
arrives, the client does not know whether the row landed. Retrying hits the
primary key on `dir` and comes back as `DuplicateError`, which is
indistinguishable from a genuine failure.

This bites hardest because creating a directory is two calls: `kvMkdir`, then
`kvPut` to link the new directory into its parent. If the connection dies
between them, the directory exists but is unreferenced, and the client cannot
finish the job — the retry fails on the first step.

## Why the retry is recognisable

Directory IDs are chosen by the client, and the seed box is sealed before the
call. A retry therefore carries the same ID and the same bytes.

## What changes

An identical replay is a no-op and returns success.

A creation that reuses a directory ID with a *different* seed box is still
refused, but now with `KV_RACE_ERROR` instead of a raw database error.

Permission checks are unchanged and still run first.

## Example

A client creates a directory, then the connection drops before it can link it
into the parent. It retries both calls.

- Before: the `kvMkdir` retry fails with a duplicate-key error, and the
  half-finished creation cannot be completed. The orphan directory is left for
  refcount GC.
- After: the `kvMkdir` retry succeeds, and the client goes on to link the
  dirent.

## Note

Companion to the same change for small files and symlinks (#352), and to the
`msg_id` idempotency `rtSend` gained in #349. The two KV changes are
independent — either can land alone, in either order.

## Test

`TestKVMkdirReplay` drives the RPC directly, because `libkv` mints a fresh
directory ID per call and so cannot express a replay. It fails against `main`
with the duplicate-key error.
