### PR TITLE
rt: let a channel opt out of push notifications

### DIFF
--- a/client/librt/minder.go
+++ b/client/librt/minder.go
@@ -159,6 +159,16 @@ func (d *Minder) MakeChannel(
 	return d.MakeChannelWithTestHooks(m, team, appId, nm, desc, roles, nil)
 }
 
+// MakeChannelOpts carries the optional knobs of channel creation, so adding
+// one later does not change MakeChannel's signature again.
+type MakeChannelOpts struct {
+	// NoPush excludes the channel from the push_outbox fan-out on send:
+	// members' parked long-polls still wake, but no phone notification is
+	// queued. For channels carrying app control traffic rather than
+	// conversation. Creation-time only.
+	NoPush bool
+}
+
 func (d *Minder) MakeChannelWithTestHooks(
 	m MetaContext,
 	team lcl.ConfigTeam,
@@ -171,13 +181,36 @@ func (d *Minder) MakeChannelWithTestHooks(
 	*proto.RTChannelID,
 	error,
 ) {
+	return d.MakeChannelWithOpts(m, team, appId, nm, desc, roles, MakeChannelOpts{}, test)
+}
+
+func (d *Minder) MakeChannelWithOpts(
+	m MetaContext,
+	team lcl.ConfigTeam,
+	appId proto.RTAppID,
+	nm proto.RTChannelName,
+	desc proto.RTChannelDesc,
+	roles proto.RolePairOpt,
+	opts MakeChannelOpts,
+	test *MakeChannelTestHooks,
+) (
+	*proto.RTChannelID,
+	error,
+) {
 	if nm.Eq(proto.RTGeneralChannel) {
 		return nil, core.RTGenericError("cannot make channel named #general")
+	}
+	// The default channel may not be created no-push. Names are encrypted, so
+	// the server cannot tell which channel is the default one; and the flag is
+	// creation-time only, so a team whose default channel was created this way
+	// would silently stop notifying for every message in it, with no way back.
+	if nm.IsEmpty() && opts.NoPush {
+		return nil, core.RTGenericError("cannot make the default channel no-push")
 	}
 	sleepDur := time.Millisecond
 	numTries := 5
 	for i := range numTries {
-		ret, err := d.makeChannelOneAttempt(m, team, appId, nm, desc, roles, test)
+		ret, err := d.makeChannelOneAttempt(m, team, appId, nm, desc, roles, opts, test)
 		if err == nil {
 			return ret, nil
 		}
@@ -216,6 +249,7 @@ func (d *Minder) makeChannelOneAttempt(
 	nm proto.RTChannelName,
 	desc proto.RTChannelDesc,
 	roles proto.RolePairOpt,
+	opts MakeChannelOpts,
 	test *MakeChannelTestHooks,
 ) (
 	*proto.RTChannelID,
@@ -349,6 +383,7 @@ func (d *Minder) makeChannelOneAttempt(
 	}
 	update.UpdatedAt = chlst.Vers + 1
 	update.Tier = newChTier
+	update.NoPush = opts.NoPush
 
 	arg := rem.RtNewChannelArg{
 		Md:      update,
@@ -534,6 +569,7 @@ func (k *Minder) decryptChannelMetadata(
 	ret.Tier = chmdenc.Tier
 	ret.UpdatedAt = chmdenc.UpdatedAt
 	ret.Unreadable = chmdenc.Unreadable
+	ret.NoPush = chmdenc.NoPush
 
 	return &ret, nil
 }

--- a/integration-tests/lib/rt_no_push_test.go
+++ b/integration-tests/lib/rt_no_push_test.go
@@ -1,0 +1,213 @@
+// No-push channels: a send queues no push_outbox rows, while the
+// inbox-version fan-out that drives online delivery is untouched.
+//
+// The two halves have to be asserted separately. Suppressing the push rows is
+// the feature; suppressing the inbox bump with them would make the channel
+// undeliverable to members who are online, which is the opposite of what a
+// control channel wants.
+//
+// These are also the first tests over push_outbox itself, so the ordinary
+// channel case below pins the existing fan-out (one row per recipient, sender
+// excluded) rather than only the new flag.
+package lib
+
+import (
+	"testing"
+
+	"github.com/foks-proj/go-foks/client/librt"
+	"github.com/foks-proj/go-foks/lib/team"
+	proto "github.com/foks-proj/go-foks/proto/lib"
+	"github.com/foks-proj/go-foks/server/shared"
+	"github.com/stretchr/testify/require"
+)
+
+// noPushScene is a team with an owner and two ordinary members, plus the
+// client machinery to create channels and send into them.
+type noPushScene struct {
+	tew               *TestEnvWrapper
+	tm                *teamObj
+	owner, mem1, mem2 *TestUser
+	mo                librt.MetaContext
+	minder            *librt.Minder
+}
+
+func setupNoPushScene(t *testing.T) *noPushScene {
+	tew := testEnvBeta(t)
+	owner := tew.NewTestUser(t)
+	mem1 := tew.NewTestUser(t)
+	mem2 := tew.NewTestUser(t)
+	tew.DirectDoubleMerklePokeInTest(t)
+
+	tm := tew.makeTeamForOwner(t, owner)
+	m := tew.MetaContext()
+	tm.makeChanges(t, m, owner,
+		[]proto.MemberRole{
+			mem1.toMemberRole(t, proto.DefaultRole, tm.hepks),
+			mem2.toMemberRole(t, proto.DefaultRole, tm.hepks),
+		}, nil,
+	)
+
+	mo := librt.NewMetaContext(tew.NewClientMetaContextWithEracer(t, owner))
+	return &noPushScene{
+		tew:    tew,
+		tm:     tm,
+		owner:  owner,
+		mem1:   mem1,
+		mem2:   mem2,
+		mo:     mo,
+		minder: librt.NewMinder(mo.G().ActiveUser()),
+	}
+}
+
+// makeChannel creates a channel with the given opts and returns its name.
+func (s *noPushScene) makeChannel(
+	t *testing.T, nm proto.RTChannelName, opts librt.MakeChannelOpts,
+) proto.RTChannelID {
+	fqt := s.tm.ToFQTeamParsed(t)
+	// Explicit member roles: an empty RolePairOpt defaults the read role to
+	// the creator's role in the team (owner), which would make the channel
+	// admin-tier and fan in nobody else -- and then a push-row count of zero
+	// would pass for the wrong reason.
+	chid, err := s.minder.MakeChannelWithOpts(
+		s.mo, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		nm, "a channel",
+		proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.DefaultRole},
+		opts, nil,
+	)
+	require.NoError(t, err)
+	return *chid
+}
+
+func (s *noPushScene) send(t *testing.T, nm string, body string) {
+	fqt := s.tm.ToFQTeamParsed(t)
+	_, err := s.minder.Send(s.mo, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		makeChannelSpecifierWithString(nm), []byte(body))
+	require.NoError(t, err)
+}
+
+// pushRows counts queued push rows for one user in one channel.
+func (s *noPushScene) pushRows(t *testing.T, chid proto.RTChannelID, u *TestUser) int {
+	m := s.tew.MetaContext()
+	db, err := m.Db(shared.DbTypeRealTime)
+	require.NoError(t, err)
+	defer db.Release()
+	var n int
+	require.NoError(t, db.QueryRow(m.Ctx(),
+		`SELECT count(*) FROM push_outbox
+		 WHERE short_host_id=$1 AND channel_id=$2 AND uid=$3`,
+		m.ShortHostID(), chid.Short().Int64(), u.uid.ExportToDB()).Scan(&n))
+	return n
+}
+
+// inboxVersion is the user's global inbox version; it bumps on every delivery.
+func (s *noPushScene) inboxVersion(t *testing.T, u *TestUser) int64 {
+	m := s.tew.MetaContext()
+	db, err := m.Db(shared.DbTypeRealTime)
+	require.NoError(t, err)
+	defer db.Release()
+	var v int64
+	err = db.QueryRow(m.Ctx(),
+		`SELECT inbox_version FROM user_inbox
+		 WHERE short_host_id=$1 AND uid=$2 AND app_id='chat'`,
+		m.ShortHostID(), u.uid.ExportToDB()).Scan(&v)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+func TestRTNoPushChannelQueuesNoPushRows(t *testing.T) {
+	sc := setupNoPushScene(t)
+	chid := sc.makeChannel(t, "control", librt.MakeChannelOpts{NoPush: true})
+
+	before := map[*TestUser]int64{}
+	for _, u := range []*TestUser{sc.mem1, sc.mem2} {
+		before[u] = sc.inboxVersion(t, u)
+	}
+
+	sc.send(t, "control", "control traffic")
+
+	for _, u := range []*TestUser{sc.owner, sc.mem1, sc.mem2} {
+		require.Equal(t, 0, sc.pushRows(t, chid, u),
+			"a no-push channel must queue no push_outbox row for anyone")
+	}
+	for _, u := range []*TestUser{sc.mem1, sc.mem2} {
+		require.Greater(t, sc.inboxVersion(t, u), before[u],
+			"no-push must not suppress the inbox-version fan-out")
+	}
+}
+
+func TestRTOrdinaryChannelStillQueuesPushRows(t *testing.T) {
+	sc := setupNoPushScene(t)
+	chid := sc.makeChannel(t, "chat", librt.MakeChannelOpts{})
+
+	sc.send(t, "chat", "conversation")
+
+	require.Equal(t, 0, sc.pushRows(t, chid, sc.owner), "the sender is never pushed to")
+	for _, u := range []*TestUser{sc.mem1, sc.mem2} {
+		require.Equal(t, 1, sc.pushRows(t, chid, u),
+			"an ordinary channel must queue one push row per recipient")
+	}
+}
+
+// The flag round-trips: into the row the send path reads, and back out to a
+// client through the channel listing.
+func TestRTNoPushRoundTrips(t *testing.T) {
+	sc := setupNoPushScene(t)
+	quiet := sc.makeChannel(t, "quiet", librt.MakeChannelOpts{NoPush: true})
+	loud := sc.makeChannel(t, "loud", librt.MakeChannelOpts{})
+
+	inRow := func(chid proto.RTChannelID) bool {
+		m := sc.tew.MetaContext()
+		db, err := m.Db(shared.DbTypeRealTime)
+		require.NoError(t, err)
+		defer db.Release()
+		var v bool
+		require.NoError(t, db.QueryRow(m.Ctx(),
+			`SELECT no_push FROM channels WHERE short_host_id=$1 AND channel_id=$2`,
+			m.ShortHostID(), chid.Short().Int64()).Scan(&v))
+		return v
+	}
+	require.True(t, inRow(quiet))
+	require.False(t, inRow(loud))
+
+	fqt := sc.tm.ToFQTeamParsed(t)
+	lst, err := sc.minder.ListAllChannelsForTeam(
+		sc.mo, team.WrapNamedPtr(fqt), proto.RTAppID_Chat)
+	require.NoError(t, err)
+	seen := 0
+	for i := range lst.Channels {
+		ch := &lst.Channels[i]
+		switch ch.Name {
+		case "quiet":
+			seen++
+			require.True(t, ch.NoPush, "flag lost on the way out to a client")
+		case "loud":
+			seen++
+			require.False(t, ch.NoPush, "flag invented for an ordinary channel")
+		}
+	}
+	require.Equal(t, 2, seen, "both channels must appear in the listing")
+}
+
+// The default channel may not be created no-push: the flag is creation-time
+// only, so a team whose #general was created this way would stop notifying
+// for every message in it with no way back.
+func TestRTDefaultChannelCannotBeNoPush(t *testing.T) {
+	sc := setupNoPushScene(t)
+	fqt := sc.tm.ToFQTeamParsed(t)
+
+	_, err := sc.minder.MakeChannelWithOpts(
+		sc.mo, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		"", "", proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.DefaultRole},
+		librt.MakeChannelOpts{NoPush: true}, nil,
+	)
+	require.Error(t, err)
+
+	_, err = sc.minder.MakeChannelWithOpts(
+		sc.mo, team.WrapNamedPtr(fqt), proto.RTAppID_Chat,
+		"", "", proto.RolePairOpt{Read: &proto.DefaultRole, Write: &proto.DefaultRole},
+		librt.MakeChannelOpts{}, nil,
+	)
+	require.NoError(t, err, "the guard must not block ordinary default-channel creation")
+}

--- a/proto-src/lcl/realtime.snowp
+++ b/proto-src/lcl/realtime.snowp
@@ -49,6 +49,7 @@ struct RTChannelMetadataPlaintext {
     updatedAt @7 : lib.RTChannelSetVersion;
     unreadable @8 : Bool; // caller can't read this channel (role below read role);
                           // kept for name-collision detection, hidden from the inbox
+    noPush @9 : Bool;     // sends here queue no push notifications (see rem)
 }
 
 struct RTChannelSetForTeam {

--- a/proto-src/rem/realtime.snowp
+++ b/proto-src/rem/realtime.snowp
@@ -77,6 +77,11 @@ struct RTChannelMetadata @0xddf6b26b2ace1535 {
     tier @11 : lib.RTChannelTier;
     unreadable @12 : Bool; // caller's role is below the read role: name is shown
                            // (for collision detection) but desc/lastMsg withheld
+    // Set at creation: this channel is excluded from the push_outbox fan-out
+    // on send. Inbox-version delivery is unaffected, so parked long-polls
+    // still wake; only the phone notification is suppressed. For channels
+    // carrying app control traffic rather than conversation.
+    noPush @13 : Bool;
 }
 
 struct RTChannelSet {

--- a/proto/lcl/realtime.go
+++ b/proto/lcl/realtime.go
@@ -458,6 +458,7 @@ type RTChannelMetadataPlaintext struct {
 	Tier       lib.RTChannelTier
 	UpdatedAt  lib.RTChannelSetVersion
 	Unreadable bool
+	NoPush     bool
 }
 type RTChannelMetadataPlaintextInternal__ struct {
 	_struct    struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -470,6 +471,7 @@ type RTChannelMetadataPlaintextInternal__ struct {
 	Tier       *lib.RTChannelTierInternal__
 	UpdatedAt  *lib.RTChannelSetVersionInternal__
 	Unreadable *bool
+	NoPush     *bool
 }
 
 func (r RTChannelMetadataPlaintextInternal__) Import() RTChannelMetadataPlaintext {
@@ -534,6 +536,12 @@ func (r RTChannelMetadataPlaintextInternal__) Import() RTChannelMetadataPlaintex
 			}
 			return *x
 		})(r.Unreadable),
+		NoPush: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.NoPush),
 	}
 }
 func (r RTChannelMetadataPlaintext) Export() *RTChannelMetadataPlaintextInternal__ {
@@ -552,6 +560,7 @@ func (r RTChannelMetadataPlaintext) Export() *RTChannelMetadataPlaintextInternal
 		Tier:       r.Tier.Export(),
 		UpdatedAt:  r.UpdatedAt.Export(),
 		Unreadable: &r.Unreadable,
+		NoPush:     &r.NoPush,
 	}
 }
 func (r *RTChannelMetadataPlaintext) Encode(enc rpc.Encoder) error {

--- a/proto/rem/realtime.go
+++ b/proto/rem/realtime.go
@@ -447,6 +447,7 @@ type RTChannelMetadata struct {
 	UpdatedAt  lib.RTChannelSetVersion
 	Tier       lib.RTChannelTier
 	Unreadable bool
+	NoPush     bool
 }
 type RTChannelMetadataInternal__ struct {
 	_struct    struct{} `codec:",toarray"` //lint:ignore U1000 msgpack internal field
@@ -463,6 +464,7 @@ type RTChannelMetadataInternal__ struct {
 	UpdatedAt  *lib.RTChannelSetVersionInternal__
 	Tier       *lib.RTChannelTierInternal__
 	Unreadable *bool
+	NoPush     *bool
 }
 
 func (r RTChannelMetadataInternal__) Import() RTChannelMetadata {
@@ -557,6 +559,12 @@ func (r RTChannelMetadataInternal__) Import() RTChannelMetadata {
 			}
 			return *x
 		})(r.Unreadable),
+		NoPush: (func(x *bool) (ret bool) {
+			if x == nil {
+				return ret
+			}
+			return *x
+		})(r.NoPush),
 	}
 }
 func (r RTChannelMetadata) Export() *RTChannelMetadataInternal__ {
@@ -584,6 +592,7 @@ func (r RTChannelMetadata) Export() *RTChannelMetadataInternal__ {
 		UpdatedAt:  r.UpdatedAt.Export(),
 		Tier:       r.Tier.Export(),
 		Unreadable: &r.Unreadable,
+		NoPush:     &r.NoPush,
 	}
 }
 func (r *RTChannelMetadata) Encode(enc rpc.Encoder) error {

--- a/server/realtime/channels.go
+++ b/server/realtime/channels.go
@@ -184,6 +184,7 @@ type channelMetadataRaw struct {
 	ctime, mtime                  time.Time
 	updatedAtSetVers              int
 	tierRaw                       string
+	noPush                        bool
 }
 
 // channelMetadataCols is the column list matching channelMetadataRaw.scanDests,
@@ -194,7 +195,7 @@ const channelMetadataCols = `c.channel_id_full, c.seqno, c.name_box, c.desc_box,
 	        c.write_role_type, c.write_role_viz_level,
 	        c.last_msg_type, c.last_msg_seq, c.last_send_time,
 	        cp.party_id, cp.uid,
-	        c.ctime, c.mtime, c.updated_at_set_vers, c.tier`
+	        c.ctime, c.mtime, c.updated_at_set_vers, c.tier, c.no_push`
 
 // lastSenderJoin attributes the channel's denormalized last message to its
 // sender; LEFT so channels with no messages still row.
@@ -210,7 +211,7 @@ func (r *channelMetadataRaw) scanDests() []any {
 		&r.lastMsgType, &r.lastMsgSeq, &r.lastSendTime,
 		&r.partyIDRaw, &r.uidRaw,
 		&r.ctime, &r.mtime, &r.updatedAtSetVers,
-		&r.tierRaw,
+		&r.tierRaw, &r.noPush,
 	}
 }
 
@@ -266,6 +267,7 @@ func (r *channelMetadataRaw) export(
 	if err != nil {
 		return nil, err
 	}
+	md.NoPush = r.noPush
 	return &md, nil
 }
 
@@ -506,11 +508,11 @@ func (c *channelMaker) insertChannel(m shared.MetaContext) error {
 			(short_host_id, channel_id, parent_team_id, app_id, channel_id_full,
 			 seqno, name_box, name_box_ptk_gen, tier, desc_box, desc_box_ptk_gen,
 			 read_role_type, read_role_viz_level, write_role_type, write_role_viz_level,
-			 ctime, mtime, updated_at_set_vers)
+			 ctime, mtime, updated_at_set_vers, no_push)
 		VALUES($1, $2, $3, $4, $5,
 		       $6, $7, $8, $9, $10, $11,
 		       $12, $13, $14, $15,
-		       NOW(), NOW(), $16)`,
+		       NOW(), NOW(), $16, $17)`,
 		m.ShortHostID(),
 		int64(c.md.Id.Short()),
 		c.md.ParentTeam.ExportToDB(),
@@ -527,6 +529,7 @@ func (c *channelMaker) insertChannel(m shared.MetaContext) error {
 		writeType,
 		writeViz,
 		c.vers.ExportToDB(),
+		c.md.NoPush,
 	)
 	if shared.IsDuplicateKeyError(err, "channels_pkey") {
 		return core.RTRaceError{Which: "channels"}

--- a/server/realtime/messages.go
+++ b/server/realtime/messages.go
@@ -34,6 +34,7 @@ type messageSender struct {
 	readRole   proto.Role
 	prevSeq    proto.RTMsgSeq
 	appID      proto.RTAppID
+	noPush     bool
 
 	// members whose inbox versions the fanout bumped; the caller wakes their
 	// parked long-pollers after the transaction commits.
@@ -53,13 +54,14 @@ func (s *messageSender) lockChannel(m shared.MetaContext) error {
 	err := s.tx.QueryRow(
 		m.Ctx(),
 		`SELECT parent_team_id, write_role_type, write_role_viz_level,
