### PR TITLE
client: keep device key seeds out of iOS device backups

### DIFF
--- a/client/libclient/keychain_accessible_ios.go
+++ b/client/libclient/keychain_accessible_ios.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+//go:build ios
+
+package libclient
+
+import (
+	"github.com/keybase/go-keychain"
+)
+
+// secretKeyAccessible is the kSecAttrAccessible class for the keychain item
+// that wraps a device key seed (see addItem in platform_darwin.go).
+//
+// ThisDeviceOnly on iOS. The plain WhenUnlocked class used on macOS is
+// included in encrypted Finder/iTunes and iCloud backups and restores onto a
+// DIFFERENT device; the ThisDeviceOnly classes are excluded from backups
+// entirely. On iOS that distinction is the difference between a device key
+// seed that is bound to the hardware it was minted on and one that rides
+// along in whatever backup the user happens to take.
+//
+// Same unlock semantics either way -- readable whenever the device is
+// unlocked -- so this costs nothing at runtime. It only forecloses restoring
+// the wrapping key onto another device, which a device key seed should not
+// survive anyway: enrolling a new device is what the kex flow is for.
+const secretKeyAccessible keychain.Accessible = keychain.AccessibleWhenUnlockedThisDeviceOnly

--- a/client/libclient/keychain_accessible_macos.go
+++ b/client/libclient/keychain_accessible_macos.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 ne43, Inc.
+// Licensed under the MIT License. See LICENSE in the project root for details.
+
+//go:build darwin && !ios
+
+package libclient
+
+import (
+	"github.com/keybase/go-keychain"
+)
+
+// secretKeyAccessible is the kSecAttrAccessible class for the keychain item
+// that wraps a device key seed (see addItem in platform_darwin.go).
+//
+// Unchanged on macOS. Two reasons not to tighten this to ThisDeviceOnly here
+// along with iOS:
+//
+//   - It would break Migration Assistant. Moving a Mac to new hardware is an
+//     ordinary, supported thing to do, and a user who does it expects their
+//     login keychain -- and so their FOKS device -- to come with them. On iOS
+//     the equivalent is restoring a backup onto a second device, which is a
+//     thing a device key seed specifically should not survive.
+//   - It would be mostly theatre anyway. go-keychain v0.0.1 does not set
+//     kSecUseDataProtectionKeychain, so on macOS these items land in the
+//     legacy file-based keychain, where access is governed by the keychain's
+//     own lock state and per-item ACLs rather than by the data-protection
+//     accessibility classes. kSecAttrAccessible is accepted and stored, but
+//     it is not the thing enforcing anything.
+//
+// Split into its own file rather than branched on runtime.GOOS so that the
+// iOS and macOS choices are each stated once, at compile time, next to the
+// reasoning for them.
+const secretKeyAccessible keychain.Accessible = keychain.AccessibleWhenUnlocked

--- a/client/libclient/platform_darwin.go
+++ b/client/libclient/platform_darwin.go
@@ -179,7 +179,10 @@ func addItem(
 	item.SetAccount(mac.Account)
 	item.SetLabel("")
 	item.SetSynchronizable(keychain.SynchronizableNo)
-	item.SetAccessible(keychain.AccessibleWhenUnlocked)
+	// Platform-dependent: WhenUnlocked on macOS, ThisDeviceOnly on iOS, where
+	// the difference decides whether this wrapping key ends up in device
+	// backups. See keychain_accessible_{ios,macos}.go.
+	item.SetAccessible(secretKeyAccessible)
 	item.SetAccessGroup("")
 	item.SetData([]byte(skey))
 


### PR DESCRIPTION
Currently the key's seed stored in the keychain will end up in device backups. There is a dedicated flow for adding a new device so I believe there are no reasons why the seed would need to leave the device. But I may be missing something