### PR TITLE
kv-store: make small-file writes idempotent on replay, and report the replay

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -39,6 +39,8 @@ changelog:
         closes: ["#347"]
       - desc: kv-store; make directory creation idempotent on replay, and report the replay in the kvMkdir result
         closes: ["#353"]
+      - desc: kv-store; make small-file and symlink writes idempotent on replay, and report the replay in the RPC result
+        closes: ["#352"]
   - version: 0.1.9
     urgency: medium
     stable: true

--- a/client/libkv/putfile.go
+++ b/client/libkv/putfile.go
@@ -56,7 +56,9 @@ func (k *Minder) prepSmallFile(
 		DataBox: ctext,
 	}
 
-	err = cli.KvPutSmallFileOrSymlink(m.Ctx(), rem.KvPutSmallFileOrSymlinkArg{
+	// The replay flag in the result is uninteresting here: a fresh node ID is
+	// minted per call, so this client never replays a write.
+	_, err = cli.KvPutSmallFileOrSymlink(m.Ctx(), rem.KvPutSmallFileOrSymlinkArg{
 		Auth: *auth,
 		Id:   *nid,
 		Sfb:  sfb,
@@ -111,7 +113,8 @@ func (k *Minder) prepSymlink(
 		DataBox: ctext,
 	}
 
-	err = cli.KvPutSmallFileOrSymlink(m.Ctx(), rem.KvPutSmallFileOrSymlinkArg{
+	// As above, a fresh node ID per call means this is never a replay.
+	_, err = cli.KvPutSmallFileOrSymlink(m.Ctx(), rem.KvPutSmallFileOrSymlinkArg{
 		Auth: *auth,
 		Id:   *nid,
 		Sfb:  sfb,

--- a/integration-tests/lib/kv_replay_test.go
+++ b/integration-tests/lib/kv_replay_test.go
@@ -1,0 +1,71 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/lib/core"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/proto/rem"
+	"github.com/stretchr/testify/require"
+)
+
+// kvStoreClientForUser opens a raw KV-store client for the given user, so a
+// test can drive the RPCs directly rather than through libkv (which mints a
+// fresh node ID per call and so cannot express a replay).
+func kvStoreClientForUser(t *testing.T, tew *TestEnvWrapper, u *TestUser) rem.KVStoreClient {
+	m := tew.NewClientMetaContext(t, u)
+	au := m.G().ActiveUser()
+	cert, err := au.ClientCert(m)
+	require.NoError(t, err)
+	pr := au.HomeServer()
+	require.NotNil(t, pr)
+	gcli, err := pr.RPCClient(m, proto.ServerType_KVStore, cert)
+	require.NoError(t, err)
+	return core.NewKVStoreClient(gcli, m)
+}
+
+// TestKVPutSmallFileReplay covers retrying a small-file write. The node ID is
+// chosen by the client and fixes the encryption nonce, so a retry after an
+// ambiguous failure sends byte-identical bytes; that must succeed as a no-op
+// rather than failing on the primary key. The same ID with different bytes
+// must still be refused.
+func TestKVPutSmallFileReplay(t *testing.T) {
+	tew := testEnvBeta(t)
+	bluey := tew.NewTestUser(t)
+	tew.DirectMerklePokeInTest(t)
+
+	m := tew.NewClientMetaContext(t, bluey)
+	cli := kvStoreClientForUser(t, tew, bluey)
+
+	var nid proto.KVNodeID
+	nid[0] = byte(proto.KVNodeType_SmallFile)
+	require.NoError(t, core.RandomFill(nid[1:]))
+
+	mk := func(body string) rem.KvPutSmallFileOrSymlinkArg {
+		return rem.KvPutSmallFileOrSymlinkArg{
+			Id: nid,
+			Sfb: proto.SmallFileBox{
+				Rg:      proto.RoleAndGen{Role: proto.OwnerRole},
+				DataBox: proto.NaclCiphertext(body),
+			},
+		}
+	}
+
+	// First write lands.
+	require.NoError(t, cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("ciphertext")))
+
+	// The same write again is the retry case: a no-op, not an error, and not
+	// a second charge against usage.
+	before, err := cli.KvUsage(m.Ctx(), rem.KVAuth{})
+	require.NoError(t, err)
+	require.NoError(t, cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("ciphertext")))
+	after, err := cli.KvUsage(m.Ctx(), rem.KVAuth{})
+	require.NoError(t, err)
+	require.Equal(t, before.Small, after.Small, "a replay must not be charged twice")
+
+	// The same ID carrying different bytes is refused.
+	err = cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("different ciphertext"))
+	require.Error(t, err)
+	var race core.KVRaceError
+	require.ErrorAs(t, err, &race)
+}

--- a/integration-tests/lib/kv_replay_test.go
+++ b/integration-tests/lib/kv_replay_test.go
@@ -51,20 +51,24 @@ func TestKVPutSmallFileReplay(t *testing.T) {
 		}
 	}
 
-	// First write lands.
-	require.NoError(t, cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("ciphertext")))
+	// First write lands, and is not a replay.
+	res, err := cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("ciphertext"))
+	require.NoError(t, err)
+	require.False(t, res.WasReplay)
 
-	// The same write again is the retry case: a no-op, not an error, and not
-	// a second charge against usage.
+	// The same write again is the retry case: a no-op that reports itself as
+	// a replay, not an error, and not a second charge against usage.
 	before, err := cli.KvUsage(m.Ctx(), rem.KVAuth{})
 	require.NoError(t, err)
-	require.NoError(t, cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("ciphertext")))
+	res, err = cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("ciphertext"))
+	require.NoError(t, err)
+	require.True(t, res.WasReplay)
 	after, err := cli.KvUsage(m.Ctx(), rem.KVAuth{})
 	require.NoError(t, err)
 	require.Equal(t, before.Small, after.Small, "a replay must not be charged twice")
 
 	// The same ID carrying different bytes is refused.