-		        read_role_type, read_role_viz_level, last_msg_seq, app_id
+		        read_role_type, read_role_viz_level, last_msg_seq, app_id,
+		        no_push
 		 FROM channels
 		 WHERE short_host_id=$1 AND channel_id=$2
 		 FOR UPDATE`,
 		m.ShortHostID(),
 		s.channelID(),
-	).Scan(&teamRaw, &wrt, &wvl, &rrt, &rvl, &prevSeqRaw, &appRaw)
+	).Scan(&teamRaw, &wrt, &wvl, &rrt, &rvl, &prevSeqRaw, &appRaw, &s.noPush)
 	if err == pgx.ErrNoRows {
 		return core.RowNotFoundError{}
 	}
@@ -341,6 +343,14 @@ func (s *messageSender) fanoutInboxVersions(
 	// does. push_outbox is already in the schema; this is the writer.
 	// kind='msg', data=NULL — a pure wake: no message content, sender or
 	// channel name leaves the E2EE boundary for a push provider.
+	//
+	// A no-push channel skips this fan-out and nothing else: the
+	// inbox-version bump above has already been made, so members' parked
+	// long-polls still wake and online delivery is unchanged. Only the
+	// phone notification is suppressed.
+	if s.noPush {
+		return nil
+	}
 	_, err = s.tx.Exec(
 		m.Ctx(),
 		`INSERT INTO push_outbox (short_host_id, uid, channel_id, kind, seq, status, ctime, mtime)

