### PR TITLE
kv-store: make directory creation idempotent on replay, and report the replay

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -37,6 +37,8 @@ changelog:
         closes: ["#350"]
       - desc: treat timeouts, DNS, TLS and mid-stream failures like connection errors when deciding whether to tolerate an unreachable server
         closes: ["#347"]
+      - desc: kv-store; make directory creation idempotent on replay, and report the replay in the kvMkdir result
+        closes: ["#353"]
   - version: 0.1.9
     urgency: medium
     stable: true

--- a/client/libkv/minder.go
+++ b/client/libkv/minder.go
@@ -694,7 +694,9 @@ func (k *Minder) makeEmptyDir(
 	if err != nil {
 		return nil, nil, err
 	}
-	err = cli.KvMkdir(m.Ctx(), rem.KvMkdirArg{
+	// The replay flag in the result is uninteresting here: a fresh directory
+	// ID is minted per call, so this client never replays a mkdir.
+	_, err = cli.KvMkdir(m.Ctx(), rem.KvMkdirArg{
 		Hdr: *hdr,
 		Dir: kvd,
 	})

--- a/integration-tests/lib/kv_mkdir_replay_test.go
+++ b/integration-tests/lib/kv_mkdir_replay_test.go
@@ -1,0 +1,62 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKVMkdirReplay covers retrying a directory creation. The directory ID is
+// chosen by the client, so a retry after an ambiguous failure carries the same
+// sealed seed; that must succeed as a no-op rather than failing on the primary
+// key. The same ID with a different seed box must still be refused.
+func TestKVMkdirReplay(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t)
+	tew.DirectMerklePokeInTest(t)
+
+	// Drive the RPC directly: libkv mints a fresh directory ID per call and
+	// so cannot express a replay.
+	m := tew.NewClientMetaContext(t, bluey)
+	au := m.G().ActiveUser()
+	cert, err := au.ClientCert(m)
+	require.NoError(t, err)
+	pr := au.HomeServer()
+	require.NotNil(t, pr)
+	gcli, err := pr.RPCClient(m, proto.ServerType_KVStore, cert)
+	require.NoError(t, err)
+	cli := core.NewKVStoreClient(gcli, m)
+
+	var dirID proto.DirID
+	require.NoError(t, core.RandomFill(dirID[:]))
+
+	mk := func(seed string) rem.KvMkdirArg {
+		return rem.KvMkdirArg{
+			Dir: proto.KVDir{
+				Id:      dirID,
+				Version: proto.KVVersion(1),
+				Box: proto.SeedBoxExternalNonce{
+					Rg:    proto.RoleAndGen{Role: proto.OwnerRole},
+					Ctext: proto.NaclCiphertext(seed),
+				},
+				WriteRole: proto.OwnerRole,
+				Status:    proto.KVDirStatus_Active,
+			},
+		}
+	}
+
+	// First creation lands.
+	require.NoError(t, cli.KvMkdir(m.Ctx(), mk("sealed seed")))
+
+	// The same creation again is the retry case: a no-op, not an error.
+	require.NoError(t, cli.KvMkdir(m.Ctx(), mk("sealed seed")))
+
+	// The same ID carrying a different seed box is refused.
+	err = cli.KvMkdir(m.Ctx(), mk("a different sealed seed"))
+	require.Error(t, err)
+	var race core.KVRaceError
+	require.ErrorAs(t, err, &race)
+}

--- a/integration-tests/lib/kv_mkdir_replay_test.go
+++ b/integration-tests/lib/kv_mkdir_replay_test.go
@@ -48,14 +48,19 @@ func TestKVMkdirReplay(t *testing.T) {
 		}
 	}
 
-	// First creation lands.
-	require.NoError(t, cli.KvMkdir(m.Ctx(), mk("sealed seed")))
+	// First creation lands, and is not a replay.
+	res, err := cli.KvMkdir(m.Ctx(), mk("sealed seed"))
+	require.NoError(t, err)
+	require.False(t, res.WasReplay)
 
-	// The same creation again is the retry case: a no-op, not an error.
-	require.NoError(t, cli.KvMkdir(m.Ctx(), mk("sealed seed")))
+	// The same creation again is the retry case: a no-op that reports itself
+	// as a replay, not an error.
+	res, err = cli.KvMkdir(m.Ctx(), mk("sealed seed"))
+	require.NoError(t, err)
+	require.True(t, res.WasReplay)
 
 	// The same ID carrying a different seed box is refused.
-	err = cli.KvMkdir(m.Ctx(), mk("a different sealed seed"))
+	_, err = cli.KvMkdir(m.Ctx(), mk("a different sealed seed"))
 	require.Error(t, err)
 	var race core.KVRaceError
 	require.ErrorAs(t, err, &race)

--- a/proto-src/rem/kv.snowp
+++ b/proto-src/rem/kv.snowp
@@ -70,6 +70,13 @@ struct KVListRes {
 
 typedef LockID = Blob(16);
 
+struct KVMkdirRes {
+    // True when this creation was an idempotent replay: a directory with the
+    // same ID and the same contents already existed, and nothing was written.
+    // Old servers omit the result, which decodes as false.
+    wasReplay @0 : Bool;
+}
+
 struct KVLock {
     idp @0 : lib.KVDirentIDPair;
     lockID @1 : LockID;
@@ -83,7 +90,7 @@ protocol KVStore
     kvMkdir @0 (
         hdr @0 : KVReqHeader,
         dir @1 : lib.KVDir
-    );
+    ) -> KVMkdirRes;
 
     kvPut @1 (
         hdr @0 : KVReqHeader,

--- a/proto/rem/kv.go
+++ b/proto/rem/kv.go
@@ -839,6 +839,45 @@ func (l LockID) Bytes() []byte {
 	return (l)[:]
 }
 
+type KVMkdirRes struct {
+	WasReplay bool
+}
+type KVMkdirResInternal__ struct {
+	_struct   struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	WasReplay *bool
+}
+
+func (k KVMkdirResInternal__) Import() KVMkdirRes {
+	return KVMkdirRes{
+		WasReplay: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(k.WasReplay),
+	}
+}
+func (k KVMkdirRes) Export() *KVMkdirResInternal__ {
+	return &KVMkdirResInternal__{
+		WasReplay: &k.WasReplay,
+	}
+}
+func (k *KVMkdirRes) Encode(enc rpc.Encoder) error {
+	return enc.Encode(k.Export())
+}
+
+func (k *KVMkdirRes) Decode(dec rpc.Decoder) error {
+	var tmp KVMkdirResInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*k = tmp.Import()
+	return nil
+}
+
+func (k *KVMkdirRes) Bytes() []byte { return nil }
+
 type KVLock struct {
 	Idp    lib.KVDirentIDPair
 	LockID LockID
@@ -1763,7 +1802,7 @@ func (k *KVSelectVhost) Decode(dec rpc.Decoder) error {
 func (k *KVSelectVhost) Bytes() []byte { return nil }
 
 type KVStoreInterface interface {
-	KvMkdir(context.Context, KvMkdirArg) error
+	KvMkdir(context.Context, KvMkdirArg) (KVMkdirRes, error)
 	KvPut(context.Context, KvPutArg) error
 	KvPutRoot(context.Context, KvPutRootArg) error
 	KvFileUploadInit(context.Context, KvFileUploadInitArg) error
@@ -1825,14 +1864,14 @@ type KVStoreClient struct {
 	CheckResHeader func(context.Context, lib.Header) error
 }
 
-func (c KVStoreClient) KvMkdir(ctx context.Context, arg KvMkdirArg) (err error) {
+func (c KVStoreClient) KvMkdir(ctx context.Context, arg KvMkdirArg) (res KVMkdirRes, err error) {
 	warg := &rpc.DataWrap[lib.Header, *KvMkdirArgInternal__]{
 		Data: arg.Export(),
 	}
 	if c.MakeArgHeader != nil {
 		warg.Header = c.MakeArgHeader()
 	}
-	var tmp rpc.DataWrap[lib.Header, interface{}]
+	var tmp rpc.DataWrap[lib.Header, KVMkdirResInternal__]
 	err = c.Cli.Call2(ctx, rpc.NewMethodV2(KVStoreProtocolID, 0, "KVStore.kvMkdir"), warg, &tmp, 0*time.Millisecond, kVStoreErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
 	if err != nil {
 		return
@@ -1843,6 +1882,7 @@ func (c KVStoreClient) KvMkdir(ctx context.Context, arg KvMkdirArg) (err error) 
 			return
 		}
 	}
+	res = tmp.Data.Import()
 	return
 }
 func (c KVStoreClient) KvPut(ctx context.Context, arg KvPutArg) (err error) {
@@ -2205,11 +2245,12 @@ func KVStoreProtocol(i KVStoreInterface) rpc.ProtocolV2 {
 							return nil, err
 						}
 						typedArg := typedWrappedArg.Data
-						err := i.KvMkdir(ctx, (typedArg.Import()))
+						tmp, err := i.KvMkdir(ctx, (typedArg.Import()))
 						if err != nil {
 							return nil, err
 						}
-						ret := rpc.DataWrap[lib.Header, interface{}]{
+						ret := rpc.DataWrap[lib.Header, *KVMkdirResInternal__]{
+							Data:   tmp.Export(),
 							Header: i.MakeResHeader(),
 						}
 						return &ret, nil

--- a/server/kv-store/dir.go
+++ b/server/kv-store/dir.go
@@ -4,6 +4,8 @@
 package kvStore
 
 import (
+	"bytes"
+
 	"github.com/foks-proj/go-foks/lib/core"
 	proto "github.com/foks-proj/go-foks/proto/lib"
 	"github.com/foks-proj/go-foks/server/shared"
@@ -107,6 +109,32 @@ func putDir(
 		return core.BadArgsError("dir version must be 1 for mkdir")
 	}
 	spid := pid.Shorten()
+
+	// A replay of an identical mkdir is a no-op. Dir IDs are chosen by the
+	// client, so a retry after an ambiguous failure -- the write reached the
+	// server, the acknowledgement did not -- carries the same sealed seed
+	// bytes. A same-ID row holding a different box is a client bug or a
+	// stray collision in a 16-byte random space; refuse it rather than
+	// silently keeping one copy or the other.
+	var existingBox []byte
+	err = tx.QueryRow(m.Ctx(),
+		`SELECT seed_box FROM dir
+		 WHERE short_host_id=$1 AND short_party_id=$2 AND dir_id=$3 AND version=$4`,
+		int(m.HostID().Short),
+		spid.ExportToDB(),
+		dir.Id.ExportToDB(),
+		int(dir.Version),
+	).Scan(&existingBox)
+	if err == nil {
+		if bytes.Equal(existingBox, box) {
+			return nil
+		}
+		return core.KVRaceError("dir id replayed with different contents")
+	}
+	if err != pgx.ErrNoRows {
+		return err
+	}
+
 	tag, err := tx.Exec(m.Ctx(),
 		`INSERT INTO dir(
 			short_host_id, short_party_id, dir_id, version, ptk_gen,

--- a/server/kv-store/dir.go
+++ b/server/kv-store/dir.go
@@ -110,38 +110,14 @@ func putDir(
 	}
 	spid := pid.Shorten()
 
-	// A replay of an identical mkdir is a no-op. Dir IDs are chosen by the
-	// client, so a retry after an ambiguous failure -- the write reached the
-	// server, the acknowledgement did not -- carries the same sealed seed
-	// bytes. A same-ID row holding a different box is a client bug or a
-	// stray collision in a 16-byte random space; refuse it rather than
-	// silently keeping one copy or the other.
-	var existingBox []byte
-	err = tx.QueryRow(m.Ctx(),
-		`SELECT seed_box FROM dir
-		 WHERE short_host_id=$1 AND short_party_id=$2 AND dir_id=$3 AND version=$4`,
-		int(m.HostID().Short),
-		spid.ExportToDB(),
-		dir.Id.ExportToDB(),
-		int(dir.Version),
-	).Scan(&existingBox)
-	if err == nil {
-		if bytes.Equal(existingBox, box) {
-			return nil
-		}
-		return core.KVRaceError("dir id replayed with different contents")
-	}
-	if err != pgx.ErrNoRows {
-		return err
-	}
-
 	tag, err := tx.Exec(m.Ctx(),
 		`INSERT INTO dir(
 			short_host_id, short_party_id, dir_id, version, ptk_gen,
 			read_role_type, read_role_viz_level,
 			write_role_type, write_role_viz_level,
 			seed_box, status, ctime, mtime
-		) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW(),NOW())`,
+		) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW(),NOW())
+		 ON CONFLICT DO NOTHING`,
 		int(m.HostID().Short),
 		spid.ExportToDB(),
 		dir.Id.ExportToDB(),
@@ -157,6 +133,45 @@ func putDir(
 	}
 	if err != nil {
 		return err
+	}
+
+	if tag.RowsAffected() == 0 {
+		// The directory ID is already taken. Directory IDs are chosen by the
+		// client and the seed is sealed before the call, so a retry after an
+		// ambiguous failure carries exactly the same row; succeeding is what
+		// lets the client go on and link the directory. Inserting first and
+		// comparing here, rather than checking beforehand, keeps the two
+		// steps atomic: a pre-check would leave a window where the original
+		// commits in between and the retry fails on the primary key.
+		//
+		// Every persisted field is compared, not just the seed: a reused ID
+		// carrying the same seed under a different generation or role is not
+		// the same directory, and silently keeping the stored metadata would
+		// hide the difference.
+		var seed []byte
+		var gen, rt, rl, wt, wl int
+		err = tx.QueryRow(m.Ctx(),
+			`SELECT seed_box, ptk_gen,
+			        read_role_type, read_role_viz_level,
+			        write_role_type, write_role_viz_level
+			 FROM dir
+			 WHERE short_host_id=$1 AND short_party_id=$2 AND dir_id=$3 AND version=$4`,
+			int(m.HostID().Short),
+			spid.ExportToDB(),
+			dir.Id.ExportToDB(),
+			int(dir.Version),
+		).Scan(&seed, &gen, &rt, &rl, &wt, &wl)
+		if err != nil {
+			return err
+		}
+		if bytes.Equal(seed, box) &&
+			gen == int(dir.Box.Rg.Gen) &&
+			rt == rtyp && rl == rlev &&
+			wt == wtyp && wl == wlev {
+			// An identical replay; the refcount row is already there too.
+			return nil
+		}
+		return core.KVRaceError("dir id reused with different contents")
 	}
 	if tag.RowsAffected() != 1 {
 		return core.InsertError("dir")

--- a/server/kv-store/dir.go
+++ b/server/kv-store/dir.go
@@ -128,9 +128,6 @@ func putDir(
 		box,
 		string(proto.KVDirStatusStringActive),
 	)
-	if shared.IsDuplicateKeyError(err, "dir_pkey") {
-		return core.DuplicateError("dir")
-	}
 	if err != nil {
 		return err
 	}
@@ -147,24 +144,28 @@ func putDir(
 		// Every persisted field is compared, not just the seed: a reused ID
 		// carrying the same seed under a different generation or role is not
 		// the same directory, and silently keeping the stored metadata would
-		// hide the difference.
+		// hide the difference. The stored row must also still be active: a
+		// replay that matches a dead directory did not create anything the
+		// client can go on to use.
 		var seed []byte
 		var gen, rt, rl, wt, wl int
+		var status string
 		err = tx.QueryRow(m.Ctx(),
 			`SELECT seed_box, ptk_gen,
 			        read_role_type, read_role_viz_level,
-			        write_role_type, write_role_viz_level
+			        write_role_type, write_role_viz_level, status
 			 FROM dir
 			 WHERE short_host_id=$1 AND short_party_id=$2 AND dir_id=$3 AND version=$4`,
 			int(m.HostID().Short),
 			spid.ExportToDB(),
 			dir.Id.ExportToDB(),
 			int(dir.Version),
-		).Scan(&seed, &gen, &rt, &rl, &wt, &wl)
+		).Scan(&seed, &gen, &rt, &rl, &wt, &wl, &status)
 		if err != nil {
 			return err
 		}
-		if bytes.Equal(seed, box) &&
+		if status == string(proto.KVDirStatusStringActive) &&
+			bytes.Equal(seed, box) &&
 			gen == int(dir.Box.Rg.Gen) &&
 			rt == rtyp && rl == rlev &&
 			wt == wtyp && wl == wlev {

--- a/server/kv-store/dir.go
+++ b/server/kv-store/dir.go
@@ -78,35 +78,38 @@ func loadDir(
 	return &ret, nil
 }
 
+// putDir creates the directory row and its refcount row. The returned bool
+// reports an idempotent replay: the directory already existed with exactly
+// these contents, and nothing was written.
 func putDir(
 	m shared.MetaContext,
 	tx pgx.Tx,
 	pid proto.PartyID,
 	role proto.Role,
 	dir *proto.KVDir,
-) error {
+) (bool, error) {
 	err := assertAtOrAbove(role, dir.Box.Rg.Role, proto.KVOp_Write, proto.KVNodeType_Dir)
 	if err != nil {
-		return err
+		return false, err
 	}
 	err = assertAtOrAbove(role, dir.WriteRole, proto.KVOp_Write, proto.KVNodeType_Dir)
 	if err != nil {
-		return err
+		return false, err
 	}
 	rtyp, rlev, err := dir.Box.Rg.Role.ExportToDB()
 	if err != nil {
-		return err
+		return false, err
 	}
 	wtyp, wlev, err := dir.WriteRole.ExportToDB()
 	if err != nil {
-		return err
+		return false, err
 	}
 	box, err := core.EncodeToBytes(&dir.Box.Ctext)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if dir.Version != proto.KVVersion(1) {
-		return core.BadArgsError("dir version must be 1 for mkdir")
+		return false, core.BadArgsError("dir version must be 1 for mkdir")
 	}
 	spid := pid.Shorten()
 
@@ -129,7 +132,7 @@ func putDir(
 		string(proto.KVDirStatusStringActive),
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if tag.RowsAffected() == 0 {
@@ -162,7 +165,7 @@ func putDir(
 			int(dir.Version),
 		).Scan(&seed, &gen, &rt, &rl, &wt, &wl, &status)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if status == string(proto.KVDirStatusStringActive) &&
 			bytes.Equal(seed, box) &&
@@ -170,12 +173,12 @@ func putDir(
 			rt == rtyp && rl == rlev &&
 			wt == wtyp && wl == wlev {
 			// An identical replay; the refcount row is already there too.
-			return nil
+			return true, nil
 		}
-		return core.KVRaceError("dir id reused with different contents")
+		return false, core.KVRaceError("dir id reused with different contents")
 	}
 	if tag.RowsAffected() != 1 {
-		return core.InsertError("dir")
+		return false, core.InsertError("dir")
 	}
 	tag, err = tx.Exec(m.Ctx(),
 		`INSERT INTO dir_refcount(
@@ -186,12 +189,12 @@ func putDir(
 		dir.Id.ExportToDB(),
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if tag.RowsAffected() != 1 {
-		return core.InsertError("dir_refcount")
+		return false, core.InsertError("dir_refcount")
 	}
-	return nil
+	return false, nil
 }
 
 func dirRef(

--- a/server/kv-store/server.go
+++ b/server/kv-store/server.go
@@ -219,14 +219,24 @@ func assertAdmin(role proto.Role, what string) error {
 	return nil
 }
 
-func (c *ClientConn) KvMkdir(ctx context.Context, arg rem.KvMkdirArg) error {
-	return c.preamble(ctx, arg.Hdr,
+func (c *ClientConn) KvMkdir(ctx context.Context, arg rem.KvMkdirArg) (rem.KVMkdirRes, error) {
+	var res rem.KVMkdirRes
+	err := c.preamble(ctx, arg.Hdr,
 		func(m shared.MetaContext, db *pgxpool.Conn, pid proto.PartyID, role proto.Role) error {
 			return shared.RetryTx(m, db, "kvMkdir",
 				func(m shared.MetaContext, tx pgx.Tx) error {
-					return putDir(m, tx, pid, role, &arg.Dir)
+					wasReplay, err := putDir(m, tx, pid, role, &arg.Dir)
+					if err != nil {
+						return err
+					}
+					res.WasReplay = wasReplay
+					return nil
 				})
 		})
+	if err != nil {
+		return rem.KVMkdirRes{}, err
+	}
+	return res, nil
 }
 
 func (c *ClientConn) KvPut(ctx context.Context, arg rem.KvPutArg) error {


### PR DESCRIPTION
Supersedes #353, keeping @st3v3y's commits (and authorship) as the base and
building on them. Companion to #352 for small files and symlinks; the two
remain independent.

## The problem (from #353)

`kvMkdir` cannot be retried safely. If the connection drops before the
response arrives, the client does not know whether the row landed; the retry
hits the primary key on `dir` and fails with a duplicate-key error, and the
half-created directory can never be linked into its parent.

Directory IDs are chosen by the client, and the seed box is sealed before the
call, so a retry carries the same ID and the same bytes — it is recognisable.

## What this PR does

- **Idempotent replay** (#353's core, unchanged in substance): the insert uses
  `ON CONFLICT DO NOTHING`; on a conflict, the stored row is compared field by
  field inside the same transaction. An identical replay succeeds as a no-op;
  a reused ID with different contents is refused with `KV_RACE_ERROR`.
- **Review fixes on top**: the `IsDuplicateKeyError(err, "dir_pkey")` branch
  is removed (unreachable once `ON CONFLICT DO NOTHING` swallows the
  violation), and the replay match now also requires the stored row's status
  to be `active` — matching a dead directory must not report success. Today
  every version-1 row is active, but the schema already indexes dead rows for
  GC.
- **The RPC reports the replay**: `kvMkdir` now returns
  `KVMkdirRes { wasReplay: Bool }`, following the `RTSendRes.wasReplay`
  precedent from #349.

## Wire compatibility of void → struct

Both directions are safe. An old client decodes the new result into
`interface{}` and discards it. A new client against an old server sees no
`Data` key at all — `DataWrap` is `codec:",omitempty"`, so a void reply's nil
`Data` is omitted from the encoded map — and go-codec leaves the absent field
at its zero value, so `wasReplay` decodes as `false`.

## Testing

`TestKVMkdirReplay` drives the RPC directly (libkv mints a fresh directory ID
per call and so cannot express a replay) and asserts `wasReplay` is false on
first creation, true on the identical retry, and that a different seed box
under the same ID fails with `KV_RACE_ERROR`. Full `integration-tests/lib`
and `integration-tests/cli` suites pass on top of current `main`.

Co-authored-by: Claude Code