-	err = cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("different ciphertext"))
+	_, err = cli.KvPutSmallFileOrSymlink(m.Ctx(), mk("different ciphertext"))
 	require.Error(t, err)
 	var race core.KVRaceError
 	require.ErrorAs(t, err, &race)

--- a/proto-src/rem/kv.snowp
+++ b/proto-src/rem/kv.snowp
@@ -77,6 +77,13 @@ struct KVMkdirRes {
     wasReplay @0 : Bool;
 }
 
+struct KVPutSmallFileOrSymlinkRes {
+    // True when this write was an idempotent replay: the node already existed
+    // with exactly these bytes, and nothing was written or charged against
+    // usage. Old servers omit the result, which decodes as false.
+    wasReplay @0 : Bool;
+}
+
 struct KVLock {
     idp @0 : lib.KVDirentIDPair;
     lockID @1 : LockID;
@@ -119,7 +126,7 @@ protocol KVStore
         auth @0 : KVAuth,
         id @1 : lib.KVNodeID, // can work for either a small file OR a symlink
         sfb @2 : lib.SmallFileBox
-    );
+    ) -> KVPutSmallFileOrSymlinkRes;
 
     kvGetRoot @8 (
         auth @0 : KVAuth

--- a/proto/rem/kv.go
+++ b/proto/rem/kv.go
@@ -878,6 +878,45 @@ func (k *KVMkdirRes) Decode(dec rpc.Decoder) error {
 
 func (k *KVMkdirRes) Bytes() []byte { return nil }
 
+type KVPutSmallFileOrSymlinkRes struct {
+	WasReplay bool
+}
+type KVPutSmallFileOrSymlinkResInternal__ struct {
+	_struct   struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
+	WasReplay *bool
+}
+
+func (k KVPutSmallFileOrSymlinkResInternal__) Import() KVPutSmallFileOrSymlinkRes {
+	return KVPutSmallFileOrSymlinkRes{
+		WasReplay: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(k.WasReplay),
+	}
+}
+func (k KVPutSmallFileOrSymlinkRes) Export() *KVPutSmallFileOrSymlinkResInternal__ {
+	return &KVPutSmallFileOrSymlinkResInternal__{
+		WasReplay: &k.WasReplay,
+	}
+}
+func (k *KVPutSmallFileOrSymlinkRes) Encode(enc rpc.Encoder) error {
+	return enc.Encode(k.Export())
+}
+
+func (k *KVPutSmallFileOrSymlinkRes) Decode(dec rpc.Decoder) error {
+	var tmp KVPutSmallFileOrSymlinkResInternal__
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return err
+	}
+	*k = tmp.Import()
+	return nil
+}
+
+func (k *KVPutSmallFileOrSymlinkRes) Bytes() []byte { return nil }
+
 type KVLock struct {
 	Idp    lib.KVDirentIDPair
 	LockID LockID
@@ -1807,7 +1846,7 @@ type KVStoreInterface interface {
 	KvPutRoot(context.Context, KvPutRootArg) error
 	KvFileUploadInit(context.Context, KvFileUploadInitArg) error
 	KvFileUploadChunk(context.Context, KvFileUploadChunkArg) error
-	KvPutSmallFileOrSymlink(context.Context, KvPutSmallFileOrSymlinkArg) error
+	KvPutSmallFileOrSymlink(context.Context, KvPutSmallFileOrSymlinkArg) (KVPutSmallFileOrSymlinkRes, error)
 	KvGetRoot(context.Context, KVAuth) (lib.KVRoot, error)
 	KvGet(context.Context, KvGetArg) (KVGetRes, error)
 	KvGetNode(context.Context, KvGetNodeArg) (KVGetNodeRes, error)
@@ -1965,14 +2004,14 @@ func (c KVStoreClient) KvFileUploadChunk(ctx context.Context, arg KvFileUploadCh
 	}
 	return
 }
-func (c KVStoreClient) KvPutSmallFileOrSymlink(ctx context.Context, arg KvPutSmallFileOrSymlinkArg) (err error) {
+func (c KVStoreClient) KvPutSmallFileOrSymlink(ctx context.Context, arg KvPutSmallFileOrSymlinkArg) (res KVPutSmallFileOrSymlinkRes, err error) {
 	warg := &rpc.DataWrap[lib.Header, *KvPutSmallFileOrSymlinkArgInternal__]{
 		Data: arg.Export(),
 	}
 	if c.MakeArgHeader != nil {
 		warg.Header = c.MakeArgHeader()
 	}
-	var tmp rpc.DataWrap[lib.Header, interface{}]
+	var tmp rpc.DataWrap[lib.Header, KVPutSmallFileOrSymlinkResInternal__]
 	err = c.Cli.Call2(ctx, rpc.NewMethodV2(KVStoreProtocolID, 7, "KVStore.kvPutSmallFileOrSymlink"), warg, &tmp, 0*time.Millisecond, kVStoreErrorUnwrapperAdapter{h: c.ErrorUnwrapper})
 	if err != nil {
 		return
@@ -1983,6 +2022,7 @@ func (c KVStoreClient) KvPutSmallFileOrSymlink(ctx context.Context, arg KvPutSma
 			return
 		}
 	}
+	res = tmp.Data.Import()
 	return
 }
 func (c KVStoreClient) KvGetRoot(ctx context.Context, auth KVAuth) (res lib.KVRoot, err error) {
@@ -2386,11 +2426,12 @@ func KVStoreProtocol(i KVStoreInterface) rpc.ProtocolV2 {
 							return nil, err
 						}
 						typedArg := typedWrappedArg.Data
-						err := i.KvPutSmallFileOrSymlink(ctx, (typedArg.Import()))
+						tmp, err := i.KvPutSmallFileOrSymlink(ctx, (typedArg.Import()))
 						if err != nil {
 							return nil, err
 						}
-						ret := rpc.DataWrap[lib.Header, interface{}]{
+						ret := rpc.DataWrap[lib.Header, *KVPutSmallFileOrSymlinkResInternal__]{
+							Data:   tmp.Export(),
 							Header: i.MakeResHeader(),
 						}
 						return &ret, nil

--- a/server/kv-store/dir.go
+++ b/server/kv-store/dir.go
@@ -150,6 +150,12 @@ func putDir(
 		// hide the difference. The stored row must also still be active: a
 		// replay that matches a dead directory did not create anything the
 		// client can go on to use.
+		//
+		// FOR UPDATE anchors the replay decision until this transaction
+		// commits: the comparison runs in a later statement (and snapshot)
+		// than the conflicting insert, so without the lock a future GC could
+		// delete or kill the row in between, leaving the reported success
+		// describing a row that no longer exists.
 		var seed []byte
 		var gen, rt, rl, wt, wl int
 		var status string
@@ -158,7 +164,8 @@ func putDir(
 			        read_role_type, read_role_viz_level,
 			        write_role_type, write_role_viz_level, status
 			 FROM dir
-			 WHERE short_host_id=$1 AND short_party_id=$2 AND dir_id=$3 AND version=$4`,
+			 WHERE short_host_id=$1 AND short_party_id=$2 AND dir_id=$3 AND version=$4
+			 FOR UPDATE`,
 			int(m.HostID().Short),
 			spid.ExportToDB(),
 			dir.Id.ExportToDB(),

--- a/server/kv-store/file.go
+++ b/server/kv-store/file.go
@@ -100,33 +100,6 @@ func putSmallFileOrSymlink(
 		return err
 	}
 
-	// A replay of an identical node is a no-op. Node IDs are client-chosen,
-	// and a small file's encryption nonce derives from its node ID, so a
-	// client retrying after an ambiguous failure -- the write landed, the
-	// ack did not -- sends byte-identical bytes. Checked before
-	// usageCheckAndInc so a retry is not charged twice. A same-ID row
-	// carrying different bytes is a client bug or a stray collision in a
-	// 16-byte random space; refuse it rather than silently keeping one copy
-	// or the other.
-	var existing []byte
-	err = tx.QueryRow(
-		m.Ctx(),
-		`SELECT box FROM small_file_or_symlink
-		 WHERE short_host_id=$1 AND short_party_id=$2 AND node_id=$3`,
-		int(m.HostID().Short),
-		pid.Shorten().ExportToDB(),
-		arg.Id.ExportToDB(),
-	).Scan(&existing)
-	if err == nil {
-		if bytes.Equal(existing, arg.Sfb.DataBox) {
-			return nil
-		}
-		return core.KVRaceError("small-file node id replayed with different content")
-	}
-	if err != pgx.ErrNoRows {
-		return err
-	}
-
 	// Max length of small file is 2k + size of Poly1305
 	lim := kv.SmallFileSize + secretbox.Overhead
 	if len(arg.Sfb.DataBox) > lim {
@@ -137,24 +110,18 @@ func putSmallFileOrSymlink(
 		}
 	}
 
-	err = usageCheckAndInc(
-		m,
-		tx,
-		pid,
-		proto.KVNodeType_SmallFile,
-		len(arg.Sfb.DataBox),
-		true,
-	)
-	if err != nil {
-		return err
-	}
-
+	// Insert first, tolerating a conflict, so recognising a replay and
+	// claiming the row are one atomic step. A pre-check would leave a window
+	// where the original write commits between check and insert, and the
+	// retry would then fail on the primary key -- the exact case this makes
+	// safe.
 	tag, err := tx.Exec(
 		m.Ctx(),
 		`INSERT INTO small_file_or_symlink(short_host_id, short_party_id, node_id, 
 			ptk_gen, read_role_type, read_role_viz_level,
 			size, box, ctime, mtime, refcount 
-		) VALUES($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW(), 0)`,
+		) VALUES($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW(), 0)
+		 ON CONFLICT DO NOTHING`,
 		int(m.HostID().Short),
 		pid.Shorten().ExportToDB(),
 		arg.Id.ExportToDB(),
@@ -167,8 +134,53 @@ func putSmallFileOrSymlink(
 	if err != nil {
 		return err
 	}
+
+	if tag.RowsAffected() == 0 {
+		// The node ID is already taken. A client retrying after an ambiguous
+		// failure sends byte-identical bytes -- node IDs are client-chosen
+		// and a small file's nonce derives from its node ID -- so an
+		// identical row is that retry, and succeeding is what lets the
+		// client carry on. Anything else reusing the ID is a bug or a stray
+		// collision in a 16-byte random space, and must not silently keep
+		// one copy or the other.
+		var box []byte
+		var gen, rt, vl int
+		err = tx.QueryRow(
+			m.Ctx(),
+			`SELECT box, ptk_gen, read_role_type, read_role_viz_level
+			 FROM small_file_or_symlink
+			 WHERE short_host_id=$1 AND short_party_id=$2 AND node_id=$3`,
+			int(m.HostID().Short),
+			pid.Shorten().ExportToDB(),
+			arg.Id.ExportToDB(),
+		).Scan(&box, &gen, &rt, &vl)
+		if err != nil {
+			return err
+		}
+		if bytes.Equal(box, arg.Sfb.DataBox) &&
+			gen == int(arg.Sfb.Rg.Gen) &&
+			rt == int(rk.Typ) &&
+			vl == int(rk.Lev) {
+			// An identical replay. No second usage charge.
+			return nil
+		}
+		return core.KVRaceError("small-file node id reused with different contents")
+	}
 	if tag.RowsAffected() != 1 {
-		return core.InsertError("large_file")
+		return core.InsertError("small_file_or_symlink")
+	}
+
+	// Only a genuinely new row is charged against usage.
+	err = usageCheckAndInc(
+		m,
+		tx,
+		pid,
+		proto.KVNodeType_SmallFile,
+		len(arg.Sfb.DataBox),
+		true,
+	)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -324,6 +336,7 @@ func (f *fileUploader) insLargeFile(m shared.MetaContext) error {
 	if err != nil {
 		return err
 	}
+
 	if tag.RowsAffected() != 1 {
 		return core.InsertError("large_file")
 	}

--- a/server/kv-store/file.go
+++ b/server/kv-store/file.go
@@ -4,6 +4,8 @@
 package kvStore
 
 import (
+	"bytes"
+
 	"github.com/foks-proj/go-foks/lib/core"
 	"github.com/foks-proj/go-foks/lib/kv"
 	proto "github.com/foks-proj/go-foks/proto/lib"
@@ -95,6 +97,33 @@ func putSmallFileOrSymlink(
 
 	rk, err := core.ImportRole(arg.Sfb.Rg.Role)
 	if err != nil {
+		return err
+	}
+
+	// A replay of an identical node is a no-op. Node IDs are client-chosen,
+	// and a small file's encryption nonce derives from its node ID, so a
+	// client retrying after an ambiguous failure -- the write landed, the
+	// ack did not -- sends byte-identical bytes. Checked before
+	// usageCheckAndInc so a retry is not charged twice. A same-ID row
+	// carrying different bytes is a client bug or a stray collision in a
+	// 16-byte random space; refuse it rather than silently keeping one copy
+	// or the other.
+	var existing []byte
+	err = tx.QueryRow(
+		m.Ctx(),
+		`SELECT box FROM small_file_or_symlink
+		 WHERE short_host_id=$1 AND short_party_id=$2 AND node_id=$3`,
+		int(m.HostID().Short),
+		pid.Shorten().ExportToDB(),
+		arg.Id.ExportToDB(),
+	).Scan(&existing)
+	if err == nil {
+		if bytes.Equal(existing, arg.Sfb.DataBox) {
+			return nil
+		}
+		return core.KVRaceError("small-file node id replayed with different content")
+	}
+	if err != pgx.ErrNoRows {
 		return err
 	}
 

--- a/server/kv-store/file.go
+++ b/server/kv-store/file.go
@@ -83,27 +83,30 @@ func (s *SimpleLargeFileStream) Len() int {
 	return len(s.data)
 }
 
+// putSmallFileOrSymlink writes the small-file (or symlink) row. The returned
+// bool reports an idempotent replay: the node already existed with exactly
+// these bytes, and nothing was written or charged against usage.
 func putSmallFileOrSymlink(
 	m shared.MetaContext,
 	tx pgx.Tx,
 	pid proto.PartyID,
 	role proto.Role,
 	arg rem.KvPutSmallFileOrSymlinkArg,
-) error {
+) (bool, error) {
 	err := assertAtOrAbove(role, arg.Sfb.Rg.Role, proto.KVOp_Read, proto.KVNodeType_Symlink)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	rk, err := core.ImportRole(arg.Sfb.Rg.Role)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Max length of small file is 2k + size of Poly1305
 	lim := kv.SmallFileSize + secretbox.Overhead
 	if len(arg.Sfb.DataBox) > lim {
-		return core.TooBigError{
+		return false, core.TooBigError{
 			Actual: len(arg.Sfb.DataBox),
 			Limit:  lim,
 			Desc:   "small file",
@@ -132,7 +135,7 @@ func putSmallFileOrSymlink(
 		arg.Sfb.DataBox.ExportToDB(),
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if tag.RowsAffected() == 0 {
@@ -155,19 +158,19 @@ func putSmallFileOrSymlink(
 			arg.Id.ExportToDB(),
 		).Scan(&box, &gen, &rt, &vl)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if bytes.Equal(box, arg.Sfb.DataBox) &&
 			gen == int(arg.Sfb.Rg.Gen) &&
 			rt == int(rk.Typ) &&
 			vl == int(rk.Lev) {
 			// An identical replay. No second usage charge.
-			return nil
+			return true, nil
 		}
-		return core.KVRaceError("small-file node id reused with different contents")
+		return false, core.KVRaceError("small-file node id reused with different contents")
 	}
 	if tag.RowsAffected() != 1 {
-		return core.InsertError("small_file_or_symlink")
+		return false, core.InsertError("small_file_or_symlink")
 	}
 
 	// Only a genuinely new row is charged against usage.
@@ -180,9 +183,9 @@ func putSmallFileOrSymlink(
 		true,
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return nil
+	return false, nil
 }
 
 type LargeFileStatus int

--- a/server/kv-store/file.go
+++ b/server/kv-store/file.go
@@ -146,13 +146,20 @@ func putSmallFileOrSymlink(
 		// client carry on. Anything else reusing the ID is a bug or a stray
 		// collision in a 16-byte random space, and must not silently keep
 		// one copy or the other.
+		//
+		// FOR UPDATE anchors the replay decision until this transaction
+		// commits: the comparison runs in a later statement (and snapshot)
+		// than the conflicting insert, so without the lock a future GC could
+		// delete the row in between, leaving the reported success describing
+		// a row that no longer exists.
 		var box []byte
 		var gen, rt, vl int
 		err = tx.QueryRow(
 			m.Ctx(),
 			`SELECT box, ptk_gen, read_role_type, read_role_viz_level
 			 FROM small_file_or_symlink
-			 WHERE short_host_id=$1 AND short_party_id=$2 AND node_id=$3`,
+			 WHERE short_host_id=$1 AND short_party_id=$2 AND node_id=$3
+			 FOR UPDATE`,
 			int(m.HostID().Short),
 			pid.Shorten().ExportToDB(),
 			arg.Id.ExportToDB(),

--- a/server/kv-store/server.go
+++ b/server/kv-store/server.go
@@ -259,14 +259,24 @@ func (c *ClientConn) KvPutRoot(ctx context.Context, arg rem.KvPutRootArg) error 
 		})
 }
 
-func (c *ClientConn) KvPutSmallFileOrSymlink(ctx context.Context, arg rem.KvPutSmallFileOrSymlinkArg) error {
-	return c.auth(ctx, arg.Auth,
+func (c *ClientConn) KvPutSmallFileOrSymlink(ctx context.Context, arg rem.KvPutSmallFileOrSymlinkArg) (rem.KVPutSmallFileOrSymlinkRes, error) {
+	var res rem.KVPutSmallFileOrSymlinkRes
+	err := c.auth(ctx, arg.Auth,
 		func(m shared.MetaContext, db *pgxpool.Conn, pid proto.PartyID, role proto.Role) error {
 			return shared.RetryTx(m, db, "kvPutFile",
 				func(m shared.MetaContext, tx pgx.Tx) error {
-					return putSmallFileOrSymlink(m, tx, pid, role, arg)
+					wasReplay, err := putSmallFileOrSymlink(m, tx, pid, role, arg)
+					if err != nil {
+						return err
+					}
+					res.WasReplay = wasReplay
+					return nil
 				})
 		})
+	if err != nil {
+		return rem.KVPutSmallFileOrSymlinkRes{}, err
+	}
+	return res, nil
 }
 
 func (c *ClientConn) KvGetRoot(ctx context.Context, auth rem.KVAuth) (proto.KVRoot, error) {


### PR DESCRIPTION
Supersedes #352, keeping @st3v3y's commits (and authorship) as the base and
building on them. Companion to #357 (the same treatment for `kvMkdir`); the
two remain independent, though both add a result struct to `kv.snowp`, so
whichever merges second needs a trivial rebase plus `make proto`.

## The problem (from #352)

`kvPutSmallFileOrSymlink` cannot be retried safely. If the connection drops
before the response arrives, the retry hits the primary key on
`small_file_or_symlink` and fails with a raw duplicate-key error,
indistinguishable from a genuine failure.

Node IDs are chosen by the client, and a small file's encryption nonce
derives from its node ID — so a retry sends byte-identical bytes, and "same
ID, same bytes" is recognisably an honest retry.

## What this PR does

- **Idempotent replay** (#352's core, unchanged in substance): the insert
  uses `ON CONFLICT DO NOTHING`; on a conflict, the stored row is compared
  field by field inside the same transaction. An identical replay succeeds as
  a no-op and is not charged against usage a second time; a reused ID with
  different bytes is refused with `KV_RACE_ERROR`.
- **The RPC reports the replay**: `kvPutSmallFileOrSymlink` now returns
  `KVPutSmallFileOrSymlinkRes { wasReplay: Bool }`, following the
  `RTSendRes.wasReplay` precedent from #349 and matching #357.

Unlike #357, no further review fixes were needed: there was no pre-existing
duplicate-key branch to remove, and this table has no status column, so the
comparison (box bytes, generation, read role; size is implied by the box) is
already complete.

## Wire compatibility of void → struct

Both directions are safe, same as #357: an old client decodes the new result
into `interface{}` and discards it; a new client against an old server sees
no `Data` key at all (`DataWrap` is `codec:",omitempty"`) and decodes the
zero struct, so `wasReplay` is `false`.

## Testing

`TestKVPutSmallFileReplay` drives the RPC directly (libkv mints a fresh node
ID per call and so cannot express a replay) and asserts `wasReplay` is false
on first write and true on the identical retry, that the replay is not
charged against usage, and that different bytes under the same ID fail with
`KV_RACE_ERROR`. Full `integration-tests/lib` and `integration-tests/cli`
suites pass on top of current `main`.

Co-authored-by: Claude Code