--- a/server/sql/embed.go
+++ b/server/sql/embed.go
@@ -80,6 +80,9 @@ var realtimePatch3 string
 //go:embed patches/foks_realtime/p4.sql
 var realtimePatch4 string
 
+//go:embed patches/foks_realtime/p5.sql
+var realtimePatch5 string
+
 var Patches = map[string]map[int]string{
 	"foks_users": {
 		1: usersPatch1,
@@ -100,5 +103,6 @@ var Patches = map[string]map[int]string{
 		2: realtimePatch2,
 		3: realtimePatch3,
 		4: realtimePatch4,
+		5: realtimePatch5,
 	},
 }

--- a/server/sql/foks_realtime.sql
+++ b/server/sql/foks_realtime.sql
@@ -80,6 +80,12 @@ CREATE TABLE channels (
     ctime TIMESTAMPTZ NOT NULL,
     mtime TIMESTAMPTZ NOT NULL,
     updated_at_set_vers INTEGER NOT NULL, /* corresponds to channel_sets at time of update */
+    /* Sends into this channel queue no push_outbox rows; inbox-version
+     * delivery is unaffected. Set at creation. Declared last to match the
+     * column order ADD COLUMN gives a database migrated by
+     * patches/foks_realtime/p5.sql, so a fresh and a migrated DB dump the
+     * same. */
+    no_push BOOLEAN NOT NULL DEFAULT false,
     PRIMARY KEY(short_host_id, channel_id)
 );
 /* no FK to teams (cross-DB); enforced at app layer */

--- a/server/sql/patches/foks_realtime/p5.sql
+++ b/server/sql/patches/foks_realtime/p5.sql
@@ -1,0 +1,13 @@
+/*
+ * No-push channels.
+ *
+ * A channel marked no_push is skipped by the push_outbox fan-out on send. The
+ * inbox-version bump is untouched, so members' parked long-polls still wake
+ * and online delivery is unchanged; what a no-push channel never does is
+ * queue a phone notification.
+ *
+ * A plaintext column rather than something derived from the channel's name:
+ * names are PTK-encrypted (name_box), so the send path cannot tell a control
+ * channel from a conversational one any other way.
+ */
+ALTER TABLE channels ADD COLUMN no_push BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Problem

Every RT send queues one content-free `push_outbox` row per recipient. That
is right for conversation, but some channels carry control traffic between
clients rather than anything a person reads, and there is no way to say so.
Such a channel is delivered in realtime **and** wakes every member's phone
for each message, with nothing to look at when they open the app.

Channel names are PTK-encrypted, so the server cannot recognize such a
channel by name.

## Solution

A creation-time per-channel `noPush` flag. A send into a flagged channel
skips the push fan-out and nothing else — the inbox-version bump still
happens, so parked long-polls still wake and online delivery is unchanged.

Creation-time only: neither `UPDATE` of the `channels` row touches the
column, and there is no RPC to flip it. `librt` refuses the flag on the
default channel, since names are encrypted and the default channel is
resolved client-side, so the server cannot catch that case — and a team
whose `#general` was created no-push would stop notifying for every message
in it with no way back.

`librt` gains `MakeChannelWithOpts`; `MakeChannel` and
`MakeChannelWithTestHooks` keep their signatures, so no existing caller
changes. The flag is carried back out on `RTChannelMetadataPlaintext`,
because `MakeChannel` reports "already exists" identically whether or not
the existing channel carries the flag, and a caller needs to tell.

## Tests

Both halves of the contract, since they fail independently:

- a send into a no-push channel queues no rows, **while every member's
  inbox version still bumps**;
- an ordinary channel still queues one row per recipient, sender excluded.

That second one is the first coverage of the `push_outbox` fan-out itself.
Also: the flag round-trips into the row and back out through the channel
listing, and the default channel cannot be created no-push while ordinary
creation still works.

## Notes

- No agent or CLI surface here — the flag is set through `librt`. Adding it
  to `ClientRTMakeChannel` would touch the `lcl` protocol and seemed better
  as a separate change if you want it.
- `no_push` is declared last in the base `CREATE TABLE` so a fresh database
  matches one migrated by `p5.sql`.
- We are running this downstream for a first-contact handshake that rides
  its own channel. It is not yet in front of users, so I can report that the
  fan-out behaves as described and the tests cover it, but not field numbers
  on notification volume.